### PR TITLE
SDK-896: Return undefined and unknown content types as string

### DIFF
--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0"?>
+<ruleset name="Yoti">
+  <rule ref="PSR2"/>
+  <file>src/Yoti</file>
+  <file>tests</file>
+</ruleset>

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ install:
 
 script:
     - vendor/bin/phpunit
-    - vendor/bin/phpcs --standard=psr2 ./src/Yoti
+    - vendor/bin/phpcs

--- a/src/Yoti/Util/Profile/AttributeConverter.php
+++ b/src/Yoti/Util/Profile/AttributeConverter.php
@@ -81,14 +81,14 @@ class AttributeConverter
             case self::CONTENT_TYPE_MULTI_VALUE:
                 return self::convertMultiValue($value);
 
-            case self::CONTENT_TYPE_UNDEFINED:
-                throw new AttributeException("Content Type is undefined");
-
             case self::CONTENT_TYPE_INT:
                 return (int) $value;
 
             case self::CONTENT_TYPE_STRING:
+                return $value;
+
             default:
+                error_log("Unknown Content Type '{$contentType}', parsing as a String", 0);
                 return $value;
         }
     }

--- a/tests/Util/Profile/AttributeConverterTest.php
+++ b/tests/Util/Profile/AttributeConverterTest.php
@@ -18,6 +18,7 @@ class AttributeConverterTest extends TestCase
     /**
      * Content Types.
      */
+    const CONTENT_TYPE_UNDEFINED = 0;
     const CONTENT_TYPE_STRING = 1;
     const CONTENT_TYPE_JPEG = 2;
     const CONTENT_TYPE_DATE = 3;
@@ -83,6 +84,30 @@ class AttributeConverterTest extends TestCase
         $attr = AttributeConverter::convertToYotiAttribute($this->getMockForProtobufAttribute('test_attr', 'my_value'));
         $this->assertEquals('test_attr', $attr->getName());
         $this->assertEquals('my_value', $attr->getValue());
+    }
+
+    /**
+     * @covers ::convertToYotiAttribute
+     */
+    public function testConvertUndefinedContentType()
+    {
+        $attr = AttributeConverter::convertToYotiAttribute(
+            $this->getMockForProtobufAttribute('undefined_attr', 'undefined_value', self::CONTENT_TYPE_UNDEFINED)
+        );
+        $this->assertEquals('undefined_attr', $attr->getName());
+        $this->assertEquals('undefined_value', $attr->getValue());
+    }
+
+    /**
+     * @covers ::convertToYotiAttribute
+     */
+    public function testConvertUnknownContentType()
+    {
+        $attr = AttributeConverter::convertToYotiAttribute(
+            $this->getMockForProtobufAttribute('unknown_attr', 'unknown_value', 100)
+        );
+        $this->assertEquals('unknown_attr', $attr->getName());
+        $this->assertEquals('unknown_value', $attr->getValue());
     }
 
     /**


### PR DESCRIPTION
- Returning undefined and unknown content types as string
- Logging message when an unknown/undefined content type is returned as string
- Added `.phpcs.xml` and included `/tests/`
 