### PR TITLE
SDK-896: Check log messages are correct

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,4 +8,6 @@ examples/vendor
 examples/*.pem
 examples/keys/*.pem
 
+logs
+
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,9 +8,6 @@ php:
 git:
   depth: 1
 
-before_install:
-    - echo 'error_log=/dev/null' >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini
-
 install:
     - travis_retry composer self-update
     - travis_retry composer install --no-interaction --prefer-source --dev

--- a/src/Yoti/Util/Profile/AttributeConverter.php
+++ b/src/Yoti/Util/Profile/AttributeConverter.php
@@ -9,6 +9,7 @@ use Compubapi\EncryptedData;
 use Attrpubapi\Attribute as ProtobufAttribute;
 use Yoti\Exception\AttributeException;
 use Yoti\Entity\MultiValue;
+use Yoti\Entity\ApplicationProfile;
 
 class AttributeConverter
 {
@@ -166,6 +167,12 @@ class AttributeConverter
     {
         $yotiAttribute = null;
 
+        // Application Logo can be empty, return NULL when this occurs.
+        if ($protobufAttribute->getName() == ApplicationProfile::ATTR_APPLICATION_LOGO &&
+          empty($protobufAttribute->getValue())) {
+            return $yotiAttribute;
+        }
+
         try {
             $yotiAnchorsMap = AnchorListConverter::convert(
                 $protobufAttribute->getAnchors()
@@ -185,7 +192,7 @@ class AttributeConverter
                 $yotiAnchorsMap
             );
         } catch (AttributeException $e) {
-            error_log($e->getMessage() . " (Attribute: {$protobufAttribute->getName()})", 0);
+            error_log("{$e->getMessage()} (Attribute: {$protobufAttribute->getName()})", 0);
         } catch (\Exception $e) {
             error_log($e->getMessage(), 0);
         }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,5 +6,32 @@ use PHPUnit_Framework_TestCase;
 
 class TestCase extends PHPUnit_Framework_TestCase
 {
+    /**
+     * Restores ini settings after tests run.
+     */
+    public function teardown()
+    {
+        parent::teardown();
+        ini_restore('error_log');
+    }
 
+    /**
+     * Capture log output so that it can be inspected.
+     */
+    protected function captureLogs()
+    {
+        mkdir('./logs');
+        ini_set('error_log', './logs/' . uniqid('error_', true) . '.log');
+    }
+
+    /**
+     * Asserts that the log file contains the provided string.
+     *
+     * @param string $str
+     */
+    protected function assertLogContains($str)
+    {
+        $this->assertFileExists(ini_get('error_log'));
+        $this->assertContains($str, file_get_contents(ini_get('error_log')));
+    }
 }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -18,9 +18,11 @@ class TestCase extends PHPUnit_Framework_TestCase
     /**
      * Capture log output so that it can be inspected.
      */
-    protected function captureLogs()
+    protected function captureExpectedLogs()
     {
-        mkdir('./logs');
+        if (!is_dir('./logs')) {
+            mkdir('./logs');
+        }
         ini_set('error_log', './logs/' . uniqid('error_', true) . '.log');
     }
 

--- a/tests/Util/Profile/AttributeConverterTest.php
+++ b/tests/Util/Profile/AttributeConverterTest.php
@@ -91,7 +91,7 @@ class AttributeConverterTest extends TestCase
      */
     public function testConvertUndefinedContentType()
     {
-        $this->captureLogs();
+        $this->captureExpectedLogs();
 
         $attr = AttributeConverter::convertToYotiAttribute(
             $this->getMockForProtobufAttribute('undefined_attr', 'undefined_value', self::CONTENT_TYPE_UNDEFINED)
@@ -107,7 +107,7 @@ class AttributeConverterTest extends TestCase
      */
     public function testConvertUnknownContentType()
     {
-        $this->captureLogs();
+        $this->captureExpectedLogs();
 
         $attr = AttributeConverter::convertToYotiAttribute(
             $this->getMockForProtobufAttribute('unknown_attr', 'unknown_value', 100)
@@ -139,12 +139,16 @@ class AttributeConverterTest extends TestCase
      */
     public function testConvertToYotiAttributeEmptyNonStringValue($contentType)
     {
+        $this->captureExpectedLogs();
+
         $attr = AttributeConverter::convertToYotiAttribute($this->getMockForProtobufAttribute(
             'test_attr',
             '',
             $contentType
         ));
+
         $this->assertNull($attr);
+        $this->assertLogContains('Warning: Value is NULL (Attribute: test_attr)');
     }
 
     /**
@@ -243,7 +247,7 @@ class AttributeConverterTest extends TestCase
      */
     public function testConvertToYotiAttributeDocumentImagesInvalid()
     {
-        $this->captureLogs();
+        $this->captureExpectedLogs();
 
         // Create mock Attribute that will return MultiValue as the value.
         $protobufAttribute = $this->getMockForProtobufAttribute(
@@ -325,6 +329,8 @@ class AttributeConverterTest extends TestCase
      */
     public function testEmptyNonStringAttributeMultiValueValue($contentType)
     {
+        $this->captureExpectedLogs();
+
         // Get MultiValue values.
         $values = $this->createMultiValueValues();
 
@@ -344,6 +350,7 @@ class AttributeConverterTest extends TestCase
 
         $attr = AttributeConverter::convertToYotiAttribute($protobufAttribute);
         $this->assertNull($attr);
+        $this->assertLogContains('Warning: Value is NULL (Attribute: test_attr)');
     }
 
     /**

--- a/tests/Util/Profile/AttributeConverterTest.php
+++ b/tests/Util/Profile/AttributeConverterTest.php
@@ -91,11 +91,15 @@ class AttributeConverterTest extends TestCase
      */
     public function testConvertUndefinedContentType()
     {
+        $this->captureLogs();
+
         $attr = AttributeConverter::convertToYotiAttribute(
             $this->getMockForProtobufAttribute('undefined_attr', 'undefined_value', self::CONTENT_TYPE_UNDEFINED)
         );
         $this->assertEquals('undefined_attr', $attr->getName());
         $this->assertEquals('undefined_value', $attr->getValue());
+
+        $this->assertLogContains("Unknown Content Type '0', parsing as a String");
     }
 
     /**
@@ -103,11 +107,15 @@ class AttributeConverterTest extends TestCase
      */
     public function testConvertUnknownContentType()
     {
+        $this->captureLogs();
+
         $attr = AttributeConverter::convertToYotiAttribute(
             $this->getMockForProtobufAttribute('unknown_attr', 'unknown_value', 100)
         );
         $this->assertEquals('unknown_attr', $attr->getName());
         $this->assertEquals('unknown_value', $attr->getValue());
+
+        $this->assertLogContains("Unknown Content Type '100', parsing as a String");
     }
 
     /**
@@ -235,6 +243,8 @@ class AttributeConverterTest extends TestCase
      */
     public function testConvertToYotiAttributeDocumentImagesInvalid()
     {
+        $this->captureLogs();
+
         // Create mock Attribute that will return MultiValue as the value.
         $protobufAttribute = $this->getMockForProtobufAttribute(
             'document_images',
@@ -244,6 +254,8 @@ class AttributeConverterTest extends TestCase
 
         $attr = AttributeConverter::convertToYotiAttribute($protobufAttribute);
         $this->assertNull($attr);
+
+        $this->assertLogContains('Document Images could not be decoded (Attribute: document_images)');
     }
 
     /**


### PR DESCRIPTION
Following #57 I've added test coverage for the logged warnings.

>Note: I'll close this PR if we feel this is unnecessary.