### PR TITLE
SDK-1039: Allow composer install without Docker

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "yoti/yoti-php-sdk",
   "description": "Yoti SDK for quickly integrating your PHP backend with Yoti",
-  "version": "2.2.0",
+  "version": "2.2.1",
   "keywords": [
     "yoti",
     "sdk"

--- a/composer.json
+++ b/composer.json
@@ -8,28 +8,6 @@
   ],
   "homepage": "https://yoti.com",
   "license": "MIT",
-  "authors": [
-    {
-      "name": "Moussa Sidibe",
-      "email": "moussa.sidibe@yoti.com",
-      "role": "Developer"
-    },
-    {
-      "name": "Simon Tong",
-      "email": "simon.tong@yoti.com",
-      "role": "Developer"
-    },
-    {
-      "name": "Omari Rodney",
-      "email": "omari.rodney@yoti.com",
-      "role": "Maintainer"
-    },
-    {
-      "name": "Quirino Zagarese",
-      "email": "quirino.zagarese@yoti.com",
-      "role": "Maintainer"
-    }
-  ],
   "require": {
     "php": ">=5.5.19"
   },

--- a/config.ini
+++ b/config.ini
@@ -1,1 +1,1 @@
-version = 2.2.0
+version = 2.2.1

--- a/examples/composer.json
+++ b/examples/composer.json
@@ -12,5 +12,10 @@
         "symlink": true
       }
     }
-  ]
+  ],
+  "scripts": {
+    "pre-install-cmd": "@copy-sdk",
+    "pre-update-cmd": "@copy-sdk",
+    "copy-sdk": "rm -fr ./sdk && mkdir ./sdk && cd ../ && cp -r `ls -A | grep -v 'examples'` ./examples/sdk/ && cd -"
+  }
 }

--- a/examples/composer.lock
+++ b/examples/composer.lock
@@ -67,10 +67,9 @@
             "name": "yoti/yoti-php-sdk",
             "version": "2.2.0",
             "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/getyoti/yoti-php-sdk/zipball/f3c770c1df2cbba3dc76a1f329938c379191ad7a",
-                "reference": "f3c770c1df2cbba3dc76a1f329938c379191ad7a",
-                "shasum": ""
+                "type": "path",
+                "url": "./sdk",
+                "reference": "549162d0d6f3c0e2b1c328f9128fb28c715da103"
             },
             "require": {
                 "php": ">=5.5.19"
@@ -95,11 +94,21 @@
                     "YotiSandbox\\": "sandbox/src"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "YotiTest\\": "tests/",
+                    "SandboxTest\\": "sandbox/tests/"
+                }
+            },
             "license": [
                 "MIT"
             ],
             "authors": [
+                {
+                    "name": "Moussa Sidibe",
+                    "email": "moussa.sidibe@yoti.com",
+                    "role": "Developer"
+                },
                 {
                     "name": "Simon Tong",
                     "email": "simon.tong@yoti.com",
@@ -114,11 +123,6 @@
                     "name": "Quirino Zagarese",
                     "email": "quirino.zagarese@yoti.com",
                     "role": "Maintainer"
-                },
-                {
-                    "name": "Moussa Sidibe",
-                    "email": "moussa.sidibe@yoti.com",
-                    "role": "Developer"
                 }
             ],
             "description": "Yoti SDK for quickly integrating your PHP backend with Yoti",
@@ -127,7 +131,9 @@
                 "sdk",
                 "yoti"
             ],
-            "time": "2019-04-24T16:02:26+00:00"
+            "transport-options": {
+                "symlink": true
+            }
         }
     ],
     "packages-dev": [],

--- a/examples/composer.lock
+++ b/examples/composer.lock
@@ -69,7 +69,7 @@
             "dist": {
                 "type": "path",
                 "url": "./sdk",
-                "reference": "5aeddc2be04fa11af2b7cc3564a9f2bad9d524d8"
+                "reference": "f103e2d2d587797d7e8484fcc9d74664677858c7"
             },
             "require": {
                 "php": ">=5.5.19"
@@ -102,28 +102,6 @@
             },
             "license": [
                 "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Moussa Sidibe",
-                    "email": "moussa.sidibe@yoti.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Simon Tong",
-                    "email": "simon.tong@yoti.com",
-                    "role": "Developer"
-                },
-                {
-                    "name": "Omari Rodney",
-                    "email": "omari.rodney@yoti.com",
-                    "role": "Maintainer"
-                },
-                {
-                    "name": "Quirino Zagarese",
-                    "email": "quirino.zagarese@yoti.com",
-                    "role": "Maintainer"
-                }
             ],
             "description": "Yoti SDK for quickly integrating your PHP backend with Yoti",
             "homepage": "https://yoti.com",

--- a/examples/composer.lock
+++ b/examples/composer.lock
@@ -65,11 +65,11 @@
         },
         {
             "name": "yoti/yoti-php-sdk",
-            "version": "2.2.0",
+            "version": "2.2.1",
             "dist": {
                 "type": "path",
                 "url": "./sdk",
-                "reference": "549162d0d6f3c0e2b1c328f9128fb28c715da103"
+                "reference": "5aeddc2be04fa11af2b7cc3564a9f2bad9d524d8"
             },
             "require": {
                 "php": ">=5.5.19"

--- a/examples/docker-compose.yml
+++ b/examples/docker-compose.yml
@@ -7,19 +7,16 @@ services:
           - "4002:443"
       volumes:
         - ./:/usr/share/nginx/html
-        - ../:/usr/share/nginx/html/sdk
       links:
           - php
   php:
       image: php:7-fpm-alpine
       volumes:
         - ./:/usr/share/nginx/html
-        - ../:/usr/share/nginx/html/sdk
 
   composer:
     image: composer
     volumes:
-      - ./:/usr/share/nginx/html
-      - ../:/usr/share/nginx/html/sdk
-    working_dir: /usr/share/nginx/html
+      - ../:/usr/share/yoti-php-sdk
+    working_dir: /usr/share/yoti-php-sdk/examples
     command: update


### PR DESCRIPTION
In #65 I updated the examples to use the local checked out SDK, however, this isn't working correctly outside docker (running `composer install` on host machine)

Composer doesn't allow parent directories as a repository, e.g.
```
  "repositories": [
    {
      "type": "path",
      "url": "../",
      "options": {
        "symlink": true
      }
    }
  ],
```

As a result I've changed the implementation to:
- Copy the parent directory into `./examples/sdk` _(excluding `./examples`)_
- `composer.json` will then install the SDK from `./examples/sdk`

>I'd appreciate any suggestions on a more elegant way of implementing `"copy-sdk"` script in `composer.json`

I've also updated the SDK version and the `./examples/composer.lock` to reflect this. 

This should work with both Docker and on host machine:
- `composer update` / `composer install`
- `docker-compose up -d` or specifically: `docker-compose up composer`
