### PR TITLE
SDK-1039: Install example project using local SDK

### DIFF
--- a/examples/composer.json
+++ b/examples/composer.json
@@ -16,6 +16,6 @@
   "scripts": {
     "pre-install-cmd": "@copy-sdk",
     "pre-update-cmd": "@copy-sdk",
-    "copy-sdk": "rm -fr ./sdk && mkdir ./sdk && cd ../ && cp -r `ls -A | grep -v 'examples'` ./examples/sdk/ && cd -"
+    "copy-sdk": "grep -q 'yoti-php-sdk' ../composer.json && rm -fr ./sdk && mkdir ./sdk && cd ../ && cp -r `ls -A | grep -v 'examples'` ./examples/sdk/ && cd - || echo 'Could not install SDK from parent directory'"
   }
 }


### PR DESCRIPTION
> Following #69 

### Changed
- Ensuring parent directory contains SDK before copying into `./sdk/`

#### Summary
- This only checks that `../composer.json` contains `yoti-php-sdk` - the version is resolved by composer and will only install from `./sdk/` if it's a compatible version.
- Echos _"Could not install SDK from parent directory"_ when the parent directory doesn't contain the SDK, but doesn't fail - this is to allow installation of compatible package on _packagist.org_
