### PR TITLE
SDK-1118: Coding Standards

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,6 @@
 /.gitignore export-ignore
 /README.md export-ignore
 /login_flow.png export-ignore
+
+# Auto detect text files and perform LF normalization
+* text=auto

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ examples/*.pem
 examples/keys/*.pem
 examples/sdk
 
+.phpcs.xml
+phpcs.xml
+
 logs
 
 .DS_Store

--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,13 @@
+<?php
+$finder = PhpCsFixer\Finder::create()
+    ->in(__DIR__ . '/src/Yoti')
+    ->in(__DIR__ . '/tests')
+;
+
+return PhpCsFixer\Config::create()
+    ->setRules([
+        'array_syntax' => ['syntax' => 'short'],
+        'no_unused_imports' => true,
+    ])
+    ->setFinder($finder)
+;

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0"?>
-<ruleset name="Yoti">
-  <rule ref="PSR12"/>
-  <file>src/Yoti</file>
-  <file>tests</file>
-</ruleset>

--- a/.phpcs.xml
+++ b/.phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Yoti">
-  <rule ref="PSR2"/>
+  <rule ref="PSR12"/>
   <file>src/Yoti</file>
   <file>tests</file>
 </ruleset>

--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,0 +1,16 @@
+<?xml version="1.0"?>
+<ruleset name="Yoti">
+  <rule ref="PSR12">
+    <!--
+    Windows users that have enabled `core.autocrlf` in their git configuration
+    can disable the `Generic.Files.LineEndings` rule by copying this file to
+    `.phpcs.xml` and adding an exclusion as follows:
+
+    <exclude name="Generic.Files.LineEndings"/>
+
+    Note: This sniff will always be included on Travis CI.
+    -->
+  </rule>
+  <file>src/Yoti</file>
+  <file>tests</file>
+</ruleset>

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,3 +15,4 @@ install:
 script:
     - vendor/bin/phpunit
     - vendor/bin/phpcs
+    - vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,5 @@ install:
     - travis_retry composer install --no-interaction --prefer-source --dev
 
 script:
-    - vendor/bin/phpunit
-    - vendor/bin/phpcs
-    - vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no
+    - composer test
+    - composer lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,9 +16,17 @@ See [.travis.yml](.travis.yml) for PHP versions we currently support.
 
 ## Style guide
 
-We follow the [PSR-2 Style Guide](https://www.php-fig.org/psr/psr-2/), which is
+We follow the [PSR-12 Style Guide](https://www.php-fig.org/psr/psr-12/), which is
 configured in [.phpcs.xml](.phpcs.xml) and can be verified by running:
 
 ```shell
 ./vendor/bin/phpcs
 ```
+
+Additional checks are configured in [.php_cs.dist](.php_cs.dist) and can be verified by running:
+
+```shell
+./vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no
+```
+
+See <https://cs.symfony.com/> for further information.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,7 +17,7 @@ See [.travis.yml](.travis.yml) for PHP versions we currently support.
 ## Style guide
 
 We follow the [PSR-12 Style Guide](https://www.php-fig.org/psr/psr-12/), which
-is configured in [.phpcs.xml](.phpcs.xml).
+is configured in [.phpcs.xml.dist](.phpcs.xml.dist).
 
 Additional checks are configured in [.php_cs.dist](.php_cs.dist) - See
 <https://cs.symfony.com/> for further information.
@@ -27,3 +27,9 @@ Coding style can be verified by running:
 ```shell
 composer lint
 ```
+
+> Note: Windows users that have enabled `core.autocrlf` in their git
+  configuration can disable the `Generic.Files.LineEndings` rule by
+  copying [.phpcs.xml.dist](.phpcs.xml.dist) file to `.phpcs.xml`
+  and adding an exclusion. This sniff will always be included on
+  Travis CI.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,24 +9,21 @@ After cloning the repository, run `composer install` to install dependencies.
 Running the tests:
 
 ```shell
-./vendor/bin/phpunit
+composer test
 ```
 
 See [.travis.yml](.travis.yml) for PHP versions we currently support.
 
 ## Style guide
 
-We follow the [PSR-12 Style Guide](https://www.php-fig.org/psr/psr-12/), which is
-configured in [.phpcs.xml](.phpcs.xml) and can be verified by running:
+We follow the [PSR-12 Style Guide](https://www.php-fig.org/psr/psr-12/), which
+is configured in [.phpcs.xml](.phpcs.xml).
+
+Additional checks are configured in [.php_cs.dist](.php_cs.dist) - See
+<https://cs.symfony.com/> for further information.
+
+Coding style can be verified by running:
 
 ```shell
-./vendor/bin/phpcs
+composer lint
 ```
-
-Additional checks are configured in [.php_cs.dist](.php_cs.dist) and can be verified by running:
-
-```shell
-./vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no
-```
-
-See <https://cs.symfony.com/> for further information.

--- a/composer.json
+++ b/composer.json
@@ -50,7 +50,7 @@
   },
   "extra": {
     "hooks": {
-        "pre-commit": [
+        "commit": [
           "composer test",
           "composer lint"
         ]

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
     "test": "vendor/bin/phpunit",
     "lint": [
       "vendor/bin/phpcs",
-      "vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no"
+      "vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --diff-format=udiff --ansi"
     ],
     "post-install-cmd": "cghooks add --ignore-lock",
     "post-update-cmd": "cghooks update"

--- a/composer.json
+++ b/composer.json
@@ -9,8 +9,7 @@
   "homepage": "https://yoti.com",
   "license": "MIT",
   "require": {
-    "php": ">=5.5.19",
-    "brainmaestro/composer-git-hooks": "^2.7"
+    "php": ">=5.5.19"
   },
   "autoload": {
     "files": [
@@ -30,7 +29,8 @@
     "php": ">=5.6.0",
     "phpunit/phpunit": "5.7.*",
     "squizlabs/php_codesniffer": "3.*",
-    "friendsofphp/php-cs-fixer": "^2.15"
+    "friendsofphp/php-cs-fixer": "^2.15",
+    "brainmaestro/composer-git-hooks": "^2.7"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -40,15 +40,19 @@
   },
   "scripts": {
     "cghooks": "vendor/bin/cghooks",
+    "test": "vendor/bin/phpunit",
+    "lint": [
+      "vendor/bin/phpcs",
+      "vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no"
+    ],
     "post-install-cmd": "cghooks add --ignore-lock",
     "post-update-cmd": "cghooks update"
   },
   "extra": {
     "hooks": {
         "pre-commit": [
-          "vendor/bin/phpunit",
-          "vendor/bin/phpcs",
-          "vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no"
+          "composer test",
+          "composer lint"
         ]
     }
   }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
   "homepage": "https://yoti.com",
   "license": "MIT",
   "require": {
-    "php": ">=5.5.19"
+    "php": ">=5.5.19",
+    "brainmaestro/composer-git-hooks": "^2.7"
   },
   "autoload": {
     "files": [
@@ -28,12 +29,27 @@
   "require-dev": {
     "php": ">=5.6.0",
     "phpunit/phpunit": "5.7.*",
-    "squizlabs/php_codesniffer": "3.*"
+    "squizlabs/php_codesniffer": "3.*",
+    "friendsofphp/php-cs-fixer": "^2.15"
   },
   "autoload-dev": {
     "psr-4": {
       "YotiTest\\": "tests/",
       "SandboxTest\\": "sandbox/tests/"
+    }
+  },
+  "scripts": {
+    "cghooks": "vendor/bin/cghooks",
+    "post-install-cmd": "cghooks add --ignore-lock",
+    "post-update-cmd": "cghooks update"
+  },
+  "extra": {
+    "hooks": {
+        "pre-commit": [
+          "vendor/bin/phpunit",
+          "vendor/bin/phpcs",
+          "vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --stop-on-violation --using-cache=no"
+        ]
     }
   }
 }

--- a/composer.json
+++ b/composer.json
@@ -39,11 +39,11 @@
     }
   },
   "scripts": {
-    "cghooks": "vendor/bin/cghooks",
-    "test": "vendor/bin/phpunit",
+    "cghooks": "cghooks",
+    "test": "phpunit",
     "lint": [
-      "vendor/bin/phpcs",
-      "vendor/bin/php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --diff-format=udiff --ansi"
+      "phpcs",
+      "php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --diff-format=udiff --ansi"
     ],
     "post-install-cmd": "cghooks add --ignore-lock",
     "post-update-cmd": "cghooks update"

--- a/src/Yoti/Exception/AttributeException.php
+++ b/src/Yoti/Exception/AttributeException.php
@@ -3,5 +3,4 @@ namespace Yoti\Exception;
 
 class AttributeException extends \Exception
 {
-
 }

--- a/src/Yoti/Util/Profile/AnchorConverter.php
+++ b/src/Yoti/Util/Profile/AnchorConverter.php
@@ -80,7 +80,7 @@ class AnchorConverter
         $signedTimeStamp = new \Compubapi\SignedTimestamp();
         $signedTimeStamp->mergeFromString($anchor->getSignedTimeStamp());
 
-        $timestamp = $signedTimeStamp->getTimestamp()/1000000;
+        $timestamp = $signedTimeStamp->getTimestamp() / 1000000;
         $timeIncMicroSeconds = number_format($timestamp, 6, '.', '');
         // Format DateTime to include microseconds and timezone
         $dateTime = \DateTime::createFromFormat(

--- a/tests/Http/RequestSignerTest.php
+++ b/tests/Http/RequestSignerTest.php
@@ -52,7 +52,7 @@ class RequestSignerTest extends TestCase
         );
         $signedMessage = $signedData[RequestSigner::SIGNED_MESSAGE_KEY];
         $endpointPath = $signedData[RequestSigner::END_POINT_PATH_KEY];
-        $messageToSign = 'POST&'.$endpointPath.'&'.$this->payload->getBase64Payload();
+        $messageToSign = 'POST&' . $endpointPath . '&' . $this->payload->getBase64Payload();
 
         $publicKey = openssl_pkey_get_public($this->getDummyPublicKey());
 

--- a/tests/Util/Age/AgeVerificationConverterTest.php
+++ b/tests/Util/Age/AgeVerificationConverterTest.php
@@ -19,7 +19,7 @@ class AgeVerificationConverterTest extends TestCase
     public function testGetAgeVerificationsFromAttrsMap()
     {
         $ageAttribute = new Attribute('age_under:18', 'true', []);
-        $ageVerificationConverter = new AgeVerificationConverter(['age_under:18'=> $ageAttribute]);
+        $ageVerificationConverter = new AgeVerificationConverter(['age_under:18' => $ageAttribute]);
         $ageVerifications = $ageVerificationConverter->getAgeVerificationsFromAttrsMap();
         $ageUnder18 = $ageVerifications['age_under:18'];
 
@@ -36,9 +36,9 @@ class AgeVerificationConverterTest extends TestCase
     public function testMultipleAgeDerivations()
     {
         $profileData = [
-            'age_under:18'=> new Attribute('age_under:18', 'false', []),
-            'age_over:50'=> new Attribute('age_over:50', 'true', []),
-            'age_breaker:50'=> new Attribute('age_breaker:50', 'true', []),
+            'age_under:18' => new Attribute('age_under:18', 'false', []),
+            'age_over:50' => new Attribute('age_over:50', 'true', []),
+            'age_breaker:50' => new Attribute('age_breaker:50', 'true', []),
         ];
         $ageVerificationConverter = new AgeVerificationConverter($profileData);
         $ageVerifications = $ageVerificationConverter->getAgeVerificationsFromAttrsMap();
@@ -74,7 +74,7 @@ class AgeVerificationConverterTest extends TestCase
                 'TEST FAMILY NAME',
                 []
             ),
-            'age_breaker:50'=> new Attribute('age_breaker:50', 'true', []),
+            'age_breaker:50' => new Attribute('age_breaker:50', 'true', []),
         ];
         $ageVerificationConverter = new AgeVerificationConverter($profileData);
         $ageVerifications = $ageVerificationConverter->getAgeVerificationsFromAttrsMap();

--- a/tests/Util/Profile/AttributeConverterTest.php
+++ b/tests/Util/Profile/AttributeConverterTest.php
@@ -360,26 +360,26 @@ class AttributeConverterTest extends TestCase
      */
     public function testEmptyStringAttributeMultiValueValue()
     {
-         // Get MultiValue values.
-         $values = $this->createMultiValueValues();
+        // Get MultiValue values.
+        $values = $this->createMultiValueValues();
 
-         // Add an empty MultiValue.
-         $values[] = $this->createMultiValueValue('', self::CONTENT_TYPE_STRING);
+        // Add an empty MultiValue.
+        $values[] = $this->createMultiValueValue('', self::CONTENT_TYPE_STRING);
 
-         // Create top-level MultiValue.
-         $protoMultiValue = new \Attrpubapi\MultiValue();
-         $protoMultiValue->setValues($values);
+        // Create top-level MultiValue.
+        $protoMultiValue = new \Attrpubapi\MultiValue();
+        $protoMultiValue->setValues($values);
 
-         // Create mock Attribute that will return MultiValue as the value.
-         $protobufAttribute = $this->getMockForProtobufAttribute(
-             'test_attr',
-             $protoMultiValue->serializeToString(),
-             self::CONTENT_TYPE_MULTI_VALUE
-         );
+        // Create mock Attribute that will return MultiValue as the value.
+        $protobufAttribute = $this->getMockForProtobufAttribute(
+            'test_attr',
+            $protoMultiValue->serializeToString(),
+            self::CONTENT_TYPE_MULTI_VALUE
+        );
 
-         $attr = AttributeConverter::convertToYotiAttribute($protobufAttribute);
-         $this->assertInstanceOf(Attribute::class, $attr);
-         $this->assertEquals('', $attr->getValue()[3]);
+        $attr = AttributeConverter::convertToYotiAttribute($protobufAttribute);
+        $this->assertInstanceOf(Attribute::class, $attr);
+        $this->assertEquals('', $attr->getValue()[3]);
     }
 
     /**


### PR DESCRIPTION
### Changed
- Using [PSR-12](https://www.php-fig.org/psr/psr-12/) (from [PSR-2](https://www.php-fig.org/psr/psr-2/))

### Added
- Pre-commit hooks using https://packagist.org/packages/brainmaestro/composer-git-hooks
- `composer test` and `composer lint` scripts to be used by Travis, pre-commit hooks and _CONTRIBUTING.md_
- https://cs.symfony.com/ to allow checks that aren't currently covered by code sniffer:
  - No unused imports
  - Use short array syntax