### PR TITLE
SDK-1080: Signed Request

### DIFF
--- a/src/Yoti/Http/AbstractRequestHandler.php
+++ b/src/Yoti/Http/AbstractRequestHandler.php
@@ -123,7 +123,8 @@ abstract class AbstractRequestHandler
      *
      * @throws RequestException
      */
-    public function sendRequest($endpoint, $httpMethod, Payload $payload = null) {
+    public function sendRequest($endpoint, $httpMethod, Payload $payload = null)
+    {
         $request = (new RequestBuilder())
           ->withBaseUrl($this->apiUrl)
           ->withPemString((string) $this->pemFile)

--- a/src/Yoti/Http/AbstractRequestHandler.php
+++ b/src/Yoti/Http/AbstractRequestHandler.php
@@ -311,4 +311,15 @@ abstract class AbstractRequestHandler
      * @throws \Yoti\Exception\RequestException
      */
     abstract protected function executeRequest(array $httpHeaders, $requestUrl, $httpMethod, $payload);
+
+    /**
+     * Execute Request against the API.
+     *
+     * @param Request $request
+     *
+     * @return array
+     *
+     * @throws \Yoti\Exception\RequestException
+     */
+    abstract protected function execute(Request $request);
 }

--- a/src/Yoti/Http/AbstractRequestHandler.php
+++ b/src/Yoti/Http/AbstractRequestHandler.php
@@ -29,7 +29,6 @@ abstract class AbstractRequestHandler
 
     /**
      * Default SDK Identifier.
-     * @deprecated 3.0.0 replaced by \Yoti\Http\RequestBuilder
      */
     const YOTI_SDK_IDENTIFIER = RequestBuilder::YOTI_SDK_IDENTIFIER;
 
@@ -60,8 +59,6 @@ abstract class AbstractRequestHandler
      * @param string $pem
      * @param string $sdkId
      * @param string $sdkIdentifier
-     *
-     * @throws RequestException
      */
     public function __construct($apiUrl, $pem, $sdkId = null, $sdkIdentifier = null)
     {
@@ -77,12 +74,9 @@ abstract class AbstractRequestHandler
     }
 
     /**
-     * @deprecated 3.0.0
-     *
      * @param string $endpoint
      * @param string $httpMethod
      * @param Payload|NULL $payload
-     * @param array queryParams
      *
      * @return array
      *
@@ -118,11 +112,7 @@ abstract class AbstractRequestHandler
     }
 
     /**
-     * @deprecated 3.0.0
-     *
-     * SDK ID is now added as a query param in \Yoti\YotiClient::sendRequest()
-     *
-     * @return string|null
+     * @return string
      */
     public function getSdkId()
     {
@@ -130,8 +120,6 @@ abstract class AbstractRequestHandler
     }
 
     /**
-     * @deprecated 3.0.0
-     *
      * @return string
      */
     public function getPem()

--- a/src/Yoti/Http/AbstractRequestHandler.php
+++ b/src/Yoti/Http/AbstractRequestHandler.php
@@ -114,6 +114,8 @@ abstract class AbstractRequestHandler
     }
 
     /**
+     * @deprecated 3.0.0 Replaced by execute()
+     *
      * @param string $endpoint
      * @param string $httpMethod
      * @param Payload|NULL $payload

--- a/src/Yoti/Http/Curl/RequestHandler.php
+++ b/src/Yoti/Http/Curl/RequestHandler.php
@@ -22,8 +22,10 @@ class RequestHandler implements RequestHandlerInterface
     public function execute(Request $request)
     {
         $headers = [];
-        foreach ($request->getHeaders() as $name => $value) {
-            $headers[] = "{$name}: {$value}";
+        if ($request->getHeaders()) {
+            foreach ($request->getHeaders() as $name => $value) {
+                $headers[] = "{$name}: {$value}";
+            }
         }
 
         $ch = curl_init($request->getUrl());
@@ -47,12 +49,17 @@ class RequestHandler implements RequestHandlerInterface
         $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
 
         // Check if any related Curl error occurred.
-        if (curl_error($ch)) {
-            throw new RequestException(curl_error($ch));
+        if ($response === false) {
+            $error = curl_error($ch);
         }
 
         // Close the session
         curl_close($ch);
+
+        // Throw if there was an error.
+        if (!empty($error)) {
+            throw new RequestException($error);
+        }
 
         return new Response($response, $statusCode);
     }

--- a/src/Yoti/Http/Curl/RequestHandler.php
+++ b/src/Yoti/Http/Curl/RequestHandler.php
@@ -5,6 +5,7 @@ namespace Yoti\Http\Curl;
 use Yoti\Http\RequestHandlerInterface;
 use Yoti\Http\Request;
 use Yoti\Http\Response;
+use Yoti\Exception\RequestException;
 
 /**
  * Handle HTTP requests.

--- a/src/Yoti/Http/Curl/RequestHandler.php
+++ b/src/Yoti/Http/Curl/RequestHandler.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Yoti\Http\Curl;
+
+use Yoti\Http\RequestHandlerInterface;
+use Yoti\Http\Request;
+use Yoti\Http\Response;
+
+/**
+ * Handle HTTP requests.
+ */
+class RequestHandler implements RequestHandlerInterface
+{
+    /**
+     * Execute HTTP request.
+     *
+     * @param Request $request
+     *
+     * @return \Yoti\Http\Response
+     */
+    public function execute(Request $request)
+    {
+        $headers = [];
+        foreach ($request->getHeaders() as $name => $value) {
+            $headers[] = "{$name}: {$value}";
+        }
+
+        $ch = curl_init($request->getUrl());
+        curl_setopt_array($ch, [
+            CURLOPT_HTTPHEADER => $headers,
+            CURLOPT_RETURNTRANSFER => true,
+        ]);
+
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $request->getMethod());
+
+        // Only send payload data for methods that need it.
+        if ($request->getPayload()) {
+            // Send payload data as a JSON string
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $request->getPayload()->getPayloadJSON());
+        }
+
+        // Set response data
+        $response = curl_exec($ch);
+
+        // Set response code
+        $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        // Check if any related Curl error occurred.
+        if (curl_error($ch)) {
+            throw new RequestException(curl_error($ch));
+        }
+
+        // Close the session
+        curl_close($ch);
+
+        return new Response($response, $statusCode);
+    }
+}

--- a/src/Yoti/Http/CurlRequestHandler.php
+++ b/src/Yoti/Http/CurlRequestHandler.php
@@ -44,7 +44,7 @@ class CurlRequestHandler extends AbstractRequestHandler
           ->execute($request);
 
         return [
-            'response' => $response->getResponse(),
+            'response' => $response->getBody(),
             'http_code' => $response->getStatusCode()
         ];
     }

--- a/src/Yoti/Http/CurlRequestHandler.php
+++ b/src/Yoti/Http/CurlRequestHandler.php
@@ -20,22 +20,36 @@ class CurlRequestHandler extends AbstractRequestHandler
      */
     protected function executeRequest(array $httpHeaders, $requestUrl, $httpMethod, $payload)
     {
+        return $this->execute();
+    }
+
+    /**
+     * Execute Request against the API.
+     *
+     * @param Request $request
+     *
+     * @return array
+     *
+     * @throws RequestException
+     */
+    protected function execute(Request $request)
+    {
         $result = [];
 
-        $ch = curl_init($requestUrl);
+        $ch = curl_init($request->getUrl());
         curl_setopt_array($ch, [
-            CURLOPT_HTTPHEADER => $httpHeaders,
+            CURLOPT_HTTPHEADER => $request->getHeaders(),
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYPEER => false,
             CURLOPT_SSL_VERIFYHOST => 0,
         ]);
 
-        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $httpMethod);
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $request->getMethod());
 
         // Only send payload data for methods that need it.
-        if ($payload instanceof Payload) {
+        if (!empty($request->getPayload())) {
             // Send payload data as a JSON string
-            curl_setopt($ch, CURLOPT_POSTFIELDS, $payload->getPayloadJSON());
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $request->getPayload());
         }
 
         // Set response data

--- a/src/Yoti/Http/CurlRequestHandler.php
+++ b/src/Yoti/Http/CurlRequestHandler.php
@@ -20,36 +20,22 @@ class CurlRequestHandler extends AbstractRequestHandler
      */
     protected function executeRequest(array $httpHeaders, $requestUrl, $httpMethod, $payload)
     {
-        return $this->execute();
-    }
-
-    /**
-     * Execute Request against the API.
-     *
-     * @param Request $request
-     *
-     * @return array
-     *
-     * @throws RequestException
-     */
-    protected function execute(Request $request)
-    {
         $result = [];
 
-        $ch = curl_init($request->getUrl());
+        $ch = curl_init($requestUrl);
         curl_setopt_array($ch, [
-            CURLOPT_HTTPHEADER => $request->getHeaders(),
+            CURLOPT_HTTPHEADER => $httpHeaders,
             CURLOPT_RETURNTRANSFER => true,
             CURLOPT_SSL_VERIFYPEER => false,
             CURLOPT_SSL_VERIFYHOST => 0,
         ]);
 
-        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $request->getMethod());
+        curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $httpMethod);
 
         // Only send payload data for methods that need it.
-        if (!empty($request->getPayload())) {
+        if ($payload instanceof Payload) {
             // Send payload data as a JSON string
-            curl_setopt($ch, CURLOPT_POSTFIELDS, $request->getPayload());
+            curl_setopt($ch, CURLOPT_POSTFIELDS, $payload->getPayloadJSON());
         }
 
         // Set response data

--- a/src/Yoti/Http/CurlRequestHandler.php
+++ b/src/Yoti/Http/CurlRequestHandler.php
@@ -6,7 +6,7 @@ use Yoti\Exception\RequestException;
 use Yoti\Http\Curl\RequestHandler;
 
 /**
- * @deprecated 3.0.0
+ * @deprecated 3.0.0 Replaced by \Yoti\Http\Curl\RequestHandler
  */
 class CurlRequestHandler extends AbstractRequestHandler
 {

--- a/src/Yoti/Http/Request.php
+++ b/src/Yoti/Http/Request.php
@@ -3,6 +3,7 @@
 namespace Yoti\Http;
 
 use Yoti\Exception\RequestException;
+use Yoti\Http\Curl\RequestHandler;
 
 class Request
 {
@@ -31,40 +32,33 @@ class Request
     /**
      * @var array
      */
-    private $queryParams;
-
-    /**
-     * @var array
-     */
     private $headers;
 
     /**
-     * @var \Yoti\Http\AbstractRequesthandler
+     * @var \Yoti\Http\RequestHandlerInterface
      */
     private $handler;
 
     /**
-     * AbstractRequestHandler constructor.
+     * Request constructor.
      *
-     * @param string $apiUrl
-     * @param string $pem
-     * @param string $sdkId
-     * @param string $sdkIdentifier - deprecated - use ::setSdkIdentifier() instead.
+     * @param string $method
+     * @param string $url
+     * @param Payload $payload
+     * @param array $header
      *
      * @throws RequestException
      */
     public function __construct(
         $method,
         $url,
-        $queryParams = [],
         Payload $payload = null,
-        $headers = []
+        array $headers = []
     ) {
         $this->validateHttpMethod($method);
         $this->validateHeaders($headers);
         $this->method = $method;
         $this->url = $url;
-        $this->queryParams = $queryParams;
         $this->payload = $payload;
         $this->headers = $headers;
     }
@@ -88,14 +82,6 @@ class Request
     /**
      * @return array
      */
-    public function getQueryParams()
-    {
-        return $this->queryParams;
-    }
-
-    /**
-     * @return array
-     */
     public function getHeaders()
     {
         return $this->headers;
@@ -110,11 +96,11 @@ class Request
     }
 
     /**
-     * @param \Yoti\Http\AbstractRequesthandler $handler
+     * @param \Yoti\Http\RequestHandlerInterface $handler
      *
      * @return \Yoti\Http\RequestBuilder
      */
-    public function setHandler(AbstractRequesthandler $handler)
+    public function setHandler(RequestHandlerInterface $handler)
     {
         $this->handler = $handler;
     }
@@ -126,7 +112,7 @@ class Request
     {
         if (is_null($this->handler)) {
             // Use Curl handler by default.
-            $this->handler = new CurlRequestHandler();
+            $this->handler = new RequestHandler();
         }
         return $this->handler;
     }
@@ -134,11 +120,11 @@ class Request
     /**
      * Execute the request.
      *
-     * @return array
+     * @return \Yoti\Http\Response
      */
     public function execute()
     {
-        $this->getHandler()->execute($this);
+        return $this->getHandler()->execute($this);
     }
 
     /**

--- a/src/Yoti/Http/Request.php
+++ b/src/Yoti/Http/Request.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace Yoti\Http;
+
+use Yoti\Exception\RequestException;
+
+class Request
+{
+    // HTTP methods
+    const METHOD_GET = 'GET';
+    const METHOD_POST = 'POST';
+    const METHOD_PUT = 'PUT';
+    const METHOD_PATCH = 'PATCH';
+    const METHOD_DELETE = 'DELETE';
+
+    /**
+     * @var string
+     */
+    private $method;
+
+    /**
+     * @var string
+     */
+    private $url;
+
+    /**
+     * @var string
+     */
+    private $payload;
+
+    /**
+     * @var array
+     */
+    private $queryParams;
+
+    /**
+     * @var array
+     */
+    private $headers;
+
+    /**
+     * AbstractRequestHandler constructor.
+     *
+     * @param string $apiUrl
+     * @param string $pem
+     * @param string $sdkId
+     * @param string $sdkIdentifier - deprecated - use ::setSdkIdentifier() instead.
+     *
+     * @throws RequestException
+     */
+    public function __construct($method, $url, $queryParams = [], Payload $payload = null, $headers = [])
+    {
+        $this->validateHttpMethod($method);
+        $this->validateHeaders($headers);
+        $this->method = $method;
+        $this->url = $url;
+        $this->queryParams = $queryParams;
+        $this->payload = (string) $payload;
+        $this->headers = $headers;
+    }
+
+    /**
+     * @return string
+     */
+    public function getMethod()
+    {
+        return $this->method;
+    }
+
+    /**
+     * @return string
+     */
+    public function getUrl()
+    {
+        return $this->url;
+    }
+
+    /**
+     * @return array
+     */
+    public function getQueryParams()
+    {
+        return $this->queryParams;
+    }
+
+    /**
+     * @return array
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
+    }
+
+    /**
+     * @return string
+     */
+    public function getPayload()
+    {
+        return $this->payload;
+    }
+
+    /**
+     * Set custom headers.
+     *
+     * @param string[] $headers
+     *   Associative array of header names and values
+     *
+     * @throws RequestException
+     */
+    public function validateHeaders($headers)
+    {
+        foreach ($headers as $name => $value) {
+            if (!is_string($value)) {
+                throw new RequestException("Header value for '{$name}' must be a string");
+            }
+        }
+    }
+
+    /**
+     * Check if the provided HTTP method is valid.
+     *
+     * @param string $httpMethod
+     *
+     * @throws RequestException
+     */
+    private static function validateHttpMethod($httpMethod)
+    {
+        if (!self::methodIsAllowed($httpMethod)) {
+            throw new RequestException("Unsupported HTTP Method {$httpMethod}", 400);
+        }
+    }
+
+    /**
+     * Check the HTTP method is allowed.
+     *
+     * @param string $httpMethod
+     *
+     * @return bool
+     */
+    private static function methodIsAllowed($httpMethod)
+    {
+        $allowedMethods = [
+            self::METHOD_GET,
+            self::METHOD_POST,
+            self::METHOD_PUT,
+            self::METHOD_PATCH,
+            self::METHOD_DELETE,
+        ];
+
+        return in_array($httpMethod, $allowedMethods, true);
+    }
+}

--- a/src/Yoti/Http/Request.php
+++ b/src/Yoti/Http/Request.php
@@ -65,7 +65,7 @@ class Request
         $this->method = $method;
         $this->url = $url;
         $this->queryParams = $queryParams;
-        $this->payload = (string) $payload;
+        $this->payload = $payload;
         $this->headers = $headers;
     }
 
@@ -102,7 +102,7 @@ class Request
     }
 
     /**
-     * @return string
+     * @return Payload|null
      */
     public function getPayload()
     {

--- a/src/Yoti/Http/RequestBuilder.php
+++ b/src/Yoti/Http/RequestBuilder.php
@@ -70,14 +70,19 @@ class RequestBuilder
     private $endpoint;
 
     /**
-     * @var Payload
+     * @var \Yoti\Http\Payload
      */
     private $payload;
 
     /**
+     * @var \Yoti\Http\AbstractRequestHandler
+     */
+    private $handler;
+
+    /**
      * @param string $baseUrl
      *
-     * @return RequestBuilder
+     * @return \Yoti\Http\RequestBuilder
      */
     public function withBaseUrl($baseUrl)
     {
@@ -86,7 +91,7 @@ class RequestBuilder
     }
 
     /**
-     * @param PemFile $pemFile
+     * @param \Yoti\Util\PemFile $pemFile
      *
      * @return RequestBuilder
      */
@@ -97,9 +102,9 @@ class RequestBuilder
     }
 
     /**
-     * @param string $pemFile
+     * @param string $filePath
      *
-     * @return RequestBuilder
+     * @return \Yoti\Http\RequestBuilder
      */
     public function withPemFilePath($filePath)
     {
@@ -109,7 +114,7 @@ class RequestBuilder
     /**
      * @param string $content
      *
-     * @return RequestBuilder
+     * @return \Yoti\Http\RequestBuilder
      */
     public function withPemString($content)
     {
@@ -119,7 +124,7 @@ class RequestBuilder
     /**
      * @param string $method
      *
-     * @return RequestBuilder
+     * @return \Yoti\Http\RequestBuilder
      */
     public function withMethod($method)
     {
@@ -128,9 +133,25 @@ class RequestBuilder
     }
 
     /**
+     * @return \Yoti\Http\RequestBuilder
+     */
+    public function withGet()
+    {
+        return $this->withMethod(Request::METHOD_GET);
+    }
+
+    /**
+     * @return \Yoti\Http\RequestBuilder
+     */
+    public function withPost()
+    {
+        return $this->withMethod(Request::METHOD_POST);
+    }
+
+    /**
      * @param string $endpoint
      *
-     * @return RequestBuilder
+     * @return \Yoti\Http\RequestBuilder
      */
     public function withEndpoint($endpoint)
     {
@@ -141,18 +162,29 @@ class RequestBuilder
     /**
      * @param string $payload
      *
-     * @return RequestBuilder
+     * @return \Yoti\Http\RequestBuilder
      */
-    public function withPayload(Payload $payload)
+    public function withPayload(Payload $payload = null)
     {
         $this->payload = $payload;
         return $this;
     }
 
     /**
+     * @param \Yoti\Http\AbstractRequesthandler $handler
+     *
+     * @return \Yoti\Http\RequestBuilder
+     */
+    public function withHandler(AbstractRequestHandler $handler)
+    {
+        $this->handler = $handler;
+        return $this;
+    }
+
+    /**
      * @param string $sdkIdentifier
      *
-     * @return RequestBuilder
+     * @return \Yoti\Http\RequestBuilder
      */
     public function withSdkIdentifier($sdkIdentifier)
     {
@@ -170,7 +202,7 @@ class RequestBuilder
     /**
      * @param string $sdkVersion
      *
-     * @return RequestBuilder
+     * @return \Yoti\Http\RequestBuilder
      */
     public function withSdkVersion($sdkVersion)
     {
@@ -185,7 +217,7 @@ class RequestBuilder
      * @param string $name
      * @param string $value
      *
-     * @return RequestBuilder
+     * @return \Yoti\Http\RequestBuilder
      */
     public function withHeader($name, $value)
     {
@@ -197,7 +229,7 @@ class RequestBuilder
      * @param string $name
      * @param string $value
      *
-     * @return RequestBuilder
+     * @return \Yoti\Http\RequestBuilder
      */
     public function withQueryParam($name, $value)
     {
@@ -235,9 +267,9 @@ class RequestBuilder
     }
 
     /**
-     * @return AbstractRequestHandler
+     * @return \Yoti\Http\Request
      *
-     * @throws RequestException
+     * @throws \Yoti\Exception\RequestException
      */
     public function build()
     {
@@ -250,7 +282,7 @@ class RequestBuilder
         }
 
         $signedDataArr = RequestSigner::sign(
-            (string) $this->pemFile,
+            $this->pemFile,
             $this->endpoint,
             $this->method,
             $this->payload,
@@ -267,7 +299,12 @@ class RequestBuilder
             $this->queryParams,
             $this->payload,
             array_merge($defaultHeaders, $this->headers),
+            $this->handler
         );
+
+        if (isset($this->handler)) {
+            $request->setHandler($this->handler);
+        }
 
         return $request;
     }

--- a/src/Yoti/Http/RequestBuilder.php
+++ b/src/Yoti/Http/RequestBuilder.php
@@ -35,7 +35,7 @@ class RequestBuilder
     private $baseUrl;
 
     /**
-     * @var Yoti\Util\PemFile
+     * @var \Yoti\Util\PemFile
      */
     private $pemFile;
 
@@ -75,7 +75,7 @@ class RequestBuilder
     private $payload;
 
     /**
-     * @var \Yoti\Http\AbstractRequestHandler
+     * @var \Yoti\Http\RequestHandlerInterface
      */
     private $handler;
 
@@ -164,18 +164,18 @@ class RequestBuilder
      *
      * @return \Yoti\Http\RequestBuilder
      */
-    public function withPayload(Payload $payload = null)
+    public function withPayload(Payload $payload)
     {
         $this->payload = $payload;
         return $this;
     }
 
     /**
-     * @param \Yoti\Http\AbstractRequesthandler $handler
+     * @param \Yoti\Http\RequestHandlerInterface $handler
      *
      * @return \Yoti\Http\RequestBuilder
      */
-    public function withHandler(AbstractRequestHandler $handler)
+    public function withHandler(RequestHandlerInterface $handler)
     {
         $this->handler = $handler;
         return $this;
@@ -296,10 +296,8 @@ class RequestBuilder
         $request = new Request(
             $this->method,
             $url,
-            $this->queryParams,
             $this->payload,
-            array_merge($defaultHeaders, $this->headers),
-            $this->handler
+            array_merge($defaultHeaders, $this->headers)
         );
 
         if (isset($this->handler)) {

--- a/src/Yoti/Http/RequestBuilder.php
+++ b/src/Yoti/Http/RequestBuilder.php
@@ -81,12 +81,25 @@ class RequestBuilder
 
     /**
      * @param string $baseUrl
+     *   Base URL with no trailing slashes.
      *
      * @return \Yoti\Http\RequestBuilder
      */
     public function withBaseUrl($baseUrl)
     {
-        $this->baseUrl = $baseUrl;
+        $this->baseUrl = rtrim($baseUrl, '/');
+        return $this;
+    }
+
+    /**
+     * @param string $endpoint
+     *   Endpoint with a single leading slash.
+     *
+     * @return \Yoti\Http\RequestBuilder
+     */
+    public function withEndpoint($endpoint)
+    {
+        $this->endpoint = '/' . ltrim($endpoint, '/');
         return $this;
     }
 
@@ -146,17 +159,6 @@ class RequestBuilder
     public function withPost()
     {
         return $this->withMethod(Request::METHOD_POST);
-    }
-
-    /**
-     * @param string $endpoint
-     *
-     * @return \Yoti\Http\RequestBuilder
-     */
-    public function withEndpoint($endpoint)
-    {
-        $this->endpoint = $endpoint;
-        return $this;
     }
 
     /**
@@ -291,7 +293,7 @@ class RequestBuilder
 
         $defaultHeaders = $this->getHeaders($signedDataArr[RequestSigner::SIGNED_MESSAGE_KEY]);
 
-        $url = rtrim($this->baseUrl, '/')  . '/' . ltrim($signedDataArr[RequestSigner::END_POINT_PATH_KEY], '/');
+        $url = $this->baseUrl . $signedDataArr[RequestSigner::END_POINT_PATH_KEY];
 
         $request = new Request(
             $this->method,

--- a/src/Yoti/Http/RequestBuilder.php
+++ b/src/Yoti/Http/RequestBuilder.php
@@ -160,7 +160,7 @@ class RequestBuilder
     }
 
     /**
-     * @param string $payload
+     * @param \Yoti\Http\Payload $payload
      *
      * @return \Yoti\Http\RequestBuilder
      */

--- a/src/Yoti/Http/RequestHandlerInterface.php
+++ b/src/Yoti/Http/RequestHandlerInterface.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Yoti\Http;
+
+/**
+ * Handle HTTP requests.
+ */
+interface RequestHandlerInterface
+{
+    /**
+     * Execute HTTP request.
+     *
+     * @param \Yoti\Http\Request $request
+     *
+     * @return \Yoti\Http\Response
+     */
+    public function execute(Request $request);
+}

--- a/src/Yoti/Http/RequestSigner.php
+++ b/src/Yoti/Http/RequestSigner.php
@@ -32,8 +32,6 @@ class RequestSigner
         Payload $payload = null,
         array $queryParams = []
     ) {
-        // Include `appId` query param if SDK ID has been provided to request handler.
-        // @deprecated 3.0.0 AbstractRequestHandler::getSDKId() will be removed in version 3.
         if (!is_null($requestHandler->getSDKId())) {
             $queryParams['appId'] = $requestHandler->getSDKId();
         }
@@ -50,10 +48,10 @@ class RequestSigner
     /**
      * Return request signed data.
      *
-     * @param PemFile $pemFile
+     * @param \Yoti\Util\PemFile $pemFile
      * @param string $endpoint
      * @param string $httpMethod
-     * @param Payload|NULL $payload
+     * @param \Yoti\Http\Payload|NULL $payload
      * @param array $queryParams
      *
      * @return array

--- a/src/Yoti/Http/RequestSigner.php
+++ b/src/Yoti/Http/RequestSigner.php
@@ -54,6 +54,32 @@ class RequestSigner
         ];
     }
 
+    public static function sign(
+        $pem,
+        $endpoint,
+        $httpMethod,
+        Payload $payload = null,
+        array $queryParams = []
+    ) {
+        $endPointPath = self::generateEndPointPath($endpoint, $queryParams);
+
+        $messageToSign = "{$httpMethod}&$endPointPath";
+        if ($payload instanceof Payload) {
+            $messageToSign .= "&{$payload->getBase64Payload()}";
+        }
+
+        openssl_sign($messageToSign, $signedMessage, $pem, OPENSSL_ALGO_SHA256);
+
+        self::validateSignedMessage($signedMessage);
+
+        $base64SignedMessage = base64_encode($signedMessage);
+
+        return [
+            self::SIGNED_MESSAGE_KEY => $base64SignedMessage,
+            self::END_POINT_PATH_KEY => $endPointPath
+        ];
+    }
+
     /**
      * @param string $endpoint
      * @param array $queryParams

--- a/src/Yoti/Http/Response.php
+++ b/src/Yoti/Http/Response.php
@@ -5,23 +5,33 @@ namespace Yoti\Http;
 class Response
 {
     /**
-     * @param string $response
+     * @var string
+     */
+    private $body;
+
+    /**
+     * @var int
+     */
+    private $statusCode;
+
+    /**
+     * @param string $body
      * @param int $statusCode
      */
     public function __construct(
-        $response,
+        $body,
         $statusCode
     ) {
-        $this->response = (string) $response;
+        $this->body = (string) $body;
         $this->statusCode = (int) $statusCode;
     }
 
     /**
      * @return string
      */
-    public function getResponse()
+    public function getBody()
     {
-        return $this->response;
+        return $this->body;
     }
 
     /**

--- a/src/Yoti/Http/Response.php
+++ b/src/Yoti/Http/Response.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Yoti\Http;
+
+class Response
+{
+    /**
+     * @param string $response
+     * @param int $statusCode
+     */
+    public function __construct(
+        $response,
+        $statusCode
+    ) {
+        $this->response = (string) $response;
+        $this->statusCode = (int) $statusCode;
+    }
+
+    /**
+     * @return string
+     */
+    public function getResponse()
+    {
+        return $this->response;
+    }
+
+    /**
+     * @return string
+     */
+    public function getStatusCode()
+    {
+        return $this->statusCode;
+    }
+}

--- a/src/Yoti/YotiClient.php
+++ b/src/Yoti/YotiClient.php
@@ -257,7 +257,7 @@ class YotiClient
         $response = $request->execute();
 
         return [
-            'response' => $response->getResponse(),
+            'response' => $response->getBody(),
             'http_code' => $response->getStatusCode()
         ];
     }

--- a/src/Yoti/YotiClient.php
+++ b/src/Yoti/YotiClient.php
@@ -230,10 +230,7 @@ class YotiClient
 
         $request = $requestBuilder->build();
 
-        $requestHandler = new CurlRequestHandler(
-            $this->connectApi,
-            (string) $this->pemFile
-        );
+        $requestHandler = new CurlRequestHandler();
 
         return $requestHandler->execute($request);
     }
@@ -389,7 +386,7 @@ class YotiClient
     /**
      * Validate and set PEM file content.
      *
-     * @deprecated this will be replaced by \Yoti\Util\PemFile in version 3.
+     * @deprecated 3.0.0 this will be replaced by \Yoti\Util\PemFile.
      *
      * @param string $pem
      *   PEM file path or string

--- a/tests/Http/AbstractRequestHandlerTest.php
+++ b/tests/Http/AbstractRequestHandlerTest.php
@@ -6,7 +6,6 @@ use Yoti\Http\AbstractRequestHandler;
 use Yoti\Http\Payload;
 use YotiTest\TestCase;
 use Yoti\Util\Config;
-use Yoti\Http\Request;
 
 /**
  * @coversDefaultClass \Yoti\Http\AbstractRequestHandler

--- a/tests/Http/AbstractRequestHandlerTest.php
+++ b/tests/Http/AbstractRequestHandlerTest.php
@@ -15,7 +15,7 @@ class AbstractRequestHandlerTest extends TestCase
     /**
      * Test Base URL.
      */
-    const BASE_URL = 'http://www.example.com/api/v1';
+    const SOME_BASE_URL = 'http://www.example.com/api/v1';
 
     /**
      * Test endpoint.
@@ -29,7 +29,7 @@ class AbstractRequestHandlerTest extends TestCase
     public function testSendRequest()
     {
         $requestHandler = $this->createRequestHandler([
-          self::BASE_URL,
+          self::SOME_BASE_URL,
           file_get_contents(PEM_FILE),
           SDK_ID,
         ]);
@@ -37,7 +37,7 @@ class AbstractRequestHandlerTest extends TestCase
         $version = Config::getInstance()->get('version');
 
         $expectedPayload = $this->createMock(Payload::class);
-        $expectedUrl = self::BASE_URL . self::SOME_ENDPOINT;
+        $expectedUrl = self::SOME_BASE_URL . self::SOME_ENDPOINT;
         $expectedMethod = 'GET';
         $expectedHeaders = [
           "X-Yoti-SDK-Version: PHP-{$version}",
@@ -65,7 +65,7 @@ class AbstractRequestHandlerTest extends TestCase
     public function testCustomSdkIdentifierConstructor()
     {
         $requestHandler = $this->createRequestHandler([
-          '/',
+          self::SOME_BASE_URL,
           file_get_contents(PEM_FILE),
           SDK_ID,
           'Drupal'
@@ -83,12 +83,12 @@ class AbstractRequestHandlerTest extends TestCase
         $this->expectExecuteRequestWith(
             $requestHandler,
             $expectedHeaders,
-            '/',
+            self::SOME_BASE_URL,
             $expectedMethod,
             null
         );
 
-        $requestHandler->sendRequest('/', $expectedMethod);
+        $requestHandler->sendRequest(self::SOME_ENDPOINT, $expectedMethod);
     }
 
     /**
@@ -100,13 +100,13 @@ class AbstractRequestHandlerTest extends TestCase
     public function testInvalidSdkIdentifier()
     {
         $requestHandler = $this->createRequestHandler([
-          '/',
+          self::SOME_BASE_URL,
           file_get_contents(PEM_FILE),
           SDK_ID,
           'Invalid'
         ]);
 
-        $requestHandler->sendRequest('/', 'GET');
+        $requestHandler->sendRequest(self::SOME_ENDPOINT, 'GET');
     }
 
     /**

--- a/tests/Http/Curl/RequestHandlerTest.php
+++ b/tests/Http/Curl/RequestHandlerTest.php
@@ -109,6 +109,34 @@ class RequestHandlerTest extends TestCase
         $this->assertEquals($expectedBody, $response->getBody());
         $this->assertEquals($expectedStatusCode, $response->getStatusCode());
     }
+
+    /**
+     * Test Curl execution error.
+     *
+     * @expectedException \Yoti\Exception\RequestException
+     * @expectedExceptionMessage some error
+     */
+    public function testExecuteError()
+    {
+        $request = $this->createMock(Request::class);
+
+        $this->mockCurl
+            ->expects($this->once())
+            ->method('curl_exec')
+            ->willReturn(false);
+
+        $this->mockCurl
+            ->expects($this->any())
+            ->method('curl_error')
+            ->willReturn('some error');
+
+        $this->mockCurl
+            ->expects($this->once())
+            ->method('curl_close');
+
+        $handler = new RequestHandler();
+        $handler->execute($request);
+    }
 }
 
 /**
@@ -128,9 +156,9 @@ function curl_getinfo($ch, $opt = null)
     return RequestHandlerTest::$curl->curl_getinfo($ch, $opt);
 }
 
-function curl_error()
+function curl_error($ch)
 {
-    return false;
+    return RequestHandlerTest::$curl->curl_error($ch);
 }
 
 function curl_init($url)

--- a/tests/Http/Curl/RequestHandlerTest.php
+++ b/tests/Http/Curl/RequestHandlerTest.php
@@ -1,0 +1,154 @@
+<?php
+
+namespace YotiTest\Http\Curl;
+
+use PHPUnit\Framework\TestCase;
+use Yoti\Http\Curl\RequestHandler;
+use Yoti\Http\Request;
+use Yoti\Http\Payload;
+
+class RequestHandlerTest extends TestCase
+{
+    /**
+     * Curl Observer.
+     */
+    public static $curl;
+
+    /**
+     * Create a Curl observer.
+     */
+    public function setup()
+    {
+        $this->mockCurl = $this->getMockBuilder(\stdClass::class)
+            ->setMethods([
+                'curl_init',
+                'curl_exec',
+                'curl_getinfo',
+                'curl_error',
+                'curl_setopt_array',
+                'curl_setopt',
+                'curl_close',
+            ])
+            ->getMock();
+
+        self::$curl = $this->mockCurl;
+    }
+
+    /**
+     * Test Curl execution.
+     */
+    public function testExecute()
+    {
+        $expectedUrl = 'https://www.example.com';
+        $expectedBody = 'SOME CONTENT';
+        $expectedMethod = 'POST';
+        $expectedStatusCode = 200;
+        $expectedPayloadJson = '{"some":"json"}';
+        $expectedPayload = $this->createMock(Payload::class);
+        $expectedHeaders = ['some' => 'header'];
+        $expectedPayload->method('getPayloadJSON')->willReturn($expectedPayloadJson);
+
+        // Mock the request.
+        $request = $this->createMock(Request::class);
+        $request->method('getUrl')->willReturn($expectedUrl);
+        $request->method('getPayload')->willReturn($expectedPayload);
+        $request->method('getHeaders')->willReturn($expectedHeaders);
+        $request->method('getMethod')->willReturn($expectedMethod);
+
+        // Observe curl functions.
+        $this->mockCurl
+            ->expects($this->once())
+            ->method('curl_init')
+            ->with($expectedUrl)
+            ->willReturn('ch');
+
+        $this->mockCurl
+            ->expects($this->once())
+            ->method('curl_exec')
+            ->willReturn('SOME CONTENT');
+
+        $this->mockCurl
+            ->expects($this->once())
+            ->method('curl_getinfo')
+            ->willReturn($expectedStatusCode);
+
+        $this->mockCurl
+            ->expects($this->any())
+            ->method('curl_setopt')
+            ->withConsecutive(
+                ['ch', CURLOPT_CUSTOMREQUEST, $expectedMethod],
+                ['ch', CURLOPT_POSTFIELDS, $expectedPayloadJson]
+            );
+
+        $this->mockCurl
+            ->expects($this->once())
+            ->method('curl_setopt_array')
+            ->with(
+                'ch',
+                [
+                    CURLOPT_HTTPHEADER => array_map(
+                        function ($name, $value) {
+                            return "${name}: ${value}";
+                        },
+                        array_keys($expectedHeaders),
+                        array_values($expectedHeaders)
+                    ),
+                    CURLOPT_RETURNTRANSFER => true,
+                ]
+            );
+
+        $this->mockCurl
+            ->expects($this->once())
+            ->method('curl_close');
+
+        // Execute request.
+        $handler = new RequestHandler();
+        $response = $handler->execute($request);
+
+        // Check response.
+        $this->assertEquals($expectedBody, $response->getBody());
+        $this->assertEquals($expectedStatusCode, $response->getStatusCode());
+    }
+}
+
+/**
+ * Mock Curl functions in the \Yoti\Http\Curl namespace.
+ */
+namespace Yoti\Http\Curl;
+
+use YotiTest\Http\Curl\RequestHandlerTest;
+
+function curl_exec($ch)
+{
+    return RequestHandlerTest::$curl->curl_exec($ch);
+}
+
+function curl_getinfo($ch, $opt = null)
+{
+    return RequestHandlerTest::$curl->curl_getinfo($ch, $opt);
+}
+
+function curl_error()
+{
+    return false;
+}
+
+function curl_init($url)
+{
+    return RequestHandlerTest::$curl->curl_init($url);
+}
+
+function curl_setopt_array($ch, $options)
+{
+    return RequestHandlerTest::$curl->curl_setopt_array($ch, $options);
+}
+
+function curl_setopt($ch, $option, $value)
+{
+    return RequestHandlerTest::$curl->curl_setopt($ch, $option, $value);
+}
+
+function curl_close($ch)
+{
+    return RequestHandlerTest::$curl->curl_close($ch);
+}

--- a/tests/Http/CurlRequestHandlerTest.php
+++ b/tests/Http/CurlRequestHandlerTest.php
@@ -11,7 +11,6 @@ use Yoti\Entity\AmlProfile;
 use Yoti\Http\RequestSigner;
 use Yoti\Http\CurlRequestHandler;
 use Yoti\Http\AbstractRequestHandler;
-use Yoti\Http\Request;
 
 /**
  * @coversDefaultClass \Yoti\Http\CurlRequestHandler
@@ -118,37 +117,6 @@ class CurlRequestHandlerTest extends TestCase
             '/profile/fakeToken',
             'GET'
         );
-        $this->assertEquals(json_encode($expectedResult), json_encode($result));
-    }
-
-    /**
-     * @covers ::execute
-     */
-    public function testExecute()
-    {
-        $expectedResult['response'] = file_get_contents(RECEIPT_JSON);
-        $expectedResult['http_code'] = 200;
-
-        $curlRequestHandler = $this->getMockBuilder('\Yoti\Http\CurlRequestHandler')
-            ->disableOriginalConstructor()
-            ->setMethods(['executeRequest'])
-            ->getMock();
-
-        // Configure the stub.
-        $curlRequestHandler->method('executeRequest')
-            ->willReturn($expectedResult);
-
-        $request = $this->getMockBuilder(Request::class)
-            ->disableOriginalConstructor()
-            ->setMethods([
-                'getHeaders',
-            ])
-            ->getMock();
-
-        $request->method('getHeaders')->willReturn([]);
-
-        $result = $curlRequestHandler->execute($request);
-
         $this->assertEquals(json_encode($expectedResult), json_encode($result));
     }
 }

--- a/tests/Http/CurlRequestHandlerTest.php
+++ b/tests/Http/CurlRequestHandlerTest.php
@@ -11,6 +11,7 @@ use Yoti\Entity\AmlProfile;
 use Yoti\Http\RequestSigner;
 use Yoti\Http\CurlRequestHandler;
 use Yoti\Http\AbstractRequestHandler;
+use Yoti\Http\Request;
 
 /**
  * @coversDefaultClass \Yoti\Http\CurlRequestHandler
@@ -112,10 +113,42 @@ class CurlRequestHandlerTest extends TestCase
         // Configure the stub.
         $curlRequestHandler->method('executeRequest')
             ->willReturn($expectedResult);
+
         $result = $curlRequestHandler->sendRequest(
             '/profile/fakeToken',
             'GET'
         );
+        $this->assertEquals(json_encode($expectedResult), json_encode($result));
+    }
+
+    /**
+     * @covers ::execute
+     */
+    public function testExecute()
+    {
+        $expectedResult['response'] = file_get_contents(RECEIPT_JSON);
+        $expectedResult['http_code'] = 200;
+
+        $curlRequestHandler = $this->getMockBuilder('\Yoti\Http\CurlRequestHandler')
+            ->disableOriginalConstructor()
+            ->setMethods(['executeRequest'])
+            ->getMock();
+
+        // Configure the stub.
+        $curlRequestHandler->method('executeRequest')
+            ->willReturn($expectedResult);
+
+        $request = $this->getMockBuilder(Request::class)
+            ->disableOriginalConstructor()
+            ->setMethods([
+                'getHeaders',
+            ])
+            ->getMock();
+
+        $request->method('getHeaders')->willReturn([]);
+
+        $result = $curlRequestHandler->execute($request);
+
         $this->assertEquals(json_encode($expectedResult), json_encode($result));
     }
 }

--- a/tests/Http/RequestBuilderTest.php
+++ b/tests/Http/RequestBuilderTest.php
@@ -5,8 +5,8 @@ namespace YotiTest\Http;
 use YotiTest\TestCase;
 use Yoti\Http\Request;
 use Yoti\Http\RequestBuilder;
-use Yoti\Http\AbstractRequestHandler;
 use Yoti\Http\Payload;
+use Yoti\Http\RequestHandlerInterface;
 
 /**
  * @coversDefaultClass \Yoti\Http\RequestBuilder
@@ -153,7 +153,7 @@ class RequestBuilderTest extends TestCase
      */
     public function testWithHandler()
     {
-        $handler = $this->getMockBuilder(AbstractRequestHandler::class)
+        $handler = $this->getMockBuilder(RequestHandlerInterface::class)
           ->disableOriginalConstructor()
           ->setMethods(['execute'])
           ->getMockForAbstractClass();
@@ -206,7 +206,6 @@ class RequestBuilderTest extends TestCase
         $this->assertEquals('custom header value', $request->getHeaders()['Custom']);
         $this->assertEquals('a second custom header value', $request->getHeaders()['Custom-2']);
     }
-
 
     /**
      * @covers ::build

--- a/tests/Http/RequestBuilderTest.php
+++ b/tests/Http/RequestBuilderTest.php
@@ -16,7 +16,12 @@ class RequestBuilderTest extends TestCase
     /**
      * Test Base URL.
      */
-    const BASE_URL = 'http://www.example.com/api/v1';
+    const SOME_BASE_URL = 'http://www.example.com/api/v1';
+
+    /**
+     * Test endpoint.
+     */
+    const SOME_ENDPOINT = '/some-endpoint';
 
     /**
      * @covers ::build
@@ -30,7 +35,7 @@ class RequestBuilderTest extends TestCase
     public function testBuild()
     {
         $request = (new RequestBuilder())
-          ->withBaseUrl(self::BASE_URL)
+          ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(PEM_FILE)
           ->withMethod('POST')
           ->withEndpoint('/some-endpoint')
@@ -40,7 +45,8 @@ class RequestBuilderTest extends TestCase
 
         $this->assertInstanceOf(Request::class, $request);
 
-        $expectedEndpointPattern = '~' . preg_quote(self::BASE_URL, '~') . '/some-endpoint.*?nonce=.*?&timestamp=.*?~';
+        $baseUrlPattern = preg_quote(self::SOME_BASE_URL, '~');
+        $expectedEndpointPattern = "~{$baseUrlPattern}/some-endpoint.*?nonce=.*?&timestamp=.*?~";
 
         $this->assertRegExp($expectedEndpointPattern, $request->getUrl());
         $this->assertEquals('POST', $request->getMethod());
@@ -60,7 +66,7 @@ class RequestBuilderTest extends TestCase
     public function testWithSdkIdentifier()
     {
         $request = (new RequestBuilder())
-          ->withBaseUrl(self::BASE_URL)
+          ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(PEM_FILE)
           ->withGet()
           ->withSdkIdentifier('Drupal')
@@ -78,7 +84,7 @@ class RequestBuilderTest extends TestCase
     public function testWithPost()
     {
         $request = (new RequestBuilder())
-          ->withBaseUrl(self::BASE_URL)
+          ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(PEM_FILE)
           ->withPost()
           ->build();
@@ -93,7 +99,7 @@ class RequestBuilderTest extends TestCase
     public function testWithGet()
     {
         $request = (new RequestBuilder())
-          ->withBaseUrl(self::BASE_URL)
+          ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(PEM_FILE)
           ->withGet()
           ->build();
@@ -111,7 +117,7 @@ class RequestBuilderTest extends TestCase
     public function testBuildWithInvalidSdkIdentifier()
     {
         (new RequestBuilder())
-          ->withBaseUrl(self::BASE_URL)
+          ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(PEM_FILE)
           ->withSdkIdentifier('Invalid')
           ->build();
@@ -127,7 +133,7 @@ class RequestBuilderTest extends TestCase
     public function testBuildWithInvalidSdkVersion()
     {
         (new RequestBuilder())
-          ->withBaseUrl(self::BASE_URL)
+          ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(PEM_FILE)
           ->withSdkVersion(['Invalid SDK Version'])
           ->build();
@@ -140,7 +146,7 @@ class RequestBuilderTest extends TestCase
     public function testBuildWithPemFromFilePath()
     {
         $request = (new RequestBuilder())
-          ->withBaseUrl(self::BASE_URL)
+          ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(PEM_FILE)
           ->withMethod('GET')
           ->build();
@@ -160,7 +166,7 @@ class RequestBuilderTest extends TestCase
           ->getMockForAbstractClass();
 
         $request = (new RequestBuilder())
-          ->withBaseUrl(self::BASE_URL)
+          ->withBaseUrl(self::SOME_BASE_URL)
           ->withEndpoint('/some-endpoint')
           ->withPemFilePath(PEM_FILE)
           ->withMethod('GET')
@@ -181,7 +187,7 @@ class RequestBuilderTest extends TestCase
     public function testBuildWithPemString()
     {
         $request = (new RequestBuilder())
-          ->withBaseUrl(self::BASE_URL)
+          ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemString(file_get_contents(PEM_FILE))
           ->withMethod('GET')
           ->build();
@@ -196,7 +202,7 @@ class RequestBuilderTest extends TestCase
     public function testBuildWithHeader()
     {
         $request = (new RequestBuilder())
-          ->withBaseUrl(self::BASE_URL)
+          ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(PEM_FILE)
           ->withHeader('Custom', 'custom header value')
           ->withHeader('Custom-2', 'a second custom header value')
@@ -217,7 +223,7 @@ class RequestBuilderTest extends TestCase
         $expectedPayload = new Payload('some content');
 
         $request = (new RequestBuilder())
-          ->withBaseUrl(self::BASE_URL)
+          ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(PEM_FILE)
           ->withPayload($expectedPayload)
           ->withPost()
@@ -235,7 +241,7 @@ class RequestBuilderTest extends TestCase
     public function testWithoutMethod()
     {
         (new RequestBuilder())
-          ->withBaseUrl(self::BASE_URL)
+          ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(PEM_FILE)
           ->build();
     }
@@ -249,7 +255,7 @@ class RequestBuilderTest extends TestCase
     public function testWithUnsupportedMethod()
     {
         (new RequestBuilder())
-          ->withBaseUrl(self::BASE_URL)
+          ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(PEM_FILE)
           ->withMethod('SOME_METHOD')
           ->build();
@@ -265,7 +271,7 @@ class RequestBuilderTest extends TestCase
     public function testWithHeaderInvalidValue()
     {
         (new RequestBuilder())
-          ->withBaseUrl(self::BASE_URL)
+          ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(PEM_FILE)
           ->withHeader('Custom', ['invalid value'])
           ->withMethod('GET')
@@ -294,7 +300,61 @@ class RequestBuilderTest extends TestCase
     public function testBuildWithoutPem()
     {
         (new RequestBuilder())
-            ->withBaseUrl(self::BASE_URL)
+            ->withBaseUrl(self::SOME_BASE_URL)
             ->build();
+    }
+
+    /**
+     * @covers ::build
+     * @covers ::withBaseUrl
+     */
+    public function testWithBaseUrlTrailingSlashes()
+    {
+        $trailingSlashes = '/////';
+
+        $request = (new RequestBuilder())
+          ->withBaseUrl(self::SOME_BASE_URL . $trailingSlashes)
+          ->withEndpoint(self::SOME_ENDPOINT)
+          ->withPemFilePath(PEM_FILE)
+          ->withMethod('GET')
+          ->build();
+
+        $this->assertContains(self::SOME_BASE_URL . self::SOME_ENDPOINT, $request->getUrl());
+    }
+
+    /**
+     * @covers ::build
+     * @covers ::withEndpoint
+     */
+    public function testWithEndpointMultipleLeadingSlashes()
+    {
+        $endpointLeadingSlashes = '/////' . self::SOME_ENDPOINT;
+
+        $request = (new RequestBuilder())
+          ->withBaseUrl(self::SOME_BASE_URL)
+          ->withEndpoint($endpointLeadingSlashes)
+          ->withPemFilePath(PEM_FILE)
+          ->withMethod('GET')
+          ->build();
+
+        $this->assertContains(self::SOME_BASE_URL . self::SOME_ENDPOINT, $request->getUrl());
+    }
+
+    /**
+     * @covers ::build
+     * @covers ::withEndpoint
+     */
+    public function testWithEndpointNoLeadingSlashes()
+    {
+        $endpointNoSlashes = ltrim(self::SOME_ENDPOINT, '/');
+
+        $request = (new RequestBuilder())
+          ->withBaseUrl(self::SOME_BASE_URL)
+          ->withEndpoint($endpointNoSlashes)
+          ->withPemFilePath(PEM_FILE)
+          ->withMethod('GET')
+          ->build();
+
+        $this->assertContains(self::SOME_BASE_URL . self::SOME_ENDPOINT, $request->getUrl());
     }
 }

--- a/tests/Http/RequestBuilderTest.php
+++ b/tests/Http/RequestBuilderTest.php
@@ -6,6 +6,7 @@ use YotiTest\TestCase;
 use Yoti\Http\Request;
 use Yoti\Http\RequestBuilder;
 use Yoti\Http\AbstractRequestHandler;
+use Yoti\Http\Payload;
 
 /**
  * @coversDefaultClass \Yoti\Http\RequestBuilder
@@ -204,6 +205,25 @@ class RequestBuilderTest extends TestCase
         $this->assertInstanceOf(Request::class, $request);
         $this->assertEquals('custom header value', $request->getHeaders()['Custom']);
         $this->assertEquals('a second custom header value', $request->getHeaders()['Custom-2']);
+    }
+
+
+    /**
+     * @covers ::build
+     * @covers ::withPayload
+     */
+    public function testWithPayload()
+    {
+        $expectedPayload = new Payload('some content');
+
+        $request = (new RequestBuilder())
+          ->withBaseUrl(self::BASE_URL)
+          ->withPemFilePath(PEM_FILE)
+          ->withPayload($expectedPayload)
+          ->withPost()
+          ->build();
+
+        $this->assertSame($expectedPayload, $request->getPayload());
     }
 
     /**

--- a/tests/Http/RequestBuilderTest.php
+++ b/tests/Http/RequestBuilderTest.php
@@ -46,10 +46,11 @@ class RequestBuilderTest extends TestCase
         $this->assertEquals('POST', $request->getMethod());
         $this->assertEquals('PHP', $request->getHeaders()['X-Yoti-SDK']);
         $this->assertEquals('PHP-1.2.3', $request->getHeaders()['X-Yoti-SDK-Version']);
+        $this->assertEquals(PEM_AUTH_KEY, $request->getHeaders()['X-Yoti-Auth-Key']);
+        $this->assertNotEmpty($request->getHeaders()['X-Yoti-Auth-Digest']);
         $this->assertEquals('application/json', $request->getHeaders()['Content-Type']);
         $this->assertEquals('application/json', $request->getHeaders()['Accept']);
     }
-
 
     /**
      * @covers ::build

--- a/tests/YotiClientTest.php
+++ b/tests/YotiClientTest.php
@@ -161,12 +161,14 @@ class YotiClientTest extends TestCase
      */
     public function testInvalidSdkIdentifierConstructor()
     {
-        new YotiClient(
+        $yotiClient = new YotiClient(
             SDK_ID,
             $this->pem,
             YotiClient::DEFAULT_CONNECT_API,
             'Invalid'
         );
+        $amlProfile = $this->createMock(AmlProfile::class);
+        $yotiClient->performAmlCheck($amlProfile);
     }
 
     /**
@@ -185,6 +187,9 @@ class YotiClientTest extends TestCase
             YotiClient::DEFAULT_CONNECT_API
         );
         $yotiClient->setSdkIdentifier('Invalid');
+
+        $amlProfile = $this->createMock(AmlProfile::class);
+        $yotiClient->performAmlCheck($amlProfile);
     }
 
     /**
@@ -203,6 +208,9 @@ class YotiClientTest extends TestCase
             YotiClient::DEFAULT_CONNECT_API
         );
         $yotiClient->setSdkVersion(['WrongVersion']);
+
+        $amlProfile = $this->createMock(AmlProfile::class);
+        $yotiClient->performAmlCheck($amlProfile);
     }
 
     /**

--- a/tests/YotiClientTest.php
+++ b/tests/YotiClientTest.php
@@ -107,7 +107,7 @@ class YotiClientTest extends TestCase
     public function testGetActivityDetails()
     {
         $response = $this->createMock(Response::class);
-        $response->method('getResponse')->willReturn(file_get_contents(RECEIPT_JSON));
+        $response->method('getBody')->willReturn(file_get_contents(RECEIPT_JSON));
         $response->method('getStatusCode')->willReturn(200);
 
         $requestHandler = $this->createMock(RequestHandlerInterface::class);
@@ -127,7 +127,7 @@ class YotiClientTest extends TestCase
     public function testPerformAmlCheck()
     {
         $response = $this->createMock(Response::class);
-        $response->method('getResponse')->willReturn(file_get_contents(AML_CHECK_RESULT_JSON));
+        $response->method('getBody')->willReturn(file_get_contents(AML_CHECK_RESULT_JSON));
         $response->method('getStatusCode')->willReturn(200);
 
         $requestHandler = $this->createMock(RequestHandlerInterface::class);


### PR DESCRIPTION
> Revision of #75 - change log notes below include changes on #75

### Example Usage
```php
use Yoti\Http\RequestBuilder;
use Yoti\Http\Payload;

$request = (new RequestBuilder)
  ->withBaseUrl('https://somehost.com/api/v1')
  ->withEndpoint('/some-endpoint')
  ->withPemString($somePemString)
  ->withMethod('POST')
  ->withPayload(new Payload(['some' => 'payload']))
  ->build();

$request->getUrl(); // Returns string
$request->getMethod(); // Returns string
$request->getHeaders(); // Returns associative array of name => value
$request->getPayload(); // Returns \Yoti\Http\Payload
$request->setHandler($handler) // Expects \Yoti\Http\RequestHandlerInterface
$request->execute(); // Executes the request using default (Curl) or custom handler
```

> Note: `Yoti\Http\Payload` is a pre-existing class that also supports payload strings

#### Optional builder methods
```php
$request_handler = (new RequestBuilder())
  ...
  ->withQueryParam('some', 'param')
  ->withPemFilePath('/path/to/file.pem') // File path
  ->withSdkIdentifier('some-sdk-identifier') // To allow plugins to override identifier header
  ->withSdkVersion('some-sdk-version') // To allow plugins to override version header
  ->withHeader('Some-Header', 'some-value') // To allow additional headers
  ->withHandler($handler) // Expects \Yoti\Http\RequestHandlerInterface
  ->withPost() // Shortcut for ::withMethod()
  ->withGet() // Shortcut for ::withMethod()
  ->build();
```

### Added
- `Yoti\Http\RequestBuilder`
- `Yoti\Http\Request`
- `Yoti\Http\Response`
- `Yoti\Util\PemFile`
- `Yoti\Exception\PemFileException`
- `\Yoti\Http\RequestHandlerInterface`
- `\Yoti\Http\Curl\RequestHandler`
- `\Yoti\YotiClient::setRequestHandler()` - allows Curl handler to be replaced with an alternative such as [Guzzle](https://github.com/guzzle/guzzle)

### Deprecated
- `Yoti\Http\AbstractRequestHandler` - replaced by `\Yoti\Http\RequestHandlerInterface`
- `Yoti\Http\CurlRequestHandler` - replaced by `\Yoti\Http\Curl\RequestHandler`

### Changed
- SDK version can now be overridden - helps resolve SDK-1071

### Fixed
- Default Curl request handler now verifies host and peer certificates
