### PR TITLE
SDK-1183: Allow custom sandbox request handler

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -1,1 +1,1 @@
-version = 2.2.1
+version = 2.3.0

--- a/sandbox/src/Http/Response.php
+++ b/sandbox/src/Http/Response.php
@@ -3,6 +3,7 @@
 namespace YotiSandbox\Http;
 
 use YotiSandbox\Exception\ResponseException;
+use Yoti\Http\Response as YotiResponse;
 
 class Response
 {
@@ -14,13 +15,13 @@ class Response
     /**
      * Response constructor.
      *
-     * @param array $result
+     * @param \Yoti\Http\Response $response
      *
      * @throws ResponseException
      */
-    public function __construct(array $result)
+    public function __construct(YotiResponse $response)
     {
-        $responseArr = $this->processData($result);
+        $responseArr = $this->processData($response);
         $this->token = $responseArr['token'];
     }
 
@@ -33,18 +34,18 @@ class Response
     }
 
     /**
-     * @param array $result
+     * @param \Yoti\Http\Response $response
      *
      * @return mixed
      *
      * @throws ResponseException
      */
-    private function processData(array $result)
+    private function processData(YotiResponse $response)
     {
-        $this->checkResponseStatus($result['http_code']);
+        $this->checkResponseStatus($response->getStatusCode());
 
         // Get decoded response data
-        $responseJSON = $result['response'];
+        $responseJSON = $response->getBody();
 
         $this->checkJsonError();
 

--- a/src/Yoti/Http/Curl/RequestHandler.php
+++ b/src/Yoti/Http/Curl/RequestHandler.php
@@ -13,6 +13,13 @@ use Yoti\Exception\RequestException;
 class RequestHandler implements RequestHandlerInterface
 {
     /**
+     * Curl options.
+     *
+     * @var array
+     */
+    private $options = [];
+
+    /**
      * Execute HTTP request.
      *
      * @param Request $request
@@ -35,6 +42,11 @@ class RequestHandler implements RequestHandlerInterface
         ]);
 
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $request->getMethod());
+
+        // Set additional options.
+        foreach ($this->options as $option => $value) {
+            curl_setopt($ch, $option, $value);
+        }
 
         // Only send payload data for methods that need it.
         if ($request->getPayload()) {
@@ -62,5 +74,22 @@ class RequestHandler implements RequestHandlerInterface
         }
 
         return new Response($response, $statusCode);
+    }
+
+    /**
+     * Set additional options.
+     *
+     * @see https://www.php.net/manual/en/function.curl-setopt.php
+     *
+     * @param int $key
+     * @param mixed $value
+     *
+     * @return Yoti\Http\Curl\RequestHandler
+     *   This request handler
+     */
+    public function setOption($key, $value)
+    {
+        $this->options[$key] = $value;
+        return $this;
     }
 }

--- a/tests/Http/AbstractRequestHandlerTest.php
+++ b/tests/Http/AbstractRequestHandlerTest.php
@@ -71,9 +71,11 @@ class AbstractRequestHandlerTest extends TestCase
           'Drupal'
         ]);
 
+        $version = Config::getInstance()->get('version');
+
         $expectedMethod = 'POST';
         $expectedHeaders = [
-          "X-Yoti-SDK-Version: Drupal-2.2.1",
+          "X-Yoti-SDK-Version: Drupal-{$version}",
           'X-Yoti-SDK: Drupal',
           'X-Yoti-Auth-Key: ' . PEM_AUTH_KEY,
           'Content-Type: application/json',


### PR DESCRIPTION
### Changed
- Sandbox Client now uses new request builder
- Sandbox Client can now use a custom request handler

### Added
- `\Yoti\Http\Curl\RequestHandler::setOption()` for customisation per environment