### PR TITLE
SDK-1183: Remove composer version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,6 @@
 {
   "name": "yoti/yoti-php-sdk",
   "description": "Yoti SDK for quickly integrating your PHP backend with Yoti",
-  "version": "2.2.1",
   "keywords": [
     "yoti",
     "sdk"


### PR DESCRIPTION
### Removed
- Composer version

See: https://getcomposer.org/doc/04-schema.md#version
> Note: Packagist uses VCS repositories, so the statement above is very much true for Packagist as well. Specifying the version yourself will most likely end up creating problems at some point due to human error.