### PR TITLE
SDK-851: SonarQube / Code Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,6 @@ logs
 
 coverage
 
+.scannerwork
+
 .DS_Store

--- a/.gitignore
+++ b/.gitignore
@@ -14,4 +14,6 @@ phpcs.xml
 
 logs
 
+coverage
+
 .DS_Store

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,14 @@ See [.travis.yml](.travis.yml) for PHP versions we currently support.
 Generate and view coverage report by running:
 
 ```shell
-composer coverage
+composer coverage-html
 open ./coverage/report/index.html
+```
+
+To generate clover report run:
+
+```shell
+composer coverage-clover
 ```
 
 ## Style guide

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,6 +14,13 @@ composer test
 
 See [.travis.yml](.travis.yml) for PHP versions we currently support.
 
+Generate and view coverage report by running:
+
+```shell
+composer coverage
+open ./coverage/report/index.html
+```
+
 ## Style guide
 
 We follow the [PSR-12 Style Guide](https://www.php-fig.org/psr/psr-12/), which

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
   "scripts": {
     "cghooks": "cghooks",
     "test": "phpunit",
-    "coverage": "phpunit --coverage-html ./coverage/report",
+    "coverage-clover": "phpunit --coverage-clover ./coverage/coverage.xml",
+    "coverage-html": "phpunit --coverage-html ./coverage/report",
     "lint": [
       "phpcs",
       "php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --diff-format=udiff --ansi"

--- a/composer.json
+++ b/composer.json
@@ -27,10 +27,11 @@
   },
   "require-dev": {
     "php": ">=5.6.0",
-    "phpunit/phpunit": "5.7.*",
-    "squizlabs/php_codesniffer": "3.*",
+    "phpunit/phpunit": "^5.7",
+    "squizlabs/php_codesniffer": "^3.4",
     "friendsofphp/php-cs-fixer": "^2.15",
-    "brainmaestro/composer-git-hooks": "^2.8"
+    "brainmaestro/composer-git-hooks": "^2.8",
+    "phpunit/php-code-coverage": "^4"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -30,8 +30,7 @@
     "phpunit/phpunit": "^5.7",
     "squizlabs/php_codesniffer": "^3.4",
     "friendsofphp/php-cs-fixer": "^2.15",
-    "brainmaestro/composer-git-hooks": "^2.8",
-    "phpunit/php-code-coverage": "^4.0"
+    "brainmaestro/composer-git-hooks": "^2.8"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -42,6 +42,7 @@
   "scripts": {
     "cghooks": "cghooks",
     "test": "phpunit",
+    "coverage": "phpunit --coverage-html ./coverage/report",
     "lint": [
       "phpcs",
       "php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --diff-format=udiff --ansi"

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
     "squizlabs/php_codesniffer": "^3.4",
     "friendsofphp/php-cs-fixer": "^2.15",
     "brainmaestro/composer-git-hooks": "^2.8",
-    "phpunit/php-code-coverage": "^4"
+    "phpunit/php-code-coverage": "^4.0"
   },
   "autoload-dev": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,7 +17,6 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="coverage-clover" target="./coverage/coverage.xml"/>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
     </logging>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -13,7 +13,12 @@
     </testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">src/</directory>
+            <directory suffix=".php">src/Yoti/</directory>
         </whitelist>
     </filter>
+    <logging>
+        <log type="coverage-html" target="./coverage/report" lowUpperBound="35" highLowerBound="70"/>
+        <log type="coverage-clover" target="./coverage/coverage.xml"/>
+        <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
+    </logging>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -17,7 +17,6 @@
         </whitelist>
     </filter>
     <logging>
-        <log type="coverage-html" target="./coverage/report" lowUpperBound="35" highLowerBound="70"/>
         <log type="coverage-clover" target="./coverage/coverage.xml"/>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
     </logging>

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey = yoti-web-sdk:php
+sonar.projectName = php-sdk
+sonar.projectVersion = 2.4.0
+sonar.sources=src/Yoti
+sonar.php.coverage.reportPaths=coverage/coverage.xml
+sonar.verbose = true

--- a/src/Yoti/Http/Request.php
+++ b/src/Yoti/Http/Request.php
@@ -55,7 +55,7 @@ class Request
         Payload $payload = null,
         array $headers = []
     ) {
-        $this->validateHttpMethod($method);
+        self::validateHttpMethod($method);
         $this->validateHeaders($headers);
         $this->method = $method;
         $this->url = $url;

--- a/src/Yoti/Http/Request.php
+++ b/src/Yoti/Http/Request.php
@@ -55,7 +55,7 @@ class Request
         Payload $payload = null,
         array $headers = []
     ) {
-        self::validateHttpMethod($method);
+        $this->validateHttpMethod($method);
         $this->validateHeaders($headers);
         $this->method = $method;
         $this->url = $url;
@@ -151,12 +151,12 @@ class Request
      *
      * @throws RequestException
      */
-    private static function validateHttpMethod($httpMethod)
+    private function validateHttpMethod($httpMethod)
     {
         if (empty($httpMethod)) {
             throw new RequestException("HTTP Method must be specified");
         }
-        if (!self::methodIsAllowed($httpMethod)) {
+        if (!$this->methodIsAllowed($httpMethod)) {
             throw new RequestException("Unsupported HTTP Method {$httpMethod}", 400);
         }
     }
@@ -168,7 +168,7 @@ class Request
      *
      * @return bool
      */
-    private static function methodIsAllowed($httpMethod)
+    private function methodIsAllowed($httpMethod)
     {
         $allowedMethods = [
             self::METHOD_GET,

--- a/src/Yoti/ShareUrl/DynamicScenarioBuilder.php
+++ b/src/Yoti/ShareUrl/DynamicScenarioBuilder.php
@@ -11,6 +11,16 @@ use Yoti\ShareUrl\Extension\Extension;
 class DynamicScenarioBuilder
 {
     /**
+     * @var string
+     */
+    private $callbackEndpoint;
+
+    /**
+     * @var \Yoti\ShareUrl\Policy\DynamicPolicy
+     */
+    private $dynamicPolicy;
+
+    /**
      * @var \Yoti\ShareUrl\Extension\Extension[]
      */
     private $extensions = [];

--- a/src/Yoti/ShareUrl/Extension/LocationConstraintContent.php
+++ b/src/Yoti/ShareUrl/Extension/LocationConstraintContent.php
@@ -10,6 +10,26 @@ use \Yoti\Util\Validation;
 class LocationConstraintContent implements \JsonSerializable
 {
     /**
+     * @var int|float
+     */
+    private $latitude;
+
+    /**
+     * @var int|float
+     */
+    private $longitude;
+
+    /**
+     * @var int|float
+     */
+    private $radius;
+
+    /**
+     * @var int|float
+     */
+    private $maxUncertainty;
+
+    /**
      * @param int|float $latitude
      *   Latitude of the user's expected location
      * @param int|float $longitude

--- a/src/Yoti/ShareUrl/Policy/WantedAnchor.php
+++ b/src/Yoti/ShareUrl/Policy/WantedAnchor.php
@@ -30,6 +30,16 @@ class WantedAnchor implements \JsonSerializable
     const VALUE_PASSCARD = 'PASS_CARD';
 
     /**
+     * @var string
+     */
+    private $value;
+
+    /**
+     * @var string
+     */
+    private $subType;
+
+    /**
      * @param string $value
      * @param string $subType
      */

--- a/tests/Entity/DocumentDetailsTest.php
+++ b/tests/Entity/DocumentDetailsTest.php
@@ -21,6 +21,13 @@ class DocumentDetailsTest extends TestCase
     }
 
     /**
+     * @covers ::__construct
+     * @covers ::parseFromValue
+     * @covers ::setType
+     * @covers ::setIssuingCountry
+     * @covers ::setDocumentNumber
+     * @covers ::setExpirationDate
+     * @covers ::setIssuingAuthority
      * @covers ::getType
      * @covers ::getIssuingCountry
      * @covers ::getDocumentNumber
@@ -54,6 +61,7 @@ class DocumentDetailsTest extends TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::validateValue
      */
     public function testShouldThrowExceptionWhenValueIsEmpty()
     {
@@ -63,6 +71,7 @@ class DocumentDetailsTest extends TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::validateValue
      */
     public function testShouldThrowExceptionForInvalidCountry()
     {
@@ -72,11 +81,12 @@ class DocumentDetailsTest extends TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::validateValue
      */
     public function testShouldThrowExceptionForInvalidNumber()
     {
         $this->expectException('Yoti\Exception\AttributeException');
-        $document = new DocumentDetails("PASSPORT GBR $%^$%^£ 2016-05-01");
+        new DocumentDetails("PASSPORT GBR $%^$%^£ 2016-05-01");
     }
 
     /**
@@ -102,7 +112,7 @@ class DocumentDetailsTest extends TestCase
     public function testWhenTheValueIsLessThanThreeWords()
     {
         $this->expectException('Yoti\Exception\AttributeException');
-        $documentDetails = new DocumentDetails('PASS_CARD GBR');
+        new DocumentDetails('PASS_CARD GBR');
     }
 
     /**
@@ -111,7 +121,7 @@ class DocumentDetailsTest extends TestCase
     public function testShouldThrowExceptionForInvalidDate()
     {
         $this->expectException('Yoti\Exception\AttributeException');
-        $document = new DocumentDetails('PASSPORT GBR 1234abc X016-05-01');
+        new DocumentDetails('PASSPORT GBR 1234abc X016-05-01');
     }
 
     /**

--- a/tests/Entity/MultiValueTest.php
+++ b/tests/Entity/MultiValueTest.php
@@ -72,7 +72,6 @@ class MultiValueTest extends TestCase
     }
 
     /**
-     * @covers ::filterType
      * @covers ::allowInstance
      */
     public function testMultiValueFilterMultipleTypes()

--- a/tests/Entity/MultiValueTest.php
+++ b/tests/Entity/MultiValueTest.php
@@ -34,7 +34,9 @@ class MultiValueTest extends TestCase
     }
 
     /**
+     * @covers ::__construct
      * @covers ::allowInstance
+     * @covers ::applyFilters
      */
     public function testMultiValueFilterArrayAccess()
     {
@@ -60,6 +62,7 @@ class MultiValueTest extends TestCase
 
     /**
      * @covers ::allowInstance
+     * @covers ::applyFilters
      */
     public function testMultiValueFilterIterator()
     {
@@ -73,6 +76,8 @@ class MultiValueTest extends TestCase
 
     /**
      * @covers ::allowInstance
+     * @covers ::allowType
+     * @covers ::applyFilters
      */
     public function testMultiValueFilterMultipleTypes()
     {
@@ -91,6 +96,7 @@ class MultiValueTest extends TestCase
 
     /**
      * @covers ::filter
+     * @covers ::applyFilters
      */
     public function testMultiValueCustomFilters()
     {
@@ -116,6 +122,8 @@ class MultiValueTest extends TestCase
     /**
      * @covers ::immutable
      * @covers ::filter
+     * @covers ::applyFilters
+     * @covers ::assertMutable
      *
      * @expectedException \LogicException
      * @expectedExceptionMessage Attempting to filter immutable array
@@ -130,6 +138,8 @@ class MultiValueTest extends TestCase
     /**
      * @covers ::immutable
      * @covers ::allowType
+     * @covers ::applyFilters
+     * @covers ::assertMutable
      *
      * @expectedException \LogicException
      * @expectedExceptionMessage Attempting to filter immutable array
@@ -142,6 +152,8 @@ class MultiValueTest extends TestCase
     /**
      * @covers ::immutable
      * @covers ::allowInstance
+     * @covers ::applyFilters
+     * @covers ::assertMutable
      *
      * @expectedException \LogicException
      * @expectedExceptionMessage Attempting to filter immutable array
@@ -154,6 +166,8 @@ class MultiValueTest extends TestCase
     /**
      * @covers ::append
      * @covers ::immutable
+     * @covers ::applyFilters
+     * @covers ::assertMutable
      *
      * @expectedException \LogicException
      * @expectedExceptionMessage Attempting to append to immutable array
@@ -169,6 +183,7 @@ class MultiValueTest extends TestCase
     /**
      * @covers ::exchangeArray
      * @covers ::immutable
+     * @covers ::assertMutable
      *
      * @expectedException \LogicException
      * @expectedExceptionMessage Attempting to change immutable array
@@ -183,6 +198,7 @@ class MultiValueTest extends TestCase
     /**
      * @covers ::offsetSet
      * @covers ::immutable
+     * @covers ::assertMutable
      *
      * @expectedException \LogicException
      * @expectedExceptionMessage Attempting to add to immutable array
@@ -198,6 +214,7 @@ class MultiValueTest extends TestCase
     /**
      * @covers ::offsetUnset
      * @covers ::immutable
+     * @covers ::assertMutable
      *
      * @expectedException \LogicException
      * @expectedExceptionMessage Attempting to remove from immutable array
@@ -213,6 +230,7 @@ class MultiValueTest extends TestCase
     /**
      * @covers ::offsetUnset
      * @covers ::immutable
+     * @covers ::assertMutable
      *
      * @expectedException \LogicException
      * @expectedExceptionMessage Attempting to remove from immutable array

--- a/tests/Http/AbstractRequestHandlerTest.php
+++ b/tests/Http/AbstractRequestHandlerTest.php
@@ -94,8 +94,6 @@ class AbstractRequestHandlerTest extends TestCase
     }
 
     /**
-     * @covers ::setSdkIdentifier
-     *
      * @expectedException \Yoti\Exception\RequestException
      * @expectedExceptionMessage 'Invalid' is not in the list of accepted identifiers: PHP, WordPress, Drupal, Joomla
      */

--- a/tests/Http/AbstractRequestHandlerTest.php
+++ b/tests/Http/AbstractRequestHandlerTest.php
@@ -23,6 +23,7 @@ class AbstractRequestHandlerTest extends TestCase
     const SOME_ENDPOINT = '/some-endpoint';
 
     /**
+     * @covers ::__construct
      * @covers ::sendRequest
      * @covers ::executeRequest
      */
@@ -59,6 +60,7 @@ class AbstractRequestHandlerTest extends TestCase
     }
 
     /**
+     * @covers ::__construct
      * @covers ::sendRequest
      * @covers ::executeRequest
      */
@@ -94,6 +96,9 @@ class AbstractRequestHandlerTest extends TestCase
     }
 
     /**
+     * @covers ::__construct
+     * @covers \Yoti\Http\RequestBuilder::withSdkIdentifier
+     *
      * @expectedException \Yoti\Exception\RequestException
      * @expectedExceptionMessage 'Invalid' is not in the list of accepted identifiers: PHP, WordPress, Drupal, Joomla
      */

--- a/tests/Http/AmlResultTest.php
+++ b/tests/Http/AmlResultTest.php
@@ -23,6 +23,9 @@ class AmlResultTest extends TestCase
 
     /**
      * @covers ::isOnPepList
+     * @covers ::__construct
+     * @covers ::setAttributes
+     * @covers ::checkAttributes
      */
     public function testIsOnPepeList()
     {
@@ -31,6 +34,9 @@ class AmlResultTest extends TestCase
 
     /**
      * @covers ::isOnFraudList
+     * @covers ::__construct
+     * @covers ::setAttributes
+     * @covers ::checkAttributes
      */
     public function testIsOnFraudList()
     {
@@ -39,6 +45,9 @@ class AmlResultTest extends TestCase
 
     /**
      * @covers ::isOnWatchList
+     * @covers ::__construct
+     * @covers ::setAttributes
+     * @covers ::checkAttributes
      */
     public function testIsOnWatchList()
     {

--- a/tests/Http/Curl/RequestHandlerTest.php
+++ b/tests/Http/Curl/RequestHandlerTest.php
@@ -7,6 +7,9 @@ use Yoti\Http\Curl\RequestHandler;
 use Yoti\Http\Request;
 use Yoti\Http\Payload;
 
+/**
+ * @coversDefaultClass \Yoti\Http\Curl\RequestHandler
+ */
 class RequestHandlerTest extends TestCase
 {
     /**
@@ -35,7 +38,7 @@ class RequestHandlerTest extends TestCase
     }
 
     /**
-     * Test Curl execution.
+     * @covers ::execute
      */
     public function testExecute()
     {

--- a/tests/Http/RequestBuilderTest.php
+++ b/tests/Http/RequestBuilderTest.php
@@ -95,6 +95,7 @@ class RequestBuilderTest extends TestCase
           ->withGet()
           ->build();
 
+        $this->assertEquals('PHP', $request->getHeaders()['X-Yoti-SDK']);
         $this->assertRegExp('~PHP-\d+.\d+.\d+~', $request->getHeaders()['X-Yoti-SDK-Version']);
     }
 

--- a/tests/Http/ShareUrlResultTest.php
+++ b/tests/Http/ShareUrlResultTest.php
@@ -15,6 +15,9 @@ class ShareUrlResultTest extends TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::getResultValue
+     * @covers ::getShareUrl
+     * @covers ::getRefId
      */
     public function testValidResponse()
     {
@@ -29,6 +32,7 @@ class ShareUrlResultTest extends TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::getResultValue
      *
      * @expectedException \Yoti\Exception\ShareUrlException
      * @expectedExceptionMessage JSON result does not contain 'qrcode'
@@ -42,6 +46,7 @@ class ShareUrlResultTest extends TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::getResultValue
      *
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage qrcode must be a string
@@ -55,6 +60,7 @@ class ShareUrlResultTest extends TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::getResultValue
      *
      * @expectedException \Yoti\Exception\ShareUrlException
      * @expectedExceptionMessage JSON result does not contain 'ref_id'
@@ -68,6 +74,7 @@ class ShareUrlResultTest extends TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::getResultValue
      *
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage ref_id must be a string

--- a/tests/ShareUrl/DynamicScenarioBuilderTest.php
+++ b/tests/ShareUrl/DynamicScenarioBuilderTest.php
@@ -6,12 +6,15 @@ use Yoti\ShareUrl\DynamicScenarioBuilder;
 use Yoti\ShareUrl\Extension\ExtensionBuilder;
 use Yoti\ShareUrl\Policy\DynamicPolicyBuilder;
 use YotiTest\TestCase;
+use Yoti\ShareUrl\Policy\DynamicPolicy;
 
 /**
  * @coversDefaultClass \Yoti\ShareUrl\DynamicScenarioBuilder
  */
 class DynamicScenarioBuilderTest extends TestCase
 {
+    const SOME_ENDPOINT = '/test-callback';
+
     /**
      * @covers ::build
      * @covers ::withCallbackEndpoint
@@ -23,8 +26,6 @@ class DynamicScenarioBuilderTest extends TestCase
      */
     public function testBuild()
     {
-        $someCallback = '/test-callback';
-
         $somePolicy = (new DynamicPolicyBuilder())
             ->withFullName()
             ->withGivenNames()
@@ -41,14 +42,14 @@ class DynamicScenarioBuilderTest extends TestCase
             ->build();
 
         $dynamicScenario = (new DynamicScenarioBuilder())
-            ->withCallbackEndpoint($someCallback)
+            ->withCallbackEndpoint(self::SOME_ENDPOINT)
             ->withPolicy($somePolicy)
             ->withExtension($someExtension1)
             ->withExtension($someExtension2)
             ->build();
 
         $expectedJsonData = [
-            'callback_endpoint' => '/test-callback',
+            'callback_endpoint' => self::SOME_ENDPOINT,
             'policy' => [
                 'wanted' => [
                     [
@@ -84,5 +85,19 @@ class DynamicScenarioBuilderTest extends TestCase
 
         $this->assertEquals(json_encode($expectedJsonData), json_encode($dynamicScenario));
         $this->assertEquals(json_encode($expectedJsonData), $dynamicScenario);
+    }
+
+    /**
+     * @covers ::build
+     * @covers \Yoti\ShareUrl\DynamicScenario::__construct
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage callbackEndpoint must be a string
+     */
+    public function testBuildWithoutCallback()
+    {
+        (new DynamicScenarioBuilder())
+            ->withPolicy($this->createMock(DynamicPolicy::class))
+            ->build();
     }
 }

--- a/tests/ShareUrl/DynamicScenarioBuilderTest.php
+++ b/tests/ShareUrl/DynamicScenarioBuilderTest.php
@@ -17,6 +17,9 @@ class DynamicScenarioBuilderTest extends TestCase
      * @covers ::withCallbackEndpoint
      * @covers ::withPolicy
      * @covers ::withExtension
+     * @covers \Yoti\ShareUrl\DynamicScenario::__construct
+     * @covers \Yoti\ShareUrl\DynamicScenario::__toString
+     * @covers \Yoti\ShareUrl\DynamicScenario::jsonSerialize
      */
     public function testBuild()
     {

--- a/tests/ShareUrl/Extension/ExtensionBuilderTest.php
+++ b/tests/ShareUrl/Extension/ExtensionBuilderTest.php
@@ -6,12 +6,17 @@ use Yoti\ShareUrl\Extension\ExtensionBuilder;
 use YotiTest\TestCase;
 
 /**
- * @coversDefaultClass \Yoti\ShareUrl\Policy\ExtensionBuilder
+ * @coversDefaultClass \Yoti\ShareUrl\Extension\ExtensionBuilder
  */
 class ExtensionBuilderTest extends TestCase
 {
     /**
      * @covers ::build
+     * @covers ::withType
+     * @covers ::withContent
+     * @covers \Yoti\ShareUrl\Extension\Extension::__construct
+     * @covers \Yoti\ShareUrl\Extension\Extension::__toString
+     * @covers \Yoti\ShareUrl\Extension\Extension::jsonSerialize
      */
     public function testBuild()
     {

--- a/tests/ShareUrl/Extension/LocationConstraintExtensionBuilderTest.php
+++ b/tests/ShareUrl/Extension/LocationConstraintExtensionBuilderTest.php
@@ -6,7 +6,7 @@ use Yoti\ShareUrl\Extension\LocationConstraintExtensionBuilder;
 use YotiTest\TestCase;
 
 /**
- * @coversDefaultClass \Yoti\ShareUrl\Policy\LocationConstraintExtensionBuilder
+ * @coversDefaultClass \Yoti\ShareUrl\Extension\LocationConstraintExtensionBuilder
  */
 class LocationConstraintExtensionBuilderTest extends TestCase
 {
@@ -135,6 +135,8 @@ class LocationConstraintExtensionBuilderTest extends TestCase
 
     /**
      * @covers ::build
+     * @covers \Yoti\ShareUrl\Extension\LocationConstraintContent::__construct
+     * @covers \Yoti\ShareUrl\Extension\LocationConstraintContent::jsonSerialize
      */
     public function testBuildDefaultValues()
     {

--- a/tests/ShareUrl/Extension/TransactionalFlowExtensionBuilderTest.php
+++ b/tests/ShareUrl/Extension/TransactionalFlowExtensionBuilderTest.php
@@ -6,7 +6,7 @@ use Yoti\ShareUrl\Extension\TransactionalFlowExtensionBuilder;
 use YotiTest\TestCase;
 
 /**
- * @coversDefaultClass \Yoti\ShareUrl\Policy\TransactionalFlowExtensionBuilder
+ * @coversDefaultClass \Yoti\ShareUrl\Extension\TransactionalFlowExtensionBuilder
  */
 class TransactionalFlowExtensionBuilderTest extends TestCase
 {

--- a/tests/ShareUrl/Policy/ConstraintsBuilderTest.php
+++ b/tests/ShareUrl/Policy/ConstraintsBuilderTest.php
@@ -14,6 +14,9 @@ class ConstraintsBuilderTest extends TestCase
     /**
      * @covers ::build
      * @covers ::withSourceConstraint
+     * @covers \Yoti\ShareUrl\Policy\Constraints::__construct
+     * @covers \Yoti\ShareUrl\Policy\Constraints::__toString
+     * @covers \Yoti\ShareUrl\Policy\Constraints::jsonSerialize
      */
     public function testBuild()
     {

--- a/tests/ShareUrl/Policy/DynamicPolicyBuilderTest.php
+++ b/tests/ShareUrl/Policy/DynamicPolicyBuilderTest.php
@@ -29,6 +29,9 @@ class DynamicPolicyBuilderTest extends TestCase
      * @covers ::withEmail
      * @covers ::withDocumentDetails
      * @covers ::withDocumentImages
+     * @covers \Yoti\ShareUrl\Policy\DynamicPolicy::__construct
+     * @covers \Yoti\ShareUrl\Policy\DynamicPolicy::__toString
+     * @covers \Yoti\ShareUrl\Policy\DynamicPolicy::jsonSerialize
      */
     public function testBuildWithAttributes()
     {

--- a/tests/ShareUrl/Policy/SourceConstraintBuilderTest.php
+++ b/tests/ShareUrl/Policy/SourceConstraintBuilderTest.php
@@ -22,6 +22,29 @@ class SourceConstraintBuilderTest extends TestCase
     const SOME_SUB_TYPE = 'test sub type';
 
     /**
+     * @covers ::build
+     * @covers \Yoti\ShareUrl\Policy\SourceConstraint::__construct
+     * @covers \Yoti\ShareUrl\Policy\SourceConstraint::__toString
+     * @covers \Yoti\ShareUrl\Policy\SourceConstraint::jsonSerialize
+     */
+    public function testBuild()
+    {
+        $sourceConstraint = (new SourceConstraintBuilder())
+            ->build();
+
+        $expectedJsonData = [
+            'type' => self::ANCHOR_TYPE_SOURCE,
+            'preferred_sources' => [
+                'anchors' => [],
+                'soft_preference' => false,
+            ]
+        ];
+
+        $this->assertEquals(json_encode($expectedJsonData), json_encode($sourceConstraint));
+        $this->assertEquals(json_encode($expectedJsonData), $sourceConstraint);
+    }
+
+    /**
      * @covers ::withPassport
      */
     public function testWithPassport()

--- a/tests/ShareUrl/Policy/WantedAnchorBuilderTest.php
+++ b/tests/ShareUrl/Policy/WantedAnchorBuilderTest.php
@@ -12,8 +12,11 @@ class WantedAnchorBuilderTest extends TestCase
 {
     /**
      * @covers ::build
-     * @covers ::withName
+     * @covers ::withValue
      * @covers ::withSubType
+     * @covers \Yoti\ShareUrl\Policy\WantedAnchor::__construct
+     * @covers \Yoti\ShareUrl\Policy\WantedAnchor::__toString
+     * @covers \Yoti\ShareUrl\Policy\WantedAnchor::jsonSerialize
      */
     public function testBuild()
     {

--- a/tests/ShareUrl/Policy/WantedAttributeBuilderTest.php
+++ b/tests/ShareUrl/Policy/WantedAttributeBuilderTest.php
@@ -16,6 +16,11 @@ class WantedAttributeBuilderTest extends TestCase
      * @covers ::build
      * @covers ::withName
      * @covers ::withDerivation
+     * @covers \Yoti\ShareUrl\Policy\WantedAttribute::__construct
+     * @covers \Yoti\ShareUrl\Policy\WantedAttribute::__toString
+     * @covers \Yoti\ShareUrl\Policy\WantedAttribute::jsonSerialize
+     * @covers \Yoti\ShareUrl\Policy\WantedAttribute::getDerivation
+     * @covers \Yoti\ShareUrl\Policy\WantedAttribute::getName
      */
     public function testBuild()
     {
@@ -39,6 +44,8 @@ class WantedAttributeBuilderTest extends TestCase
 
     /**
      * @covers ::withAcceptSelfAsserted
+     * @covers \Yoti\ShareUrl\Policy\WantedAttribute::jsonSerialize
+     * @covers \Yoti\ShareUrl\Policy\WantedAttribute::getAcceptSelfAsserted
      */
     public function testAcceptSelfAsserted()
     {
@@ -70,6 +77,8 @@ class WantedAttributeBuilderTest extends TestCase
 
     /**
      * @covers ::withAcceptSelfAsserted
+     * @covers \Yoti\ShareUrl\Policy\WantedAttribute::jsonSerialize
+     * @covers \Yoti\ShareUrl\Policy\WantedAttribute::getAcceptSelfAsserted
      */
     public function testWithoutAcceptSelfAsserted()
     {
@@ -93,6 +102,8 @@ class WantedAttributeBuilderTest extends TestCase
 
     /**
      * @covers ::withConstraints
+     * @covers \Yoti\ShareUrl\Policy\WantedAttribute::jsonSerialize
+     * @covers \Yoti\ShareUrl\Policy\WantedAttribute::getConstraints
      */
     public function testWithConstraints()
     {

--- a/tests/Util/Age/AgeOverVerificationProcessorTest.php
+++ b/tests/Util/Age/AgeOverVerificationProcessorTest.php
@@ -13,6 +13,7 @@ class AgeOverVerificationProcessorTest extends TestCase
 {
     /**
      * @covers ::process
+     * @covers ::createAgeVerification
      * @covers \Yoti\Entity\AgeVerification::getResult
      * @covers \Yoti\Entity\AgeVerification::getCheckType
      * @covers \Yoti\Entity\AgeVerification::getAge
@@ -30,6 +31,7 @@ class AgeOverVerificationProcessorTest extends TestCase
 
     /**
      * @covers ::process
+     * @covers ::createAgeVerification
      * @covers \Yoti\Entity\AgeVerification::getResult
      * @covers \Yoti\Entity\AgeVerification::getCheckType
      * @covers \Yoti\Entity\AgeVerification::getAge
@@ -47,6 +49,7 @@ class AgeOverVerificationProcessorTest extends TestCase
 
     /**
      * @covers ::process
+     * @covers ::createAgeVerification
      */
     public function testWhenThereIsNotAgeOverShouldReturnNull()
     {

--- a/tests/Util/Age/AgeUnderVerificationProcessorTest.php
+++ b/tests/Util/Age/AgeUnderVerificationProcessorTest.php
@@ -13,6 +13,7 @@ class AgeUnderVerificationProcessorTest extends TestCase
 {
     /**
      * @covers ::process
+     * @covers ::createAgeVerification
      * @covers \Yoti\Entity\AgeVerification::getResult
      * @covers \Yoti\Entity\AgeVerification::getCheckType
      * @covers \Yoti\Entity\AgeVerification::getAge
@@ -30,6 +31,7 @@ class AgeUnderVerificationProcessorTest extends TestCase
 
     /**
      * @covers ::process
+     * @covers ::createAgeVerification
      * @covers \Yoti\Entity\AgeVerification::getResult
      * @covers \Yoti\Entity\AgeVerification::getCheckType
      * @covers \Yoti\Entity\AgeVerification::getAge
@@ -47,6 +49,7 @@ class AgeUnderVerificationProcessorTest extends TestCase
 
     /**
      * @covers ::process
+     * @covers ::createAgeVerification
      */
     public function testWhenThereIsNotAgeUnderShouldReturnNull()
     {

--- a/tests/Util/Age/AgeVerificationConverterTest.php
+++ b/tests/Util/Age/AgeVerificationConverterTest.php
@@ -15,6 +15,8 @@ class AgeVerificationConverterTest extends TestCase
 {
     /**
      * @covers ::getAgeVerificationsFromAttrsMap
+     * @covers \Yoti\Entity\AgeVerification::__construct
+     * @covers \Yoti\Entity\AgeVerification::getAttribute
      */
     public function testGetAgeVerificationsFromAttrsMap()
     {

--- a/tests/Util/PemFileTest.php
+++ b/tests/Util/PemFileTest.php
@@ -24,7 +24,7 @@ class PemFileTest extends TestCase
     }
 
     /**
-     * @covers ::__constructor
+     * @covers ::__construct
      * @covers ::__toString
      */
     public function testConstructFromString()

--- a/tests/Util/Profile/AttributeConverterTest.php
+++ b/tests/Util/Profile/AttributeConverterTest.php
@@ -88,6 +88,7 @@ class AttributeConverterTest extends TestCase
 
     /**
      * @covers ::convertToYotiAttribute
+     * @covers ::convertValueBasedOnContentType
      */
     public function testConvertUndefinedContentType()
     {
@@ -104,6 +105,7 @@ class AttributeConverterTest extends TestCase
 
     /**
      * @covers ::convertToYotiAttribute
+     * @covers ::convertValueBasedOnContentType
      */
     public function testConvertUnknownContentType()
     {
@@ -153,6 +155,7 @@ class AttributeConverterTest extends TestCase
 
     /**
      * @covers ::convertToYotiAttribute
+     * @covers ::convertValueBasedOnContentType
      *
      * @dataProvider validIntegerDataProvider
      */
@@ -178,6 +181,7 @@ class AttributeConverterTest extends TestCase
      * Check that `document_images` attribute is an array of 2 images.
      *
      * @covers ::convertToYotiAttribute
+     * @covers ::convertValueBasedOnAttributeName
      */
     public function testConvertToYotiAttributeDocumentImages()
     {
@@ -211,6 +215,8 @@ class AttributeConverterTest extends TestCase
      * Check that `document_images` attribute has non-image values filtered out.
      *
      * @covers ::convertToYotiAttribute
+     * @covers ::convertValueBasedOnAttributeName
+     * @covers ::convertMultiValue
      */
     public function testConvertToYotiAttributeDocumentImagesFiltered()
     {
@@ -244,6 +250,7 @@ class AttributeConverterTest extends TestCase
      * Check that `document_images` is null when not converted to a MultiValue object.
      *
      * @covers ::convertToYotiAttribute
+     * @covers ::convertValueBasedOnAttributeName
      */
     public function testConvertToYotiAttributeDocumentImagesInvalid()
     {
@@ -324,6 +331,7 @@ class AttributeConverterTest extends TestCase
      * Check that empty non-string MultiValue Values result in no attribute being returned.
      *
      * @covers ::convertToYotiAttribute
+     * @covers ::convertValueBasedOnContentType
      *
      * @dataProvider nonStringContentTypesDataProvider
      */

--- a/tests/Util/ValidationTest.php
+++ b/tests/Util/ValidationTest.php
@@ -1,0 +1,327 @@
+<?php
+
+namespace YotiTest\Util;
+
+use Yoti\Util\Validation;
+use YotiTest\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\Util\Validation
+ */
+class ValidationTest extends TestCase
+{
+    const SOME_NAME = 'some_name';
+    const SOME_STRING = 'some string';
+
+    /**
+     * @covers ::isString
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testIsString()
+    {
+        Validation::isString(self::SOME_STRING, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::isString
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage some_name must be a string
+     */
+    public function testIsStringInvalid()
+    {
+        Validation::isString(['some array'], self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::isBoolean
+     *
+     * @doesNotPerformAssertions
+     *
+     * @dataProvider booleanDataProvider
+     */
+    public function testIsBoolean($boolean)
+    {
+        Validation::isBoolean($boolean, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::isBoolean
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage some_name must be a boolean
+     */
+    public function testIsBooleanInvalid()
+    {
+        Validation::isBoolean(self::SOME_STRING, self::SOME_NAME);
+    }
+
+    /**
+     * Provides valid booleans.
+     *
+     * @return array
+     */
+    public function booleanDataProvider()
+    {
+        return [
+            [ true ],
+            [ false ],
+        ];
+    }
+
+    /**
+     * @covers ::isInteger
+     *
+     * @doesNotPerformAssertions
+     *
+     * @dataProvider integerDataProvider
+     */
+    public function testIsInteger($integer)
+    {
+        Validation::isInteger($integer, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::isInteger
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage some_name must be an integer
+     */
+    public function testIsIntegerInvalid()
+    {
+        Validation::isInteger(self::SOME_STRING, self::SOME_NAME);
+    }
+
+    /**
+     * Provides valid integers.
+     *
+     * @return array
+     */
+    public function integerDataProvider()
+    {
+        return [
+            [ -20 ],
+            [ 1 ],
+            [ 50 ],
+        ];
+    }
+
+    /**
+     * @covers ::isFloat
+     *
+     * @doesNotPerformAssertions
+     *
+     * @dataProvider floatDataProvider
+     */
+    public function testIsFloat($float)
+    {
+        Validation::isFloat($float, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::isFloat
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage some_name must be a float
+     */
+    public function testIsFloatInvalid()
+    {
+        Validation::isFloat(self::SOME_STRING, self::SOME_NAME);
+    }
+
+    /**
+     * Provides valid floats.
+     *
+     * @return array
+     */
+    public function floatDataProvider()
+    {
+        return [
+            [ -20.000 ],
+            [ 1.6 ],
+            [ 5000.1 ],
+        ];
+    }
+
+    /**
+     * @covers ::isNumeric
+     *
+     * @doesNotPerformAssertions
+     *
+     * @dataProvider floatDataProvider
+     * @dataProvider integerDataProvider
+     */
+    public function testIsNumeric($number)
+    {
+        Validation::isNumeric($number, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::isNumeric
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage some_name must be numeric
+     */
+    public function testIsNumericInvalid()
+    {
+        Validation::isNumeric(self::SOME_STRING, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::notNull
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testNotNull()
+    {
+        Validation::notNull(self::SOME_STRING, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::notNull
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage some_name cannot be null
+     */
+    public function testNotNullInvalid()
+    {
+        Validation::notNull(null, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::notGreaterThan
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testNotGreaterThan()
+    {
+        Validation::notGreaterThan(1, 2, self::SOME_NAME);
+        Validation::notGreaterThan(2, 2, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::notGreaterThan
+     *
+     * @expectedException \RangeException
+     * @expectedExceptionMessage 'some_name' value '2' is greater than '1'
+     */
+    public function testNotGreaterThanInvalid()
+    {
+        Validation::notGreaterThan(2, 1, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::notLessThan
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testNotLessThan()
+    {
+        Validation::notLessThan(2, 1, self::SOME_NAME);
+        Validation::notLessThan(2, 2, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::notLessThan
+     *
+     * @expectedException \RangeException
+     * @expectedExceptionMessage 'some_name' value '1' is less than '2'
+     */
+    public function testNotLessThanInvalid()
+    {
+        Validation::notLessThan(1, 2, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::withinRange
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testWithinRangeThan()
+    {
+        Validation::withinRange(2, 1, 3, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::withinRange
+     *
+     * @expectedException \RangeException
+     * @expectedExceptionMessage 'some_name' value '4' is greater than '3'
+     */
+    public function testWithinRangeGreaterThan()
+    {
+        Validation::withinRange(4, 1, 3, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::withinRange
+     *
+     * @expectedException \RangeException
+     * @expectedExceptionMessage 'some_name' value '1' is less than '2'
+     */
+    public function testWithinRangeLessThan()
+    {
+        Validation::withinRange(1, 2, 4, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::isArrayOfIntegers
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testIsArrayOfIntegers()
+    {
+        Validation::isArrayOfIntegers([-1, 0, 1, 3, 100], self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::isArrayOfIntegers
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage some_name must be array of integers
+     */
+    public function testIsArrayOfIntegersInvalid()
+    {
+        Validation::isArrayOfIntegers([1, self::SOME_STRING], self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::isArrayOfType
+     * @covers ::isOneOfType
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testIsArrayOfType()
+    {
+        $arrayOfTypes = [
+            new \stdClass(),
+            new \DateTime(),
+        ];
+        $allowedTypes = [
+            \stdClass::class,
+            \DateTime::class,
+        ];
+        Validation::isArrayOfType($arrayOfTypes, $allowedTypes, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::isArrayOfType
+     * @covers ::isOneOfType
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage some_name must be array of ArrayObject, DateTime
+     */
+    public function testIsArrayOfTypeInvalid()
+    {
+        $arrayOfTypes = [
+            new \stdClass(),
+            new \ArrayObject(),
+        ];
+        $allowedTypes = [
+            \ArrayObject::class,
+            \DateTime::class,
+        ];
+        Validation::isArrayOfType($arrayOfTypes, $allowedTypes, self::SOME_NAME);
+    }
+}

--- a/tests/YotiClientTest.php
+++ b/tests/YotiClientTest.php
@@ -115,11 +115,10 @@ class YotiClientTest extends TestCase
      * @covers ::decryptConnectToken
      * @covers ::setRequestHandler
      * @covers ::sendRequest
+     * @covers ::sendConnectRequest
      * @covers ::getReceipt
+     * @covers ::processJsonResponse
      * @covers ::checkForReceipt
-     * @covers ::processResult
-     * @covers ::checkResponseStatus
-     * @covers ::checkJsonError
      */
     public function testGetActivityDetails()
     {
@@ -140,6 +139,7 @@ class YotiClientTest extends TestCase
 
     /**
      * @covers ::getActivityDetails
+     * @covers ::isResponseSuccess
      *
      * @dataProvider httpErrorStatusCodeProvider
      *
@@ -156,7 +156,12 @@ class YotiClientTest extends TestCase
      * @covers ::performAmlCheck
      * @covers ::setRequestHandler
      * @covers ::sendRequest
-     * @covers ::validateResult
+     * @covers ::sendConnectRequest
+     * @covers ::processJsonResponse
+     * @covers ::validateAmlResult
+     * @covers \Yoti\Entity\AmlAddress::__construct
+     * @covers \Yoti\Entity\AmlProfile::__construct
+     * @covers \Yoti\Entity\Country::__construct
      */
     public function testPerformAmlCheck()
     {
@@ -179,6 +184,9 @@ class YotiClientTest extends TestCase
 
     /**
      * @covers ::performAmlCheck
+     * @covers ::validateAmlResult
+     * @covers ::getErrorMessage
+     * @covers ::isResponseSuccess
      *
      * @dataProvider httpErrorStatusCodeProvider
      *
@@ -305,6 +313,8 @@ class YotiClientTest extends TestCase
 
     /**
      * @covers ::createShareUrl
+     * @covers ::sendConnectRequest
+     * @covers ::processJsonResponse
      */
     public function testCreateShareUrl()
     {
@@ -350,6 +360,7 @@ class YotiClientTest extends TestCase
 
     /**
      * @covers ::createShareUrl
+     * @covers ::isResponseSuccess
      *
      * @dataProvider httpErrorStatusCodeProvider
      *

--- a/tests/YotiClientTest.php
+++ b/tests/YotiClientTest.php
@@ -47,6 +47,8 @@ class YotiClientTest extends TestCase
      * Test the use of pem file path
      *
      * @covers ::__construct
+     * @covers ::extractPemContent
+     * @covers ::checkRequiredModules
      */
     public function testCanUsePemFile()
     {
@@ -58,6 +60,7 @@ class YotiClientTest extends TestCase
      * Test the use of pem file path with file:// stream wrapper
      *
      * @covers ::__construct
+     * @covers ::extractPemContent
      */
     public function testCanUsePemFileStreamWrapper()
     {
@@ -69,6 +72,7 @@ class YotiClientTest extends TestCase
      * Test passing invalid pem file path with file:// stream wrapper
      *
      * @covers ::__construct
+     * @covers ::extractPemContent
      *
      * @expectedException \Yoti\Exception\YotiClientException
      * @expectedExceptionMessage PEM file was not found
@@ -82,6 +86,7 @@ class YotiClientTest extends TestCase
      * Test passing pem file with invalid contents
      *
      * @covers ::__construct
+     * @covers ::extractPemContent
      *
      * @expectedException \Yoti\Exception\YotiClientException
      * @expectedExceptionMessage PEM file path or content is invalid
@@ -95,6 +100,7 @@ class YotiClientTest extends TestCase
      * Test passing invalid pem string
      *
      * @covers ::__construct
+     * @covers ::extractPemContent
      *
      * @expectedException \Yoti\Exception\YotiClientException
      * @expectedExceptionMessage PEM file path or content is invalid
@@ -106,6 +112,14 @@ class YotiClientTest extends TestCase
 
     /**
      * @covers ::getActivityDetails
+     * @covers ::decryptConnectToken
+     * @covers ::setRequestHandler
+     * @covers ::sendRequest
+     * @covers ::getReceipt
+     * @covers ::checkForReceipt
+     * @covers ::processResult
+     * @covers ::checkResponseStatus
+     * @covers ::checkJsonError
      */
     public function testGetActivityDetails()
     {
@@ -140,6 +154,9 @@ class YotiClientTest extends TestCase
 
     /**
      * @covers ::performAmlCheck
+     * @covers ::setRequestHandler
+     * @covers ::sendRequest
+     * @covers ::validateResult
      */
     public function testPerformAmlCheck()
     {
@@ -191,6 +208,7 @@ class YotiClientTest extends TestCase
      * Test invalid http header value for X-Yoti-SDK
      *
      * @covers ::__construct
+     * @covers ::sendRequest
      *
      * @expectedException \Yoti\Exception\RequestException
      * @expectedExceptionMessage 'Invalid' is not in the list of accepted identifiers: PHP, WordPress, Drupal, Joomla
@@ -211,6 +229,7 @@ class YotiClientTest extends TestCase
      * Test invalid http header value for X-Yoti-SDK
      *
      * @covers ::setSdkIdentifier
+     * @covers ::sendRequest
      *
      * @expectedException \Yoti\Exception\RequestException
      * @expectedExceptionMessage 'Invalid' is not in the list of accepted identifiers: PHP, WordPress, Drupal, Joomla


### PR DESCRIPTION
### Added
- Configured _phpunit_ to output text coverage report _(will run on pre-commit)_
- `$ composer coverage-html` script to generate html reports that can be viewed locally
- `$ composer coverage-clover` script to generate clover reports for _SonarQube_
- _SonarQube_ configuration
- Additional `@covers` test annotations - _this is used when generating coverage reports_
- Test coverage for `\Yoti\Util\Validation`
- Test coverage for `\Yoti\Http\RequestSigner::sign`
- Test coverage for all `\Yoti\Entity\Profile` attribute getters

### Fixed
- Incorrect `@covers` test annotations