### PR TITLE
SDK-1211: Request Builder Headers

### DIFF
--- a/src/Yoti/Http/AbstractRequestHandler.php
+++ b/src/Yoti/Http/AbstractRequestHandler.php
@@ -4,6 +4,7 @@ namespace Yoti\Http;
 
 use Yoti\Util\PemFile;
 use Yoti\Exception\RequestException;
+use Yoti\YotiClient;
 
 /**
  * @deprecated 3.0.0 Replaced by \Yoti\Http\RequestHandlerInterface
@@ -22,7 +23,7 @@ abstract class AbstractRequestHandler
     /**
      * Request HttpHeader keys
      */
-    const YOTI_AUTH_HEADER_KEY = RequestBuilder::YOTI_AUTH_HEADER_KEY;
+    const YOTI_AUTH_HEADER_KEY = YotiClient::YOTI_AUTH_HEADER_KEY;
     const YOTI_DIGEST_HEADER_KEY = RequestBuilder::YOTI_DIGEST_HEADER_KEY;
     const YOTI_SDK_IDENTIFIER_KEY = RequestBuilder::YOTI_SDK_IDENTIFIER_KEY;
     const YOTI_SDK_VERSION = RequestBuilder::YOTI_SDK_VERSION;

--- a/src/Yoti/Http/RequestBuilder.php
+++ b/src/Yoti/Http/RequestBuilder.php
@@ -5,6 +5,7 @@ namespace Yoti\Http;
 use Yoti\Exception\RequestException;
 use Yoti\Util\Config;
 use Yoti\Util\PemFile;
+use Yoti\YotiClient;
 
 class RequestBuilder
 {
@@ -20,13 +21,19 @@ class RequestBuilder
         'Joomla',
     ];
 
-    // Request HttpHeader keys
-    const YOTI_AUTH_HEADER_KEY = 'X-Yoti-Auth-Key';
+    /** Digest HTTP header key. */
     const YOTI_DIGEST_HEADER_KEY = 'X-Yoti-Auth-Digest';
+
+    /** SDK Identifier HTTP header key. */
     const YOTI_SDK_IDENTIFIER_KEY = 'X-Yoti-SDK';
+
+    /** SDK Version HTTP header key. */
     const YOTI_SDK_VERSION = 'X-Yoti-SDK-Version';
 
-    // Default SDK Identifier.
+    /** SDK Version HTTP header key. @deprecated 3.0.0 */
+    const YOTI_AUTH_HEADER_KEY = YotiClient::YOTI_AUTH_HEADER_KEY;
+
+    /** Default SDK Identifier. */
     const YOTI_SDK_IDENTIFIER = 'PHP';
 
     /**
@@ -250,12 +257,14 @@ class RequestBuilder
     {
         // Prepare request Http Headers
         $requestHeaders = [
-            self::YOTI_AUTH_HEADER_KEY => $this->pemFile->getAuthKey(),
             self::YOTI_DIGEST_HEADER_KEY => $signedMessage,
             self::YOTI_SDK_IDENTIFIER_KEY => $this->sdkIdentifier,
-            'Content-Type' => 'application/json',
             'Accept' => 'application/json',
         ];
+
+        if (isset($this->payload)) {
+            $requestHeaders['Content-Type'] = 'application/json';
+        }
 
         if (is_null($this->sdkVersion) && ($configVersion = Config::getInstance()->get('version'))) {
             $this->sdkVersion = $configVersion;

--- a/src/Yoti/Http/RequestBuilder.php
+++ b/src/Yoti/Http/RequestBuilder.php
@@ -30,7 +30,7 @@ class RequestBuilder
     /** SDK Version HTTP header key. */
     const YOTI_SDK_VERSION = 'X-Yoti-SDK-Version';
 
-    /** SDK Version HTTP header key. @deprecated 3.0.0 */
+    /** Auth HTTP header key. @deprecated 3.0.0 */
     const YOTI_AUTH_HEADER_KEY = YotiClient::YOTI_AUTH_HEADER_KEY;
 
     /** Default SDK Identifier. */

--- a/src/Yoti/YotiClient.php
+++ b/src/Yoti/YotiClient.php
@@ -28,28 +28,29 @@ use Yoti\Util\Validation;
  */
 class YotiClient
 {
-    /**
-     * Request successful outcome
-     */
+    /** Request successful outcome */
     const OUTCOME_SUCCESS = 'SUCCESS';
 
-    // Default url for api (is passed in via constructor)
+    /** Default url for api (is passed in via constructor) */
     const DEFAULT_CONNECT_API = 'https://api.yoti.com:443/api/v1';
 
-    // Base url for connect page (user will be redirected to this page eg. baseurl/app-id)
+    /** Base url for connect page (user will be redirected to this page eg. baseurl/app-id) */
     const CONNECT_BASE_URL = 'https://www.yoti.com/connect';
 
-    // Yoti Hub login
+    /** Yoti Hub login */
     const DASHBOARD_URL = 'https://hub.yoti.com';
 
-    // Aml check endpoint
+    /** Aml check endpoint */
     const AML_CHECK_ENDPOINT = '/aml-check';
 
-    // Profile sharing endpoint
+    /** Profile sharing endpoint */
     const PROFILE_REQUEST_ENDPOINT = '/profile/%s';
 
-    // Share URL endpoint
+    /** Share URL endpoint */
     const SHARE_URL_ENDPOINT = '/qrcodes/apps/%s';
+
+    /** HTTP auth key header. */
+    const YOTI_AUTH_HEADER_KEY = 'X-Yoti-Auth-Key';
 
     /**
      * @var \Yoti\Util\PemFile
@@ -258,7 +259,7 @@ class YotiClient
      *
      * @throws \Yoti\Exception\RequestException
      */
-    private function sendConnectRequest($endpoint, $httpMethod, Payload $payload = null)
+    private function sendConnectRequest($endpoint, $httpMethod, Payload $payload = null, $headers = [])
     {
         $requestBuilder = (new RequestBuilder())
             ->withBaseUrl($this->connectApi)
@@ -283,6 +284,10 @@ class YotiClient
             $requestBuilder->withHandler($this->requestHandler);
         }
 
+        foreach ($headers as $name => $value) {
+            $requestBuilder->withHeader($name, $value);
+        }
+
         return $requestBuilder->build()->execute();
     }
 
@@ -300,9 +305,9 @@ class YotiClient
      *
      * @throws \Yoti\Exception\RequestException
      */
-    protected function sendRequest($endpoint, $httpMethod, Payload $payload = null)
+    protected function sendRequest($endpoint, $httpMethod, Payload $payload = null, $headers = [])
     {
-        $response = $this->sendConnectRequest($endpoint, $httpMethod, $payload);
+        $response = $this->sendConnectRequest($endpoint, $httpMethod, $payload, $headers);
 
         return [
             'response' => $response->getBody(),
@@ -357,8 +362,6 @@ class YotiClient
      * Decrypt and return receipt data.
      *
      * @param string $encryptedConnectToken
-     * @param string $httpMethod
-     * @param Payload|null $payload
      *
      * @return \Yoti\Entity\Receipt
      *
@@ -366,7 +369,7 @@ class YotiClient
      * @throws \Yoti\Exception\ReceiptException
      * @throws \Yoti\Exception\RequestException
      */
-    private function getReceipt($encryptedConnectToken, $httpMethod = Request::METHOD_GET, $payload = null)
+    private function getReceipt($encryptedConnectToken)
     {
         // Decrypt connect token
         $token = $this->decryptConnectToken($encryptedConnectToken);
@@ -376,7 +379,12 @@ class YotiClient
 
         // Request endpoint
         $endpoint = sprintf(self::PROFILE_REQUEST_ENDPOINT, $token);
-        $response = $this->sendRequest($endpoint, $httpMethod, $payload);
+        $response = $this->sendRequest(
+            $endpoint,
+            Request::METHOD_GET,
+            null,
+            [self::YOTI_AUTH_HEADER_KEY => $this->pemFile->getAuthKey()]
+        );
 
         $httpCode = (int) $response['http_code'];
         if (!$this->isResponseSuccess($httpCode)) {

--- a/src/Yoti/YotiClient.php
+++ b/src/Yoti/YotiClient.php
@@ -49,7 +49,7 @@ class YotiClient
     /** Share URL endpoint */
     const SHARE_URL_ENDPOINT = '/qrcodes/apps/%s';
 
-    /** HTTP auth key header. */
+    /** Auth HTTP header key */
     const YOTI_AUTH_HEADER_KEY = 'X-Yoti-Auth-Key';
 
     /**

--- a/tests/Http/AbstractRequestHandlerTest.php
+++ b/tests/Http/AbstractRequestHandlerTest.php
@@ -43,7 +43,6 @@ class AbstractRequestHandlerTest extends TestCase
         $expectedHeaders = [
           "X-Yoti-SDK-Version: PHP-{$version}",
           'X-Yoti-SDK: PHP',
-          'X-Yoti-Auth-Key: ' . PEM_AUTH_KEY,
           'Content-Type: application/json',
           'Accept: application/json',
         ];
@@ -79,8 +78,6 @@ class AbstractRequestHandlerTest extends TestCase
         $expectedHeaders = [
           "X-Yoti-SDK-Version: Drupal-{$version}",
           'X-Yoti-SDK: Drupal',
-          'X-Yoti-Auth-Key: ' . PEM_AUTH_KEY,
-          'Content-Type: application/json',
           'Accept: application/json',
         ];
 

--- a/tests/Http/RequestBuilderTest.php
+++ b/tests/Http/RequestBuilderTest.php
@@ -40,6 +40,8 @@ class RequestBuilderTest extends TestCase
      */
     public function testBuild()
     {
+        $expectedPayload = new Payload('SOME PAYLOAD');
+
         $request = (new RequestBuilder())
           ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(PEM_FILE)
@@ -47,6 +49,7 @@ class RequestBuilderTest extends TestCase
           ->withEndpoint('/some-endpoint')
           ->withSdkIdentifier('PHP')
           ->withSdkVersion('1.2.3')
+          ->withPayload($expectedPayload)
           ->build();
 
         $this->assertInstanceOf(Request::class, $request);
@@ -58,10 +61,10 @@ class RequestBuilderTest extends TestCase
         $this->assertEquals('POST', $request->getMethod());
         $this->assertEquals('PHP', $request->getHeaders()['X-Yoti-SDK']);
         $this->assertEquals('PHP-1.2.3', $request->getHeaders()['X-Yoti-SDK-Version']);
-        $this->assertEquals(PEM_AUTH_KEY, $request->getHeaders()['X-Yoti-Auth-Key']);
         $this->assertNotEmpty($request->getHeaders()['X-Yoti-Auth-Digest']);
         $this->assertEquals('application/json', $request->getHeaders()['Content-Type']);
         $this->assertEquals('application/json', $request->getHeaders()['Accept']);
+        $this->assertEquals($expectedPayload, $request->getPayload());
     }
 
     /**
@@ -127,6 +130,7 @@ class RequestBuilderTest extends TestCase
           ->build();
 
         $this->assertEquals('GET', $request->getMethod());
+        $this->assertArrayNotHasKey('Content-Type', $request->getHeaders());
     }
 
     /**

--- a/tests/config.php
+++ b/tests/config.php
@@ -14,5 +14,10 @@ define('AML_PRIVATE_KEY', __DIR__ . '/sample-data/aml-check-private-key.pem');
 define('AML_PUBLIC_KEY', __DIR__ . '/sample-data/aml-check-public-key.pem');
 define('AML_CHECK_RESULT_JSON', __DIR__ . '/sample-data/aml-check-result.json');
 define('YOTI_CONNECT_TOKEN', file_get_contents(__DIR__ . '/sample-data/connect-token.txt'));
+define(
+    'YOTI_CONNECT_TOKEN_DECRYPTED',
+    'i79CctmY-22ad195c-d166-49a2-af16-8f356788c9dd-be094d26-19b5-450d-afce-070101760f0b'
+);
 define('MULTI_VALUE_ATTRIBUTE', file_get_contents(__DIR__ . '/sample-data/attributes/multi-value.txt'));
 define('PEM_AUTH_KEY', file_get_contents(__DIR__ . '/sample-data/pem-auth-key.txt'));
+define('CONNECT_BASE_URL', 'https://api.yoti.com:443/api/v1');


### PR DESCRIPTION
### Changed
- `X-Yoti-Auth-Key` header is only provided to profile endpoint
- Default `Content-Type` header is only added when payload is provided

### Deprecated
- `Yoti\Http\RequestBuilder::YOTI_AUTH_HEADER_KEY`