### PR TITLE
SDK-1238: Coveralls

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,31 @@
 language: php
 
-php:
-    - 5.6
-    - 7.2
-    - 7.3
-
 git:
   depth: 1
 
-install:
-    - travis_retry composer self-update
-    - travis_retry composer install --no-interaction --prefer-source --dev
-
-script:
-    - composer test
-    - composer lint
+jobs:
+  include:
+    - &test
+      stage: Test
+      php: "7.3"
+      os: linux
+      install:
+        - travis_retry composer self-update
+        - travis_retry composer install --no-interaction --prefer-source --dev
+      script:
+        - composer test
+        - composer lint
+    - &compatibility
+      <<: *test
+      stage: Compatibility
+      php: "5.6"
+    - <<: *compatibility
+      php: "7.2"
+    - <<: *compatibility
+      php: "7.1"
+    - <<: *test
+      stage: Coverage
+      name: Coveralls
+      if: type = pull_request
+      script:
+        - composer coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,6 @@ jobs:
     - <<: *test
       stage: Coverage
       name: Coveralls
-      if: type = pull_request
+      if: type = pull_request OR branch = master
       script:
         - composer coveralls

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Yoti PHP SDK
 
 [![Build Status](https://travis-ci.com/getyoti/yoti-php-sdk.svg?branch=master)](https://travis-ci.com/getyoti/yoti-php-sdk)
+[![Coverage Status](https://coveralls.io/repos/github/getyoti/yoti-php-sdk/badge.svg?branch=master)](https://coveralls.io/github/getyoti/yoti-php-sdk?branch=master)
 
 Welcome to the Yoti PHP SDK. This repo contains the tools you need to quickly integrate your PHP back-end with Yoti, so that your users can share their identity details with your application in a secure and trusted way.
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
     "phpunit/phpunit": "^5.7",
     "squizlabs/php_codesniffer": "^3.4",
     "friendsofphp/php-cs-fixer": "^2.15",
-    "brainmaestro/composer-git-hooks": "^2.8"
+    "brainmaestro/composer-git-hooks": "^2.8",
+    "php-coveralls/php-coveralls": "^2.1"
   },
   "autoload-dev": {
     "psr-4": {
@@ -43,6 +44,10 @@
     "test": "phpunit",
     "coverage-clover": "phpunit --coverage-clover ./coverage/coverage.xml",
     "coverage-html": "phpunit --coverage-html ./coverage/report",
+    "coveralls": [
+      "@coverage-clover",
+      "php-coveralls --coverage_clover ./coverage/coverage.xml --json_path ./coverage/coveralls-upload.json"
+    ],
     "lint": [
       "phpcs",
       "php-cs-fixer fix --config=.php_cs.dist -v --dry-run --using-cache=no --diff-format=udiff --ansi"

--- a/tests/Entity/AmlAddressTest.php
+++ b/tests/Entity/AmlAddressTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace YotiTest\Entity;
+
+use Yoti\Entity\AmlAddress;
+use YotiTest\TestCase;
+use Yoti\Entity\Country;
+
+/**
+ * @coversDefaultClass \Yoti\Entity\AmlAddress
+ */
+class AmlAddressTest extends TestCase
+{
+    const SOME_POSTCODE = 'BN2 1TW';
+    const SOME_COUNTRY_CODE = 'GBR';
+
+    /**
+     * @covers ::__construct
+     * @covers ::getCountry
+     */
+    public function testGetCountry()
+    {
+        $someCountry = $this->createMock(Country::class);
+        $amlAddress = new AmlAddress($someCountry);
+
+        $this->assertEquals($someCountry, $amlAddress->getCountry());
+    }
+
+    /**
+     * @covers ::setCountry
+     */
+    public function testSetCountry()
+    {
+        $amlAddress = new AmlAddress($this->createMock(Country::class));
+        $someCountry = $this->createMock(Country::class);
+        $amlAddress->setCountry($someCountry);
+
+        $this->assertSame($someCountry, $amlAddress->getCountry());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getPostcode
+     */
+    public function testGetPostcode()
+    {
+        $amlAddress = new AmlAddress(
+            $this->createMock(Country::class),
+            self::SOME_POSTCODE
+        );
+
+        $this->assertEquals(self::SOME_POSTCODE, $amlAddress->getPostcode());
+    }
+
+    /**
+     * @covers ::setPostcode
+     */
+    public function testSetPostcode()
+    {
+        $amlAddress = new AmlAddress($this->createMock(Country::class));
+        $amlAddress->setPostcode(self::SOME_POSTCODE);
+
+        $this->assertEquals(self::SOME_POSTCODE, $amlAddress->getPostcode());
+    }
+
+    /**
+     * @covers ::getData
+     * @covers ::__toString
+     */
+    public function testGetData()
+    {
+        $someCountry = $this->createMock(Country::class);
+        $someCountry
+            ->method('getCode')
+            ->willreturn(self::SOME_COUNTRY_CODE);
+
+        $amlAddress = new AmlAddress($someCountry, self::SOME_POSTCODE);
+
+        $expectedData = [
+            'post_code' => self::SOME_POSTCODE,
+            'country' => self::SOME_COUNTRY_CODE,
+        ];
+
+        $this->assertEquals($expectedData, $amlAddress->getData());
+        $this->assertEquals(json_encode($expectedData), (string) $amlAddress);
+    }
+}

--- a/tests/Entity/AmlProfileTest.php
+++ b/tests/Entity/AmlProfileTest.php
@@ -1,0 +1,151 @@
+<?php
+
+namespace YotiTest\Entity;
+
+use YotiTest\TestCase;
+use Yoti\Entity\AmlAddress;
+use Yoti\Entity\AmlProfile;
+use Yoti\Entity\Country;
+
+/**
+ * @coversDefaultClass \Yoti\Entity\AmlProfile
+ */
+class AmlProfileTest extends TestCase
+{
+    const SOME_COUNTRY_CODE = 'GBR';
+    const SOME_POSTCODE = 'BN2 1TW';
+    const SOME_GIVEN_NAMES = 'Edward Richard George';
+    const SOME_FAMILY_NAME = 'Heath';
+    const SOME_SSN = '1234';
+
+    /**
+     * @var Yoti\Entity\AmlProfile
+     */
+    private $amlProfile;
+
+    /**
+     * @var Yoti\Entity\AmlAddress
+     */
+    private $amlAddress;
+
+    /**
+     * @var Yoti\Entity\Country
+     */
+    private $country;
+
+    /**
+     * Create test AmlProfile.
+     */
+    public function setup()
+    {
+        $this->country = new Country(self::SOME_COUNTRY_CODE);
+        $this->amlAddress = new AmlAddress($this->country, self::SOME_POSTCODE);
+        $this->amlProfile =  new AmlProfile(
+            self::SOME_GIVEN_NAMES,
+            self::SOME_FAMILY_NAME,
+            $this->amlAddress,
+            self::SOME_SSN
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getGivenNames
+     */
+    public function testGetGivenNames()
+    {
+        $this->assertEquals(self::SOME_GIVEN_NAMES, $this->amlProfile->getGivenNames());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::setGivenNames
+     */
+    public function testSetGivenNames()
+    {
+        $someGivenNames = 'some given names';
+        $this->amlProfile->setGivenNames($someGivenNames);
+        $this->assertEquals($someGivenNames, $this->amlProfile->getGivenNames());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getFamilyName
+     */
+    public function testGetFamilyName()
+    {
+        $this->assertEquals(self::SOME_FAMILY_NAME, $this->amlProfile->getFamilyName());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::setFamilyName
+     */
+    public function testSetFamilyName()
+    {
+        $someFamilyName = 'some family name';
+        $this->amlProfile->setFamilyName($someFamilyName);
+        $this->assertEquals($someFamilyName, $this->amlProfile->getFamilyName());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getSsn
+     */
+    public function testGetSsn()
+    {
+        $this->assertEquals(self::SOME_SSN, $this->amlProfile->getSsn());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::setSsn
+     */
+    public function testSetSsn()
+    {
+        $someSsn = 'some ssn';
+        $this->amlProfile->setSsn($someSsn);
+        $this->assertEquals($someSsn, $this->amlProfile->getSsn());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getAmlAddress
+     */
+    public function testGetAmlAddress()
+    {
+        $this->assertSame($this->amlAddress, $this->amlProfile->getAmlAddress());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::setAmlAddress
+     */
+    public function testSetAmlAddress()
+    {
+        $someAmlAddress = $this->createMock(AmlAddress::class);
+        $this->amlProfile->setAmlAddress($someAmlAddress);
+        $this->assertSame($someAmlAddress, $this->amlProfile->getAmlAddress());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getData
+     * @covers ::__toString
+     */
+    public function testGetData()
+    {
+        $expectedData = [
+            'given_names' => self::SOME_GIVEN_NAMES,
+            'family_name' => self::SOME_FAMILY_NAME,
+            'ssn' => self::SOME_SSN,
+            'address' => [
+                'post_code' => self::SOME_POSTCODE,
+                'country' => self::SOME_COUNTRY_CODE,
+            ],
+        ];
+
+        $this->assertEquals($expectedData, $this->amlProfile->getData());
+        $this->assertEquals(json_encode($expectedData), (string) $this->amlProfile);
+    }
+}

--- a/tests/Entity/BaseProfileTest.php
+++ b/tests/Entity/BaseProfileTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace YotiTest\Entity;
+
+use YotiTest\TestCase;
+use Yoti\Entity\Attribute;
+use Yoti\Entity\BaseProfile;
+
+/**
+ * @coversDefaultClass \Yoti\Entity\BaseProfile
+ */
+class BaseProfileTest extends TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::getProfileAttribute
+     */
+    public function testAttributeGetters()
+    {
+        $someAttributeName = 'some_attribute';
+        $someAttribute = $this->createMock(Attribute::class);
+
+        $someInvalidAttributeName = 'some_invalid_attribute';
+
+        $someProfileData = [
+            $someAttributeName => $someAttribute,
+            $someInvalidAttributeName => 'invalid',
+        ];
+
+        $baseProfile = new BaseProfile($someProfileData);
+
+        $this->assertSame($someAttribute, $baseProfile->getProfileAttribute($someAttributeName));
+        $this->assertNull($baseProfile->getProfileAttribute($someInvalidAttributeName));
+        $this->assertNull($baseProfile->getProfileAttribute('some_missing_attribute'));
+    }
+}

--- a/tests/Entity/CountryTest.php
+++ b/tests/Entity/CountryTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace YotiTest\Entity;
+
+use YotiTest\TestCase;
+use Yoti\Entity\Country;
+
+/**
+ * @coversDefaultClass \Yoti\Entity\Country
+ */
+class CountryTest extends TestCase
+{
+    const SOME_COUNTRY_CODE = 'GBR';
+
+    /**
+     * @covers ::__construct
+     * @covers ::getCode
+     */
+    public function testGetCode()
+    {
+        $country = new Country(self::SOME_COUNTRY_CODE);
+
+        $this->assertEquals(self::SOME_COUNTRY_CODE, $country->getCode());
+    }
+
+    /**
+     * @covers ::setCode
+     */
+    public function testSetCode()
+    {
+        $country = new Country('');
+        $country->setCode(self::SOME_COUNTRY_CODE);
+
+        $this->assertEquals(self::SOME_COUNTRY_CODE, $country->getCode());
+    }
+}

--- a/tests/Entity/SignedTimestampTest.php
+++ b/tests/Entity/SignedTimestampTest.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace YotiTest\Entity;
+
+use YotiTest\TestCase;
+use Yoti\Entity\SignedTimeStamp;
+
+/**
+ * @coversDefaultClass \Yoti\Entity\SignedTimeStamp
+ */
+class SignedTimeStampTest extends TestCase
+{
+    const SOME_VERSION = 'some_version';
+
+    /**
+     * @var Yoti\Entity\SignedTimeStamp
+     */
+    private $signedTimestamp;
+
+    /**
+     * @var \DateTime
+     */
+    private $timestamp;
+
+    /**
+     * Create SignedTimeStamp.
+     */
+    public function setup()
+    {
+        $this->timestamp = new \DateTime();
+        $this->signedTimestamp =  new SignedTimeStamp(
+            self::SOME_VERSION,
+            $this->timestamp
+        );
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getTimestamp
+     */
+    public function testGetTimestamp()
+    {
+        $this->assertSame($this->timestamp, $this->signedTimestamp->getTimestamp());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getVersion
+     */
+    public function testGetVersion()
+    {
+        $this->assertSame(self::SOME_VERSION, $this->signedTimestamp->getVersion());
+    }
+}

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace YotiTest\Http;
+
+use Yoti\Http\Response;
+use YotiTest\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\Http\Response
+ */
+class ResponseTest extends TestCase
+{
+    const SOME_BODY = 'some body';
+    const SOME_STATUS_CODE = '200';
+
+    /**
+     * @var \Yoti\Http\Response
+     */
+    public $response;
+
+    public function setup()
+    {
+        $this->response = new Response(self::SOME_BODY, self::SOME_STATUS_CODE);
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getBody
+     */
+    public function testGetBody()
+    {
+        $this->assertEquals(self::SOME_BODY, $this->response->getBody());
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getStatusCode
+     */
+    public function testGetStatusCode()
+    {
+        $this->assertEquals(self::SOME_STATUS_CODE, $this->response->getStatusCode());
+        $this->assertTrue(is_int($this->response->getStatusCode()));
+    }
+}


### PR DESCRIPTION
### Added
- [Coveralls](https://coveralls.io) to _Travis CI_
- Additional test coverage for:
  - `\Yoti\Entity\AmlAddress`
  - `\Yoti\Entity\AmlProfile`
  - `\Yoti\Entity\Country`
  - `\Yoti\Entity\BaseProfile`
  - `\Yoti\Http\Response`
  - `\Yoti\Entity\SignedTimeStamp`