### PR TITLE
SDK-1265: Add ThirdPartyAttribute extension

### DIFF
--- a/src/Yoti/Entity/AttributeDefinition.php
+++ b/src/Yoti/Entity/AttributeDefinition.php
@@ -4,7 +4,7 @@ namespace Yoti\Entity;
 
 use Yoti\Util\Validation;
 
-class AttributeDefinition
+class AttributeDefinition implements \JsonSerializable
 {
     /**
      * @param string $name
@@ -21,5 +21,25 @@ class AttributeDefinition
     public function getName()
     {
         return $this->name;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'name' => $this->getName(),
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return json_encode($this);
     }
 }

--- a/src/Yoti/Entity/AttributeIssuanceDetails.php
+++ b/src/Yoti/Entity/AttributeIssuanceDetails.php
@@ -7,6 +7,14 @@ use Yoti\Util\Validation;
 class AttributeIssuanceDetails
 {
     /**
+     * RFC3339 format used by third party attributes.
+     *
+     * This will be replaced by \DateTime::RFC3339_EXTENDED
+     * once PHP 5.6 is no longer supported.
+     */
+    const DATE_FORMAT_RFC3339 = 'Y-m-d\TH:i:s.uP';
+
+    /**
      * @param string $token
      * @param \DateTime $expiryDate
      * @param \Yoti\Entity\AttributeDefinition[] $issuingAttributes

--- a/src/Yoti/Entity/AttributeIssuanceDetails.php
+++ b/src/Yoti/Entity/AttributeIssuanceDetails.php
@@ -7,14 +7,6 @@ use Yoti\Util\Validation;
 class AttributeIssuanceDetails
 {
     /**
-     * RFC3339 format used by third party attributes.
-     *
-     * This will be replaced by \DateTime::RFC3339_EXTENDED
-     * once PHP 5.6 is no longer supported.
-     */
-    const DATE_FORMAT_RFC3339 = 'Y-m-d\TH:i:s.uP';
-
-    /**
      * @param string $token
      * @param \DateTime $expiryDate
      * @param \Yoti\Entity\AttributeDefinition[] $issuingAttributes

--- a/src/Yoti/ShareUrl/Extension/LocationConstraintExtensionBuilder.php
+++ b/src/Yoti/ShareUrl/Extension/LocationConstraintExtensionBuilder.php
@@ -2,8 +2,6 @@
 
 namespace Yoti\ShareUrl\Extension;
 
-const LOCATION_CONSTRAINT = 'LOCATION_CONSTRAINT';
-
 /**
  * Builds location constraint Extension.
  */
@@ -106,6 +104,7 @@ class LocationConstraintExtensionBuilder
             $this->radius,
             $this->maxUncertainty
         );
-        return new Extension(LOCATION_CONSTRAINT, $content);
+
+        return new Extension(self::LOCATION_CONSTRAINT, $content);
     }
 }

--- a/src/Yoti/ShareUrl/Extension/ThirdPartyAttributeContent.php
+++ b/src/Yoti/ShareUrl/Extension/ThirdPartyAttributeContent.php
@@ -3,7 +3,7 @@
 namespace Yoti\ShareUrl\Extension;
 
 use Yoti\Entity\AttributeDefinition;
-use Yoti\Entity\AttributeIssuanceDetails;
+use Yoti\Util\Constants;
 use Yoti\Util\Validation;
 
 /**
@@ -43,7 +43,7 @@ class ThirdPartyAttributeContent implements \JsonSerializable
         return [
             'expiry_date' => $this->expiryDate
                 ->setTimezone(new \DateTimeZone('UTC'))
-                ->format(AttributeIssuanceDetails::DATE_FORMAT_RFC3339),
+                ->format(Constants::DATE_FORMAT_RFC3339),
             'definitions' => $this->definitions,
         ];
     }

--- a/src/Yoti/ShareUrl/Extension/ThirdPartyAttributeContent.php
+++ b/src/Yoti/ShareUrl/Extension/ThirdPartyAttributeContent.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Yoti\ShareUrl\Extension;
+
+use Yoti\Entity\AttributeDefinition;
+use Yoti\Entity\AttributeIssuanceDetails;
+use Yoti\Util\Validation;
+
+/**
+ * Defines a third party attribute.
+ */
+class ThirdPartyAttributeContent implements \JsonSerializable
+{
+    /**
+     * @var \Yoti\Entity\AttributeDefinition[]
+     */
+    private $definitions = [];
+
+    /**
+     * @var \DateTime
+     */
+    private $expiryDate;
+
+    /**
+     * @param \DateTime $expiryDate
+     * @param \Yoti\Entity\AttributeDefinition[] $definitions
+     */
+    public function __construct(\DateTime $expiryDate, array $definitions)
+    {
+        $this->expiryDate = $expiryDate;
+
+        Validation::isArrayOfType($definitions, [AttributeDefinition::class], 'definitions');
+        $this->definitions = $definitions;
+    }
+
+    /**
+     * @inheritDoc
+     *
+     * @return array
+     */
+    public function jsonSerialize()
+    {
+        return [
+            'expiry_date' => $this->expiryDate
+                ->setTimezone(new \DateTimeZone('UTC'))
+                ->format(AttributeIssuanceDetails::DATE_FORMAT_RFC3339),
+            'definitions' => $this->definitions,
+        ];
+    }
+
+    /**
+     * @return string
+     */
+    public function __toString()
+    {
+        return json_encode($this);
+    }
+}

--- a/src/Yoti/ShareUrl/Extension/ThirdPartyAttributeExtensionBuilder.php
+++ b/src/Yoti/ShareUrl/Extension/ThirdPartyAttributeExtensionBuilder.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Yoti\ShareUrl\Extension;
+
+use Yoti\Entity\AttributeDefinition;
+use Yoti\Util\Validation;
+
+/**
+ * Builds third party attribute extension.
+ */
+class ThirdPartyAttributeExtensionBuilder
+{
+    /**
+     * Third Party Attribute Extension Type.
+     */
+    const THIRD_PARTY_ATTRIBUTE = 'THIRD_PARTY_ATTRIBUTE';
+
+    /**
+     * @var \Yoti\Entity\AttributeDefinition[]
+     */
+    private $definitions = [];
+
+    /**
+     * @var \DateTime
+     */
+    private $expiryDate;
+
+    /**
+     * @param \DateTime $expiryDate
+     *
+     * @return \Yoti\ShareUrl\Extension\ThirdPartyAttributeExtensionBuilder
+     */
+    public function withExpiryDate($expiryDate)
+    {
+        $this->expiryDate = $expiryDate;
+        return $this;
+    }
+
+    /**
+     * @param string $definition
+     *
+     * @return \Yoti\ShareUrl\Extension\ThirdPartyAttributeExtensionBuilder
+     */
+    public function withDefinition($definition)
+    {
+        Validation::isString($definition, 'definition');
+        $this->definitions[] = new AttributeDefinition($definition);
+        return $this;
+    }
+
+    /**
+     * @param string $definition
+     *
+     * @return \Yoti\ShareUrl\Extension\ThirdPartyAttributeExtensionBuilder
+     */
+    public function withDefinitions($definitions)
+    {
+        Validation::isArrayOfStrings($definitions, 'definitions');
+        $this->definitions = array_map(
+            function ($definition) {
+                return new AttributeDefinition($definition);
+            },
+            $definitions
+        );
+        return $this;
+    }
+
+    /**
+     * @return \Yoti\ShareUrl\Extension\Extension
+     */
+    public function build()
+    {
+        return new Extension(
+            self::THIRD_PARTY_ATTRIBUTE,
+            new ThirdPartyAttributeContent(
+                $this->expiryDate,
+                $this->definitions
+            )
+        );
+    }
+}

--- a/src/Yoti/Util/Constants.php
+++ b/src/Yoti/Util/Constants.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Yoti\Util;
+
+class Constants
+{
+    /**
+     * RFC3339 format with microseconds.
+     *
+     * This will be replaced by \DateTime::RFC3339_EXTENDED
+     * once PHP 5.6 is no longer supported.
+     */
+    const DATE_FORMAT_RFC3339 = 'Y-m-d\TH:i:s.uP';
+}

--- a/src/Yoti/Util/ExtraData/ThirdPartyAttributeConverter.php
+++ b/src/Yoti/Util/ExtraData/ThirdPartyAttributeConverter.php
@@ -5,6 +5,7 @@ namespace Yoti\Util\ExtraData;
 use Yoti\Entity\AttributeDefinition;
 use Yoti\Entity\AttributeIssuanceDetails;
 use Yoti\Exception\ExtraDataException;
+use Yoti\Util\Constants;
 use Sharepubapi\IssuingAttributes;
 use Sharepubapi\ThirdPartyAttribute as ThirdPartyAttributeProto;
 
@@ -28,7 +29,7 @@ class ThirdPartyAttributeConverter
 
         if ($issuingAttributesProto instanceof IssuingAttributes) {
             $parsedDateTime = \DateTime::createFromFormat(
-                AttributeIssuanceDetails::DATE_FORMAT_RFC3339,
+                Constants::DATE_FORMAT_RFC3339,
                 $issuingAttributesProto->getExpiryDate(),
                 new \DateTimeZone("UTC")
             );

--- a/src/Yoti/Util/ExtraData/ThirdPartyAttributeConverter.php
+++ b/src/Yoti/Util/ExtraData/ThirdPartyAttributeConverter.php
@@ -11,14 +11,6 @@ use Sharepubapi\ThirdPartyAttribute as ThirdPartyAttributeProto;
 class ThirdPartyAttributeConverter
 {
     /**
-     * RFC3339 format used by third party attributes.
-     *
-     * This will be replaced by \DateTime::RFC3339_EXTENDED
-     * once PHP 5.6 is no longer supported.
-     */
-    const DATE_FORMAT_RFC3339 = 'Y-m-d\TH:i:s.uP';
-
-    /**
      * @param string $value
      *
      * @return \Yoti\Entity\AttributeIssuanceDetails
@@ -36,7 +28,7 @@ class ThirdPartyAttributeConverter
 
         if ($issuingAttributesProto instanceof IssuingAttributes) {
             $parsedDateTime = \DateTime::createFromFormat(
-                self::DATE_FORMAT_RFC3339,
+                AttributeIssuanceDetails::DATE_FORMAT_RFC3339,
                 $issuingAttributesProto->getExpiryDate(),
                 new \DateTimeZone("UTC")
             );

--- a/tests/Entity/AttributeDefinitionTest.php
+++ b/tests/Entity/AttributeDefinitionTest.php
@@ -13,13 +13,22 @@ class AttributeDefinitionTest extends TestCase
     const SOME_NAME = 'some name';
 
     /**
+     * @var \Yoti\Entity\AttributeDefinition
+     */
+    private $attributeDefinition;
+
+    public function setup()
+    {
+        $this->attributeDefinition = new AttributeDefinition(self::SOME_NAME);
+    }
+
+    /**
      * @covers ::__construct
      * @covers ::getName
      */
     public function testGetName()
     {
-        $attributeDefinition = new AttributeDefinition(self::SOME_NAME);
-        $this->assertEquals(self::SOME_NAME, $attributeDefinition->getName());
+        $this->assertEquals(self::SOME_NAME, $this->attributeDefinition->getName());
     }
 
     /**
@@ -50,5 +59,24 @@ class AttributeDefinitionTest extends TestCase
             [ [] ],
             [ (object)[] ],
         ];
+    }
+
+    /**
+     * @covers ::jsonSerialize
+     * @covers ::__toString
+     */
+    public function testJsonSerialize()
+    {
+        $expectedJson = json_encode(['name' => self::SOME_NAME]);
+
+        $this->assertEquals(
+            $expectedJson,
+            json_encode($this->attributeDefinition)
+        );
+
+        $this->assertEquals(
+            $expectedJson,
+            $this->attributeDefinition
+        );
     }
 }

--- a/tests/ShareUrl/Extension/ThirdPartyAttributeContentTest.php
+++ b/tests/ShareUrl/Extension/ThirdPartyAttributeContentTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace YotiTest\ShareUrl\Extension;
+
+use Yoti\Entity\AttributeDefinition;
+use Yoti\ShareUrl\Extension\ThirdPartyAttributeContent;
+use YotiTest\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\ShareUrl\Extension\ThirdPartyAttributeContent
+ */
+class ThirdPartyAttributeContentTest extends TestCase
+{
+    /**
+     * @covers ::__construct
+     * @covers ::jsonSerialize
+     * @covers ::__toString
+     */
+    public function testJsonSerialize()
+    {
+        $someDefinition = 'some definition';
+
+        $thirdPartyAttributeContent = new ThirdPartyAttributeContent(
+            new \DateTime('2019-12-02T12:00:00.123Z'),
+            [
+                new AttributeDefinition($someDefinition),
+            ]
+        );
+
+        $expectedJson = json_encode([
+            'expiry_date' => '2019-12-02T12:00:00.123000+00:00',
+            'definitions' => [
+                [
+                    'name' => $someDefinition,
+                ],
+            ],
+        ]);
+
+        $this->assertEquals($expectedJson, json_encode($thirdPartyAttributeContent));
+        $this->assertEquals($expectedJson, $thirdPartyAttributeContent);
+    }
+}

--- a/tests/ShareUrl/Extension/ThirdPartyAttributeExtensionBuilderTest.php
+++ b/tests/ShareUrl/Extension/ThirdPartyAttributeExtensionBuilderTest.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace YotiTest\ShareUrl\Extension;
+
+use Yoti\ShareUrl\Extension\ThirdPartyAttributeExtensionBuilder;
+use YotiTest\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\ShareUrl\Extension\ThirdPartyAttributeExtensionBuilder
+ */
+class ThirdPartyAttributeExtensionBuilderTest extends TestCase
+{
+    const THIRD_PARTY_ATTRIBUTE_TYPE = 'THIRD_PARTY_ATTRIBUTE';
+    const SOME_DEFINITION = 'some definition';
+    const SOME_OTHER_DEFINITION = 'some other definition';
+
+    /**
+     * @covers ::withExpiryDate
+     * @covers ::withDefinition
+     * @covers ::build
+     */
+    public function testBuild()
+    {
+        $thirdPartyAttributeExtension = (new ThirdPartyAttributeExtensionBuilder())
+            ->withExpiryDate(new \DateTime('2019-12-02T12:00:00.123Z'))
+            ->withDefinition(self::SOME_DEFINITION)
+            ->withDefinition(self::SOME_OTHER_DEFINITION)
+            ->build();
+
+        $expectedJson = $this->createExpectedJson(
+            '2019-12-02T12:00:00.123000+00:00',
+            [
+                self::SOME_DEFINITION,
+                self::SOME_OTHER_DEFINITION,
+            ]
+        );
+
+        $this->assertEquals($expectedJson, json_encode($thirdPartyAttributeExtension));
+    }
+
+    /**
+     * @covers ::withDefinitions
+     */
+    public function testWithDefinitionsOverwritesExistingDefinitions()
+    {
+        $thirdPartyAttributeExtension = (new ThirdPartyAttributeExtensionBuilder())
+            ->withExpiryDate(new \DateTime('2019-12-02T12:00:00.123Z'))
+            ->withDefinition('initial definition')
+            ->withDefinitions([
+                self::SOME_DEFINITION,
+                self::SOME_OTHER_DEFINITION,
+            ])
+            ->build();
+
+        $this->assertEquals(
+            $this->createExpectedJson(
+                '2019-12-02T12:00:00.123000+00:00',
+                [
+                    self::SOME_DEFINITION,
+                    self::SOME_OTHER_DEFINITION,
+                ]
+            ),
+            json_encode($thirdPartyAttributeExtension)
+        );
+    }
+
+    /**
+     * Create expected third party extension JSON.
+     *
+     * @param string $expiryDate
+     * @param string[] $definitions
+     *
+     * @return string
+     */
+    private function createExpectedJson($expiryDate, $definitions)
+    {
+        return json_encode([
+            'type' => self::THIRD_PARTY_ATTRIBUTE_TYPE,
+            'content' => [
+                'expiry_date' => $expiryDate,
+                'definitions' => array_map(
+                    function ($definition) {
+                        return [ 'name' => $definition ];
+                    },
+                    $definitions
+                ),
+            ],
+        ]);
+    }
+}

--- a/tests/Util/EncryptedDataTest.php
+++ b/tests/Util/EncryptedDataTest.php
@@ -28,7 +28,7 @@ class EncrypedDataTest extends TestCase
     public function setup()
     {
         $this->pem = file_get_contents(PEM_FILE);
-        $this->wrappedKey = json_decode(RECEIPT_JSON)['wrapped_receipt_key'];
+        $this->wrappedKey = json_decode(file_get_contents(RECEIPT_JSON), true)['receipt']['wrapped_receipt_key'];
         $this->encryptedDataProto = $this->createEncryptedDataProto();
     }
 


### PR DESCRIPTION
- [x] Depends on (branched from) #93 - see diff here: https://github.com/getyoti/yoti-php-sdk/compare/SDK-1234-credential-issuance-details..SDK-1265-third-party-attribute-extension

### Added
- `Yoti\ShareUrl\Extension\ThirdPartyAttributeContent`
- `Yoti\ShareUrl\Extension\ThirdPartyAttributeExtensionBuilder`

### Changed
- `Yoti\Entity\AttributeDefinition` now implements `\JsonSerializable`

### Removed
- Global `LOCATION_CONSTRAINT` constant (this should not exist) - `LocationConstraintExtensionBuilder::LOCATION_CONSTRAINT` should be used instead