### PR TITLE
SDK-1272: Reorganise ActivityDetails unit tests

### DIFF
--- a/tests/ActivityDetailsTest.php
+++ b/tests/ActivityDetailsTest.php
@@ -49,20 +49,30 @@ class ActivityDetailsTest extends TestCase
             new Receipt($this->receiptArr),
             $this->pem
         );
-        $this->profile = $this->activityDetails->getProfile();
-        $this->applicationProfile = $this->activityDetails->getApplicationProfile();
     }
 
     /**
-     * Test getting ActivityDetails Instance.
+     * Test creation of ActivityDetails with test data.
+     *
+     * @covers ::__construct
      */
     public function testActivityDetailsInstance()
     {
         $this->assertInstanceOf(ActivityDetails::class, $this->activityDetails);
+
+        $profile = $this->activityDetails->getProfile();
+        $this->assertNull($profile->getFamilyName());
+        $this->assertNull($profile->getFullName());
+        $this->assertNull($profile->getDateOfBirth());
+        $this->assertNull($profile->getEmailAddress());
+        $this->assertEquals('+447474747474', $profile->getPhoneNumber()->getValue());
+        $this->assertInstanceOf(Attribute::class, $profile->getSelfie());
+        $this->assertInstanceOf(Image::class, $profile->getSelfie()->getValue());
     }
 
     /**
      * @covers ::getRememberMeId
+     * @covers ::setRememberMeId
      */
     public function testGetRememberMeId()
     {
@@ -72,6 +82,7 @@ class ActivityDetailsTest extends TestCase
 
     /**
      * @covers ::getRememberMeId
+     * @covers ::setRememberMeId
      */
     public function testGetRememberMeIdNotPresent()
     {
@@ -85,6 +96,7 @@ class ActivityDetailsTest extends TestCase
 
     /**
      * @covers ::getRememberMeId
+     * @covers ::setRememberMeId
      */
     public function testGetRememberMeIdEmpty()
     {
@@ -98,6 +110,7 @@ class ActivityDetailsTest extends TestCase
 
     /**
      * @covers ::getParentRememberMeId
+     * @covers ::setParentRememberMeId
      */
     public function testGetParentRememberMeIdExists()
     {
@@ -107,6 +120,9 @@ class ActivityDetailsTest extends TestCase
 
     /**
      * @covers ::getProfile
+     * @covers ::setProfile
+     * @covers ::processUserProfileAttributes
+     * @covers ::appendAgeVerifications
      */
     public function testGetProfile()
     {
@@ -115,6 +131,7 @@ class ActivityDetailsTest extends TestCase
 
     /**
      * @covers ::getApplicationProfile
+     * @covers ::setApplicationProfile
      */
     public function testGetApplicationProfile()
     {
@@ -125,58 +142,8 @@ class ActivityDetailsTest extends TestCase
     }
 
     /**
-     * @covers \Yoti\Entity\Profile::getFamilyName
-     */
-    public function testGetFamilyName()
-    {
-        $this->assertNull($this->profile->getFamilyName());
-    }
-
-    /**
-     * @covers \Yoti\Entity\Profile::getFullName
-     */
-    public function testGetFullName()
-    {
-        $this->assertNull($this->profile->getFullName());
-    }
-
-    /**
-     * @covers \Yoti\Entity\Profile::getDateOfBirth
-     */
-    public function testGetDateOfBirth()
-    {
-        $this->assertNull($this->profile->getDateOfBirth());
-    }
-
-    /**
-     * @covers \Yoti\Entity\Profile::getPhoneNumber
-     * @covers \Yoti\Entity\Attribute::getValue
-     */
-    public function testGetPhoneNumber()
-    {
-        $this->assertEquals('+447474747474', $this->profile->getPhoneNumber()->getValue());
-    }
-
-    /**
-     * @covers \Yoti\Entity\Profile::getEmailAddress
-     */
-    public function testGetEmailAddress()
-    {
-        $this->assertNull($this->profile->getEmailAddress());
-    }
-
-    /**
-     * @covers \Yoti\Entity\Profile::getSelfie
-     * @covers \Yoti\Entity\Attribute::getValue
-     */
-    public function testGetSelfie()
-    {
-        $this->assertInstanceOf(Attribute::class, $this->profile->getSelfie());
-        $this->assertInstanceOf(Image::class, $this->profile->getSelfie()->getValue());
-    }
-
-    /**
      * @covers ::getTimestamp
+     * @covers ::setTimestamp
      */
     public function testGetTimestamp()
     {
@@ -198,8 +165,9 @@ class ActivityDetailsTest extends TestCase
 
     /**
      * @covers ::getExtraData
+     * @covers ::setExtraData
      */
-    public function testGetAttributeIssuanceDetails()
+    public function testGetExtraData()
     {
         $extraData = $this->activityDetails->getExtraData();
 

--- a/tests/Entity/AnchorTest.php
+++ b/tests/Entity/AnchorTest.php
@@ -23,9 +23,11 @@ class AnchorTest extends TestCase
 
     /**
      * @covers ::getType
+     * @covers ::getSubType
      * @covers ::getValue
      * @covers ::getSignedTimeStamp
      * @covers ::getOriginServerCerts
+     * @covers ::__construct
      */
     public function testYotiAnchorEndpoints()
     {
@@ -40,6 +42,7 @@ class AnchorTest extends TestCase
         $sourceAnchor = $anchorList[Anchor::TYPE_SOURCE_OID][0];
 
         $this->assertEquals(Anchor::TYPE_SOURCE_NAME, $sourceAnchor->getType());
+        $this->assertEquals('', $sourceAnchor->getSubtype());
         $this->assertequals('DRIVING_LICENCE', $sourceAnchor->getValue());
         $this->assertInstanceOf(
             \DateTime::class,

--- a/tests/Entity/AttributeTest.php
+++ b/tests/Entity/AttributeTest.php
@@ -40,6 +40,7 @@ class AttributeTest extends TestCase
 
     /**
      * @covers ::getName
+     * @covers ::__construct
      */
     public function testAttributeName()
     {
@@ -48,6 +49,7 @@ class AttributeTest extends TestCase
 
     /**
      * @covers ::getValue
+     * @covers ::__construct
      */
     public function testAttributeValue()
     {
@@ -56,6 +58,7 @@ class AttributeTest extends TestCase
 
     /**
      * @covers ::getSources
+     * @covers ::__construct
      */
     public function testGetSources()
     {
@@ -75,6 +78,7 @@ class AttributeTest extends TestCase
 
     /**
      * @covers ::getVerifiers
+     * @covers ::__construct
      */
     public function testVerifiers()
     {
@@ -91,6 +95,11 @@ class AttributeTest extends TestCase
 
     /**
      * @covers ::getAnchors
+     * @covers ::setSources
+     * @covers ::setVerifiers
+     * @covers ::setAnchors
+     * @covers ::getAnchorType
+     * @covers ::__construct
      */
     public function testGetAnchors()
     {

--- a/tests/Entity/ExtraDataTest.php
+++ b/tests/Entity/ExtraDataTest.php
@@ -13,6 +13,8 @@ class ExtraDataTest extends TestCase
 {
     /**
      * @covers ::getAttributeIssuanceDetails
+     * @covers ::setAttributeIssuanceDetails
+     * @covers ::__construct
      */
     public function testGetAttributeIssuanceDetails()
     {
@@ -31,6 +33,8 @@ class ExtraDataTest extends TestCase
 
     /**
      * @covers ::getAttributeIssuanceDetails
+     * @covers ::setAttributeIssuanceDetails
+     * @covers ::__construct
      */
     public function testGetAttributeIssuanceDetailsEmpty()
     {

--- a/tests/Entity/ImageTest.php
+++ b/tests/Entity/ImageTest.php
@@ -10,6 +10,8 @@ use YotiTest\TestCase;
  */
 class ImageTest extends TestCase
 {
+    const SOME_IMAGE_DATA = 'dummyImageData';
+
     /**
      * @var \Yoti\Entity\Image
      */
@@ -17,7 +19,7 @@ class ImageTest extends TestCase
 
     public function setup()
     {
-        $this->dummyImage = new Image('dummyImageData', 'png');
+        $this->dummyImage = new Image(self::SOME_IMAGE_DATA, 'png');
     }
 
     /**
@@ -30,10 +32,12 @@ class ImageTest extends TestCase
 
     /**
      * @covers ::getContent
+     * @covers ::__toString
      */
     public function testGetContent()
     {
-        $this->assertEquals('dummyImageData', $this->dummyImage->getContent());
+        $this->assertEquals(self::SOME_IMAGE_DATA, $this->dummyImage->getContent());
+        $this->assertEquals(self::SOME_IMAGE_DATA, (string) $this->dummyImage);
     }
 
     /**
@@ -47,10 +51,12 @@ class ImageTest extends TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::imageTypeToMimeType
+     * @covers ::validateImageExtension
      */
     public function testShouldThrowExceptionForUnsupportedExtension()
     {
         $this->expectException("\Yoti\Exception\AttributeException");
-        $image = new Image('dummyImageData', 'bmp');
+        new Image(self::SOME_IMAGE_DATA, 'bmp');
     }
 }

--- a/tests/Entity/ReceiptTest.php
+++ b/tests/Entity/ReceiptTest.php
@@ -6,6 +6,8 @@ use YotiTest\TestCase;
 use Yoti\Entity\Profile;
 use Yoti\Entity\Receipt;
 use Yoti\Entity\ApplicationProfile;
+use Yoti\Entity\AttributeIssuanceDetails;
+use Yoti\Entity\ExtraData;
 use Yoti\Util\Profile\AttributeListConverter;
 
 /**
@@ -37,6 +39,7 @@ class ReceiptTest extends TestCase
 
     /**
      * @covers ::__construct
+     * @covers ::validateReceipt
      */
     public function testShouldThrowExceptionForInvalidReceipt()
     {
@@ -53,12 +56,49 @@ class ReceiptTest extends TestCase
     }
 
     /**
+     * @covers ::getAttribute
+     */
+    public function testGetAttribute()
+    {
+        $someKey = 'some key';
+        $someValue = 'some value';
+
+        $receipt = new Receipt([
+            'wrapped_receipt_key' => '',
+            $someKey => $someValue,
+        ]);
+
+        $this->assertEquals($someValue, $receipt->getAttribute($someKey));
+    }
+
+    /**
+     * @covers ::getAttribute
+     */
+    public function testGetAttributeNull()
+    {
+        $receipt = new Receipt([
+            'wrapped_receipt_key' => '',
+        ]);
+
+        $this->assertNull($receipt->getAttribute('some key'));
+    }
+
+    /**
      * @covers ::getRememberMeId
      */
     public function testGetRememberMeId()
     {
         $expectedRememberMeId = 'Hig2yAT79cWvseSuXcIuCLa5lNkAPy70rxetUaeHlTJGmiwc/g1MWdYWYrexWvPU';
         $this->assertEquals($expectedRememberMeId, $this->receipt->getRememberMeId());
+    }
+
+    /**
+     * @covers ::getParentRememberMeId
+     */
+    public function testGetParentRememberMeId()
+    {
+        $parentRememberMeId = 'f5RjVQMyoKOvO/hkv43Ik+t6d6mGfP2tdrNijH4k4qafTG0FSNUgQIvd2Z3Nx1j8';
+        $this->assertEquals($parentRememberMeId, $this->receipt->getParentRememberMeId());
     }
 
     /**
@@ -103,6 +143,7 @@ class ReceiptTest extends TestCase
 
     /**
      * @covers ::parseAttribute
+     * @covers ::getWrappedReceiptKey
      */
     public function testShouldParseOtherPartyProfileContent()
     {
@@ -135,5 +176,16 @@ class ReceiptTest extends TestCase
         $this->assertEquals('https://example.com', $applicationProfile->getApplicationUrl()->getValue());
         $this->assertEquals('Node SDK Test', $applicationProfile->getApplicationName()->getValue());
         $this->assertEquals('#ffffff', $applicationProfile->getApplicationReceiptBgColor()->getValue());
+    }
+
+    /**
+     * @covers ::parseExtraData
+     */
+    public function testParseExtraData()
+    {
+        $extraData = $this->receipt->parseExtraData(file_get_contents(PEM_FILE));
+
+        $this->assertInstanceOf(ExtraData::class, $extraData);
+        $this->assertInstanceOf(AttributeIssuanceDetails::class, $extraData->getAttributeIssuanceDetails());
     }
 }

--- a/tests/Util/Profile/AnchorConverterTest.php
+++ b/tests/Util/Profile/AnchorConverterTest.php
@@ -7,12 +7,18 @@ use YotiTest\TestCase;
 use Yoti\Util\Profile\AnchorConverter;
 
 /**
- * @coversDefaultClass \Yoti\Util\Profile\AnchorListConverter
+ * @coversDefaultClass \Yoti\Util\Profile\AnchorConverter
  */
 class AnchorConverterTest extends TestCase
 {
     /**
      * @covers ::convert
+     * @covers ::convertToYotiSignedTimestamp
+     * @covers ::decodeAnchorValue
+     * @covers ::getAnchorTypeByOid
+     * @covers ::getAnchorTypesMap
+     * @covers ::convertCertsListToX509
+     * @covers ::convertCertToX509
      */
     public function testConvertingSourceAnchor()
     {
@@ -32,6 +38,12 @@ class AnchorConverterTest extends TestCase
 
     /**
      * @covers ::convert
+     * @covers ::convertToYotiSignedTimestamp
+     * @covers ::decodeAnchorValue
+     * @covers ::getAnchorTypeByOid
+     * @covers ::getAnchorTypesMap
+     * @covers ::convertCertsListToX509
+     * @covers ::convertCertToX509
      */
     public function testConvertingVerifierAnchor()
     {

--- a/tests/Util/Profile/AttributeConverterTest.php
+++ b/tests/Util/Profile/AttributeConverterTest.php
@@ -183,6 +183,7 @@ class AttributeConverterTest extends TestCase
      *
      * @covers ::convertToYotiAttribute
      * @covers ::convertValueBasedOnAttributeName
+     * @covers ::imageTypeToExtension
      */
     public function testConvertToYotiAttributeDocumentImages()
     {
@@ -418,6 +419,7 @@ class AttributeConverterTest extends TestCase
     {
         $receiptArr = json_decode(file_get_contents(RECEIPT_JSON), true);
         $encryptedData = AttributeConverter::getEncryptedData($receiptArr['receipt']['profile_content']);
+
         $this->assertInstanceOf(EncryptedData::class, $encryptedData);
     }
 


### PR DESCRIPTION
- [x] Depends on (branched from) #94 - see diff: https://github.com/getyoti/yoti-php-sdk/compare/SDK-1265-third-party-attribute-extension..SDK-1272-activity-details-tests

### Changed
- Added correct `@covers` annotations to tests

### Removed
- Removed profile unit tests from `YotiTest\ActivityDetailsTest` (covered in `YotiTest\ProfileTest`) - moved test data checks into `::testActivityDetailsInstance()`

### Added
- Missing test coverage:
  - `YotiTest\Entity\ReceiptTest`
    - `::testGetAttribute()`
    - `::testGetAttributeNull()`
    - `::testGetParentRememberMeId()`
    - `::testParseExtraData()`
 - `YotiTest\Util\Profile\AttributeListConverterTest`

