### PR TITLE
SDK-1269: Optional Derivation

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -57,10 +57,7 @@
   },
   "extra": {
     "hooks": {
-        "pre-commit": [
-          "composer test",
-          "composer lint"
-        ]
+        "pre-commit": "composer test && composer lint"
     }
   }
 }

--- a/src/Yoti/ShareUrl/Policy/WantedAttribute.php
+++ b/src/Yoti/ShareUrl/Policy/WantedAttribute.php
@@ -35,12 +35,14 @@ class WantedAttribute implements \JsonSerializable
      * @param boolean $acceptSelfAsserted
      * @param \Yoti\ShareUrl\Policy\Constraints $constraints
      */
-    public function __construct($name, $derivation = '', $acceptSelfAsserted = null, Constraints $constraints = null)
+    public function __construct($name, $derivation = null, $acceptSelfAsserted = null, Constraints $constraints = null)
     {
         Validation::isString($name, 'name');
         $this->name = $name;
 
-        Validation::isString($derivation, 'derivation');
+        if ($derivation !== null) {
+            Validation::isString($derivation, 'derivation');
+        }
         $this->derivation = $derivation;
 
         if ($acceptSelfAsserted !== null) {
@@ -105,9 +107,12 @@ class WantedAttribute implements \JsonSerializable
     {
         $json = [
             'name' => $this->getName(),
-            'derivation' => $this->getDerivation(),
             'optional' => false,
         ];
+
+        if ($this->getDerivation() !== null) {
+            $json['derivation'] = $this->getDerivation();
+        }
 
         if ($this->getConstraints() !== null) {
             $json['constraints'] = $this->getConstraints();

--- a/src/Yoti/ShareUrl/Policy/WantedAttributeBuilder.php
+++ b/src/Yoti/ShareUrl/Policy/WantedAttributeBuilder.php
@@ -15,7 +15,7 @@ class WantedAttributeBuilder
     /**
      * @var string
      */
-    private $derivation = '';
+    private $derivation;
 
     /**
      * @var \Yoti\ShareUrl\Policy\Constraints

--- a/tests/ShareUrl/DynamicScenarioBuilderTest.php
+++ b/tests/ShareUrl/DynamicScenarioBuilderTest.php
@@ -54,12 +54,10 @@ class DynamicScenarioBuilderTest extends TestCase
                 'wanted' => [
                     [
                         'name' => 'full_name',
-                        'derivation' => '',
                         'optional' => false,
                     ],
                     [
                         'name' => 'given_names',
-                        'derivation' => '',
                         'optional' => false,
                     ],
                 ],

--- a/tests/ShareUrl/Policy/DynamicPolicyBuilderTest.php
+++ b/tests/ShareUrl/Policy/DynamicPolicyBuilderTest.php
@@ -53,19 +53,19 @@ class DynamicPolicyBuilderTest extends TestCase
 
         $expectedWantedAttributeData = [
             'wanted' => [
-                ['name' => 'family_name', 'derivation' => '', 'optional' => false],
-                ['name' => 'given_names', 'derivation' => '', 'optional' => false],
-                ['name' => 'full_name', 'derivation' => '', 'optional' => false],
-                ['name' => 'date_of_birth', 'derivation' => '', 'optional' => false],
-                ['name' => 'gender', 'derivation' => '', 'optional' => false],
-                ['name' => 'postal_address', 'derivation' => '', 'optional' => false],
-                ['name' => 'structured_postal_address', 'derivation' => '', 'optional' => false],
-                ['name' => 'nationality', 'derivation' => '', 'optional' => false],
-                ['name' => 'phone_number', 'derivation' => '', 'optional' => false],
-                ['name' => 'selfie', 'derivation' => '', 'optional' => false],
-                ['name' => 'email_address', 'derivation' => '', 'optional' => false],
-                ['name' => 'document_details', 'derivation' => '', 'optional' => false],
-                ['name' => 'document_images', 'derivation' => '', 'optional' => false],
+                ['name' => 'family_name', 'optional' => false],
+                ['name' => 'given_names', 'optional' => false],
+                ['name' => 'full_name', 'optional' => false],
+                ['name' => 'date_of_birth', 'optional' => false],
+                ['name' => 'gender', 'optional' => false],
+                ['name' => 'postal_address', 'optional' => false],
+                ['name' => 'structured_postal_address', 'optional' => false],
+                ['name' => 'nationality', 'optional' => false],
+                ['name' => 'phone_number', 'optional' => false],
+                ['name' => 'selfie', 'optional' => false],
+                ['name' => 'email_address', 'optional' => false],
+                ['name' => 'document_details', 'optional' => false],
+                ['name' => 'document_images', 'optional' => false],
             ],
             'wanted_auth_types' => [],
             'wanted_remember_me' => false,
@@ -89,7 +89,7 @@ class DynamicPolicyBuilderTest extends TestCase
 
         $expectedWantedAttributeData = [
             'wanted' => [
-                ['name' => 'family_name', 'derivation' => '', 'optional' => false],
+                ['name' => 'family_name', 'optional' => false],
             ],
             'wanted_auth_types' => [],
             'wanted_remember_me' => false,
@@ -112,8 +112,8 @@ class DynamicPolicyBuilderTest extends TestCase
 
         $expectedWantedAttributeData = [
             'wanted' => [
-                ['name' => 'family_name', 'derivation' => '', 'optional' => false],
-                ['name' => 'given_names', 'derivation' => '', 'optional' => false],
+                ['name' => 'family_name', 'optional' => false],
+                ['name' => 'given_names', 'optional' => false],
             ],
             'wanted_auth_types' => [],
             'wanted_remember_me' => false,
@@ -144,8 +144,8 @@ class DynamicPolicyBuilderTest extends TestCase
 
         $expectedWantedAttributeData = [
             'wanted' => [
-                ['name' => 'family_name', 'derivation' => '', 'optional' => false],
-                ['name' => 'given_names', 'derivation' => '', 'optional' => false],
+                ['name' => 'family_name', 'optional' => false],
+                ['name' => 'given_names', 'optional' => false],
             ],
             'wanted_auth_types' => [],
             'wanted_remember_me' => false,
@@ -171,10 +171,10 @@ class DynamicPolicyBuilderTest extends TestCase
 
         $expectedWantedAttributeData = [
             'wanted' => [
-                ['name' => 'date_of_birth', 'derivation' => '', 'optional' => false],
-                ['name' => 'date_of_birth', 'derivation' => 'age_over:18', 'optional' => false],
-                ['name' => 'date_of_birth', 'derivation' => 'age_under:30', 'optional' => false],
-                ['name' => 'date_of_birth', 'derivation' => 'age_under:40', 'optional' => false],
+                ['name' => 'date_of_birth', 'optional' => false],
+                ['name' => 'date_of_birth', 'optional' => false, 'derivation' => 'age_over:18'],
+                ['name' => 'date_of_birth', 'optional' => false, 'derivation' => 'age_under:30'],
+                ['name' => 'date_of_birth', 'optional' => false, 'derivation' => 'age_under:40'],
             ],
             'wanted_auth_types' => [],
             'wanted_remember_me' => false,
@@ -224,7 +224,7 @@ class DynamicPolicyBuilderTest extends TestCase
 
         $expectedWantedAttributeData = [
             'wanted' => [
-                ['name' => 'date_of_birth', 'derivation' => 'age_under:30', 'optional' => false],
+                ['name' => 'date_of_birth', 'optional' => false, 'derivation' => 'age_under:30'],
             ],
             'wanted_auth_types' => [],
             'wanted_remember_me' => false,

--- a/tests/ShareUrl/Policy/WantedAttributeBuilderTest.php
+++ b/tests/ShareUrl/Policy/WantedAttributeBuilderTest.php
@@ -34,8 +34,8 @@ class WantedAttributeBuilderTest extends TestCase
 
         $expectedJsonData = [
             'name' => $someName,
-            'derivation' => $someDerivation,
             'optional' => false,
+            'derivation' => $someDerivation,
         ];
 
         $this->assertEquals(json_encode($expectedJsonData), json_encode($wantedAttribute));
@@ -53,7 +53,6 @@ class WantedAttributeBuilderTest extends TestCase
 
         $expectedJsonData = [
             'name' => $someName,
-            'derivation' => '',
             'optional' => false,
             'accept_self_asserted' => true,
         ];
@@ -86,7 +85,6 @@ class WantedAttributeBuilderTest extends TestCase
 
         $expectedJsonData = [
             'name' => $someName,
-            'derivation' => '',
             'optional' => false,
             'accept_self_asserted' => false,
         ];
@@ -124,7 +122,6 @@ class WantedAttributeBuilderTest extends TestCase
 
         $expectedJsonData = [
             'name' => $someName,
-            'derivation' => '',
             'optional' => false,
             'constraints' => [
                 [


### PR DESCRIPTION
### Changed
- Add derivation to payload only when specified

### Fixed
- Pre-commit hook was only failing on exit code of `composer lint` - both `test` and `lint` now need to pass