### PR TITLE
SDK-1151: Allow multiple attributes with the same name

### DIFF
--- a/examples/composer.lock
+++ b/examples/composer.lock
@@ -69,7 +69,7 @@
             "dist": {
                 "type": "path",
                 "url": "./sdk",
-                "reference": "bf8461699d97cbaf61a0a8bec4e87e6a9b0b0ec2"
+                "reference": "e2b9afb931cb106595eb06005c3b95321a897c99"
             },
             "require": {
                 "php": ">=5.5.19"

--- a/examples/composer.lock
+++ b/examples/composer.lock
@@ -69,7 +69,7 @@
             "dist": {
                 "type": "path",
                 "url": "./sdk",
-                "reference": "18a5d5ecc6d61e97bc9599b78d2eacd216487bb6"
+                "reference": "bf8461699d97cbaf61a0a8bec4e87e6a9b0b0ec2"
             },
             "require": {
                 "php": ">=5.5.19"
@@ -85,10 +85,7 @@
             "type": "library",
             "extra": {
                 "hooks": {
-                    "pre-commit": [
-                        "composer test",
-                        "composer lint"
-                    ]
+                    "pre-commit": "composer test && composer lint"
                 }
             },
             "autoload": {

--- a/examples/public/dynamic-share.php
+++ b/examples/public/dynamic-share.php
@@ -12,22 +12,6 @@ use Yoti\ShareUrl\Policy\SourceConstraintBuilder;
 
 $yotiClient = new Yoti\YotiClient(YOTI_SDK_ID, YOTI_KEY_FILE_PATH);
 
-$drivingLicenseConstraint = (new ConstraintsBuilder())
-    ->withSourceConstraint(
-        (new SourceConstraintBuilder())
-            ->withDrivingLicence()
-            ->build()
-    )
-    ->build();
-
-$passportConstraint = (new ConstraintsBuilder())
-    ->withSourceConstraint(
-        (new SourceConstraintBuilder())
-            ->withPassport()
-            ->build()
-    )
-    ->build();
-
 $locationConstraint = (new LocationConstraintExtensionBuilder())
     ->withLatitude(50.8169)
     ->withLongitude(-0.1367)
@@ -36,9 +20,7 @@ $locationConstraint = (new LocationConstraintExtensionBuilder())
 
 $policy = (new DynamicPolicyBuilder())
     ->withFullName()
-    ->withGivenNames()
-    ->withDocumentDetails($drivingLicenseConstraint)
-    ->withDocumentDetails($passportConstraint)
+    ->withDocumentDetails()
     ->withDocumentImages()
     ->withAgeOver(18)
     ->withSelfie()

--- a/examples/public/dynamic-share.php
+++ b/examples/public/dynamic-share.php
@@ -6,9 +6,27 @@ require_once __DIR__ . '/../bootstrap.php';
 
 use Yoti\ShareUrl\DynamicScenarioBuilder;
 use Yoti\ShareUrl\Extension\LocationConstraintExtensionBuilder;
+use Yoti\ShareUrl\Policy\ConstraintsBuilder;
 use Yoti\ShareUrl\Policy\DynamicPolicyBuilder;
+use Yoti\ShareUrl\Policy\SourceConstraintBuilder;
 
 $yotiClient = new Yoti\YotiClient(YOTI_SDK_ID, YOTI_KEY_FILE_PATH);
+
+$drivingLicenseConstraint = (new ConstraintsBuilder())
+    ->withSourceConstraint(
+        (new SourceConstraintBuilder())
+            ->withDrivingLicence()
+            ->build()
+    )
+    ->build();
+
+$passportConstraint = (new ConstraintsBuilder())
+    ->withSourceConstraint(
+        (new SourceConstraintBuilder())
+            ->withPassport()
+            ->build()
+    )
+    ->build();
 
 $locationConstraint = (new LocationConstraintExtensionBuilder())
     ->withLatitude(50.8169)
@@ -18,7 +36,8 @@ $locationConstraint = (new LocationConstraintExtensionBuilder())
 
 $policy = (new DynamicPolicyBuilder())
     ->withFullName()
-    ->withDocumentDetails()
+    ->withDocumentDetails($drivingLicenseConstraint)
+    ->withDocumentDetails($passportConstraint)
     ->withDocumentImages()
     ->withAgeOver(18)
     ->withSelfie()

--- a/examples/public/dynamic-share.php
+++ b/examples/public/dynamic-share.php
@@ -36,6 +36,7 @@ $locationConstraint = (new LocationConstraintExtensionBuilder())
 
 $policy = (new DynamicPolicyBuilder())
     ->withFullName()
+    ->withGivenNames()
     ->withDocumentDetails($drivingLicenseConstraint)
     ->withDocumentDetails($passportConstraint)
     ->withDocumentImages()

--- a/examples/public/profile.inc.php
+++ b/examples/public/profile.inc.php
@@ -71,7 +71,23 @@ try {
             'name' => 'Document Images',
             'obj' => $profile->getDocumentImages(),
             'icon' => 'yoti-icon-profile',
-        ]
+        ],
+        [
+            'name' => 'Passport Details',
+            'obj' => findAttributeWithSourceValue(
+                $profile->getAttributesByName('document_details'),
+                'PASSPORT'
+            ),
+            'icon' => 'yoti-icon-profile',
+        ],
+        [
+            'name' => 'Driving Licence Details',
+            'obj' => findAttributeWithSourceValue(
+                $profile->getAttributesByName('document_details'),
+                'DRIVING_LICENCE'
+            ),
+            'icon' => 'yoti-icon-profile',
+        ],
     ];
 
     $ageVerifications = $profile->getAgeVerifications();
@@ -87,7 +103,27 @@ try {
     }
 
     $fullName = $profile->getFullName();
-} catch(\Exception $e) {
-    header('Location: /error.php?msg='.$e->getMessage());
+} catch (\Exception $e) {
+    header('Location: /error.php?msg=' . $e->getMessage());
     exit;
+}
+
+/**
+ * Returns attribute with provided source value.
+ *
+ * @param \Yoti\Entity\Attribute[] $attributeList
+ * @param string $source
+ *
+ * @return \Yoti\Entity\Attribute
+ */
+function findAttributeWithSourceValue($attributeList, $source)
+{
+    $filteredAttributes = array_filter(
+        $attributeList,
+        function ($attribute) use ($source) {
+            return $attribute->getSources()[0]->getValue() === $source;
+        }
+    );
+
+    return reset($filteredAttributes);
 }

--- a/examples/public/profile.inc.php
+++ b/examples/public/profile.inc.php
@@ -1,6 +1,10 @@
 <?php
 
 // Load dependent packages and env data
+
+use Yoti\Entity\Attribute;
+use Yoti\Entity\Profile;
+
 require_once __DIR__ . '/../bootstrap.php';
 
 // Get the token
@@ -12,84 +16,56 @@ try {
     $activityDetails = $yotiClient->getActivityDetails($token);
     $profile = $activityDetails->getProfile();
 
-    $ageVerifications = $profile->getAgeVerifications();
-    // Get the first AgeVerification element
-    $ageVerification = current($ageVerifications);
+    $profileAttributes = [];
+    foreach ($profile->getAttributesList() as $attribute) {
+        switch ($attribute->getName()) {
+            case Profile::ATTR_SELFIE:
+            case Profile::ATTR_FULL_NAME:
+                // Selfie and full name are handled separately.
+                break;
+            case Profile::ATTR_GIVEN_NAMES:
+                $profileAttributes[] = createAttributeDisplayItem($attribute, 'Given names', 'yoti-icon-profile');
+                break;
+            case Profile::ATTR_FAMILY_NAME:
+                $profileAttributes[] = createAttributeDisplayItem($attribute, 'Family names', 'yoti-icon-profile');
+                break;
+            case Profile::ATTR_DATE_OF_BIRTH:
+                $profileAttributes[] = createAttributeDisplayItem($attribute, 'Date of Birth', 'yoti-icon-calendar');
+                break;
+            case Profile::ATTR_GENDER:
+                $profileAttributes[] = createAttributeDisplayItem($attribute, 'Gender', 'yoti-icon-gender');
+                break;
+            case Profile::ATTR_STRUCTURED_POSTAL_ADDRESS:
+                $profileAttributes[] = createAttributeDisplayItem($attribute, 'Structured Postal Address', 'yoti-icon-address');
+                break;
+            case Profile::ATTR_POSTAL_ADDRESS:
+                $profileAttributes[] = createAttributeDisplayItem($attribute, 'Address', 'yoti-icon-address');
+                break;
+            case Profile::ATTR_PHONE_NUMBER:
+                $profileAttributes[] = createAttributeDisplayItem($attribute, 'Mobile number', 'yoti-icon-phone');
+                break;
+            case Profile::ATTR_NATIONALITY:
+                $profileAttributes[] = createAttributeDisplayItem($attribute, 'Nationality', 'yoti-icon-nationality');
+                break;
+            case Profile::ATTR_EMAIL_ADDRESS:
+                $profileAttributes[] = createAttributeDisplayItem($attribute, 'Email address', 'yoti-icon-email');
+                break;
+            case Profile::ATTR_DOCUMENT_DETAILS:
+                $profileAttributes[] = createAttributeDisplayItem($attribute, 'Document Details', 'yoti-icon-profile');
+                break;
+            case Profile::ATTR_DOCUMENT_IMAGES:
+                $profileAttributes[] = createAttributeDisplayItem($attribute, 'Document Images', 'yoti-icon-profile');
+                break;
+            default:
+                $profileAttributes[] = createAttributeDisplayItem(
+                    $attribute,
+                    ucwords(str_replace('_', ' ', $attribute->getName())),
+                    'yoti-icon-profile'
+                );
+        }
+    }
 
-    $profileAttributes = [
-        [
-            'name' => 'Given names',
-            'obj' => $profile->getGivenNames(),
-            'icon' => 'yoti-icon-profile',
-        ],
-        [
-            'name' => 'Family names',
-            'obj' => $profile->getFamilyName(),
-            'icon' => 'yoti-icon-profile',
-        ],
-        [
-            'name' => 'Mobile number',
-            'obj' => $profile->getPhoneNumber(),
-            'icon' => 'yoti-icon-phone',
-        ],
-        [
-            'name' => 'Email address',
-            'obj' => $profile->getEmailAddress(),
-            'icon' => 'yoti-icon-email',
-        ],
-        [
-            'name' => 'Date of birth',
-            'obj' => $profile->getDateOfBirth(),
-            'icon' => 'yoti-icon-calendar',
-        ],
-        [
-            'name' => 'Address',
-            'obj' => $profile->getPostalAddress(),
-            'icon' => 'yoti-icon-address',
-        ],
-        [
-            'name' => 'Gender',
-            'obj' => $profile->getGender(),
-            'icon' => 'yoti-icon-gender',
-        ],
-        [
-            'name' => 'Nationality',
-            'obj' => $profile->getNationality(),
-            'icon' => 'yoti-icon-nationality',
-        ],
-        [
-            'name' => 'Structured Postal Address',
-            'obj' => $profile->getStructuredPostalAddress(),
-            'icon' => 'yoti-icon-profile',
-        ],
-        [
-            'name' => 'Document Details',
-            'obj' => $profile->getDocumentDetails(),
-            'icon' => 'yoti-icon-profile',
-        ],
-        [
-            'name' => 'Document Images',
-            'obj' => $profile->getDocumentImages(),
-            'icon' => 'yoti-icon-profile',
-        ],
-        [
-            'name' => 'Passport Details',
-            'obj' => findAttributeWithSourceValue(
-                $profile->getAttributesByName('document_details'),
-                'PASSPORT'
-            ),
-            'icon' => 'yoti-icon-profile',
-        ],
-        [
-            'name' => 'Driving Licence Details',
-            'obj' => findAttributeWithSourceValue(
-                $profile->getAttributesByName('document_details'),
-                'DRIVING_LICENCE'
-            ),
-            'icon' => 'yoti-icon-profile',
-        ],
-    ];
-
+    // Add age verifications.
     $ageVerifications = $profile->getAgeVerifications();
     if ($ageVerifications) {
         foreach ($ageVerifications as $ageVerification) {
@@ -109,21 +85,16 @@ try {
 }
 
 /**
- * Returns attribute with provided source value.
+ * @param  \Yoti\Entity\Attribute $attribute
+ * @param string $displayName
+ * @param string $iconClass
  *
- * @param \Yoti\Entity\Attribute[] $attributeList
- * @param string $source
- *
- * @return \Yoti\Entity\Attribute
+ * @return array
  */
-function findAttributeWithSourceValue($attributeList, $source)
-{
-    $filteredAttributes = array_filter(
-        $attributeList,
-        function ($attribute) use ($source) {
-            return $attribute->getSources()[0]->getValue() === $source;
-        }
-    );
-
-    return reset($filteredAttributes);
+function createAttributeDisplayItem(Attribute $attribute, $displayName, $iconClass) {
+    return [
+        'name' => $displayName,
+        'obj' => $attribute,
+        'icon' => $iconClass,
+    ];
 }

--- a/examples/public/profile.php
+++ b/examples/public/profile.php
@@ -1,5 +1,120 @@
 <?php
+
+use Yoti\Entity\AgeVerification;
+use Yoti\Entity\DocumentDetails;
+use Yoti\Entity\Image;
+
 require_once __DIR__ . '/profile.inc.php';
+
+/**
+ * Formats attribute value based on type.
+ *
+ * @param mixed $value
+ */
+function formatAttributeValue($value)
+{
+    if ($value instanceof \Yoti\Entity\MultiValue)
+    {
+        foreach ($value as $multiValue) {
+            formatAttributeValue($multiValue);
+        }
+    } elseif ($value instanceof \Yoti\Entity\Image) {
+        formatImage($value);
+    } elseif ($value instanceof \Yoti\Entity\DocumentDetails) {
+        formatDocumentDetails($value);
+    } elseif ($value instanceof \DateTime) {
+        echo htmlspecialchars($value->format('d-m-Y'));
+    } else {
+        echo htmlspecialchars($value);
+    }
+}
+
+/**
+ * Format Image.
+ *
+ * @param \Yoti\Entity\Image $value
+ */
+function formatImage(Image $image)
+{
+    ?>
+    <img src="<?php echo htmlspecialchars($image->getBase64Content()); ?>" />
+    <?php
+}
+
+/**
+ * Format Document Details.
+ *
+ * @param \Yoti\Entity\DocumentDetails $value
+ */
+function formatDocumentDetails(DocumentDetails $documentDetails)
+{
+    ?>
+    <table>
+        <tr>
+            <td>Type</td>
+            <td><?php echo htmlspecialchars($documentDetails->getType()); ?></td>
+        </tr>
+        <tr>
+            <td>Issuing Country</td>
+            <td><?php echo htmlspecialchars($documentDetails->getIssuingCountry()); ?></td>
+        </tr>
+        <tr>
+            <td>Document Number</td>
+            <td><?php echo htmlspecialchars($documentDetails->getDocumentNumber()); ?></td>
+        </tr>
+        <tr>
+            <td>Expiration Date</td>
+            <td><?php echo htmlspecialchars($documentDetails->getExpirationDate()->format('d-m-Y')); ?></td>
+        </tr>
+    </table>
+    <?php
+}
+
+/**
+ * Format Age Verification.
+ *
+ * @param \Yoti\Entity\AgeVerification $ageVerification
+ */
+function formatAgeVerification(AgeVerification $ageVerification)
+{
+    ?>
+    <table>
+        <tr>
+            <td>Check Type</td>
+            <td><?php echo htmlspecialchars($ageVerification->getCheckType()); ?></td>
+        </tr>
+        <tr>
+            <td>Age</td>
+            <td><?php echo htmlspecialchars($ageVerification->getAge()); ?></td>
+        </tr>
+        <tr>
+            <td>Result</td>
+            <td><?php echo htmlspecialchars($ageVerification->getResult()); ?></td>
+        </tr>
+    </table>
+    <?php
+}
+
+
+/**
+ * Format Structure Postal Address.
+ *
+ * @param array $structuredAddress
+ */
+function formatStructuredAddress(array $structuredAddress)
+{
+    ?>
+    <table>
+        <?php foreach ($structuredAddress as $key => $value): ?>
+            <tr>
+                <td><?php echo htmlspecialchars($key); ?></td>
+                <td><?php echo htmlspecialchars($value); ?></td>
+            </tr>
+        <?php endforeach; ?>
+    </table>
+    <?php
+}
+
 ?>
 <!DOCTYPE html>
 <html class="yoti-html">
@@ -68,72 +183,15 @@ require_once __DIR__ . '/profile.inc.php';
                                 <div class="yoti-attribute-value">
                                    <div class="yoti-attribute-value-text">
                                    <?php
-                                   $attributeObj = $item['obj'];
                                    switch ($item['name']) {
-                                        case 'Date of birth';
-                                            echo htmlspecialchars($item['obj']->getValue()->format('d-m-Y'));
-                                            break;
                                         case 'Age Verification':
-                                            ?>
-                                            <table>
-                                                <tr>
-                                                    <td>Check Type</td>
-                                                    <td><?php echo htmlspecialchars($item['age_verification']->getCheckType()); ?></td>
-                                                </tr>
-                                                <tr>
-                                                    <td>Age</td>
-                                                    <td><?php echo htmlspecialchars($item['age_verification']->getAge()); ?></td>
-                                                </tr>
-                                                <tr>
-                                                    <td>Result</td>
-                                                    <td><?php echo htmlspecialchars($item['age_verification']->getResult()); ?></td>
-                                                </tr>
-                                            </table>
-                                            <?php
+                                            formatAgeVerification($item['age_verification']);
                                             break;
                                         case 'Structured Postal Address':
-                                            ?>
-                                            <table>
-                                                <?php foreach ($item['obj']->getValue() as $key => $value): ?>
-                                                    <tr>
-                                                        <td><?php echo htmlspecialchars($key); ?></td>
-                                                        <td><?php echo htmlspecialchars($value); ?></td>
-                                                    </tr>
-                                                <?php endforeach; ?>
-                                            </table>
-                                            <?php
-                                            break;
-                                        case 'Document Details':
-                                            ?>
-                                            <table>
-                                                <tr>
-                                                    <td>Type</td>
-                                                    <td><?php echo htmlspecialchars($item['obj']->getValue()->getType()); ?></td>
-                                                </tr>
-                                                <tr>
-                                                    <td>Issuing Country</td>
-                                                    <td><?php echo htmlspecialchars($item['obj']->getValue()->getIssuingCountry()); ?></td>
-                                                </tr>
-                                                <tr>
-                                                    <td>Document Number</td>
-                                                    <td><?php echo htmlspecialchars($item['obj']->getValue()->getDocumentNumber()); ?></td>
-                                                </tr>
-                                                <tr>
-                                                    <td>Expiration Date</td>
-                                                    <td><?php echo htmlspecialchars($item['obj']->getValue()->getExpirationDate()->format('d-m-Y')); ?></td>
-                                                </tr>
-                                            </table>
-                                            <?php
-                                            break;
-                                        case 'Document Images':
-                                            foreach ($item['obj']->getValue() as $image) {
-                                            ?>
-                                                <img src="<?php echo htmlspecialchars($image->getBase64Content()); ?>" />
-                                            <?php
-                                            }
+                                            formatStructuredAddress($item['obj']->getValue());
                                             break;
                                         default:
-                                            echo htmlspecialchars($item['obj']->getValue());
+                                            formatAttributeValue($item['obj']->getValue());
                                    }
                                    ?>
                                    </div>
@@ -143,7 +201,7 @@ require_once __DIR__ . '/profile.inc.php';
                                    <div class="yoti-attribute-anchors-head -value">Value</div>
                                    <div class="yoti-attribute-anchors-head -subtype">Sub type</div>
 
-                                   <?php foreach($attributeObj->getAnchors() as $anchor) : ?>
+                                   <?php foreach($item['obj']->getAnchors() as $anchor) : ?>
                                        <div class="yoti-attribute-anchors -s-v"><?php echo htmlspecialchars($anchor->getType()); ?></div>
                                        <div class="yoti-attribute-anchors -value"><?php echo htmlspecialchars($anchor->getValue()); ?></div>
                                        <div class="yoti-attribute-anchors -subtype"><?php echo htmlspecialchars($anchor->getSubType()); ?></div>

--- a/examples/public/profile.php
+++ b/examples/public/profile.php
@@ -13,8 +13,7 @@ require_once __DIR__ . '/profile.inc.php';
  */
 function formatAttributeValue($value)
 {
-    if ($value instanceof \Yoti\Entity\MultiValue)
-    {
+    if ($value instanceof \Yoti\Entity\MultiValue) {
         foreach ($value as $multiValue) {
             formatAttributeValue($multiValue);
         }

--- a/examples/public/profile.php
+++ b/examples/public/profile.php
@@ -96,7 +96,7 @@ function formatAgeVerification(AgeVerification $ageVerification)
 
 
 /**
- * Format Structure Postal Address.
+ * Format Structured Postal Address.
  *
  * @param array $structuredAddress
  */

--- a/src/Yoti/ActivityDetails.php
+++ b/src/Yoti/ActivityDetails.php
@@ -4,9 +4,7 @@ namespace Yoti;
 
 use Yoti\Entity\Profile;
 use Yoti\Entity\Receipt;
-use Attrpubapi\AttributeList;
 use Yoti\Entity\ApplicationProfile;
-use Yoti\Util\Age\AgeVerificationConverter;
 use Yoti\Util\Profile\AttributeConverter;
 use Yoti\Util\Profile\AttributeListConverter;
 
@@ -98,7 +96,9 @@ class ActivityDetails
             Receipt::ATTR_OTHER_PARTY_PROFILE_CONTENT,
             $this->pem
         );
-        $this->userProfile = new Profile($this->processUserProfileAttributes($protobufAttrList));
+        $this->userProfile = new Profile(
+            AttributeListConverter::convertToYotiAttributesList($protobufAttrList)
+        );
     }
 
     private function setApplicationProfile()
@@ -108,28 +108,8 @@ class ActivityDetails
             $this->pem
         );
         $this->applicationProfile = new ApplicationProfile(
-            AttributeListConverter::convertToYotiAttributesMap($protobufAttributesList)
+            AttributeListConverter::convertToYotiAttributesList($protobufAttributesList)
         );
-    }
-
-    private function processUserProfileAttributes(AttributeList $protobufAttributesList)
-    {
-        $attributesMap = AttributeListConverter::convertToYotiAttributesMap($protobufAttributesList);
-        $this->appendAgeVerifications($attributesMap);
-
-        return $attributesMap;
-    }
-
-    /**
-     * Add age_verifications data to the attributesMap
-     *
-     * @param array $attributesMap
-     */
-    private function appendAgeVerifications(array &$attributesMap)
-    {
-        $ageVerificationConverter = new AgeVerificationConverter($attributesMap);
-        $ageVerifications = $ageVerificationConverter->getAgeVerificationsFromAttrsMap();
-        $attributesMap[Profile::ATTR_AGE_VERIFICATIONS] = $ageVerifications;
     }
 
     /**

--- a/src/Yoti/Entity/BaseProfile.php
+++ b/src/Yoti/Entity/BaseProfile.php
@@ -4,37 +4,121 @@ namespace Yoti\Entity;
 
 class BaseProfile
 {
+    /**
+     * @var \Yoti\Entity\Attribute[]
+     */
+    private $attributesList;
+
+    /**
+     * @var \Yoti\Entity\Attribute[][] keyed by attribute name.
+     */
+    private $attributesMap;
+
+    /**
+     * @deprecated 3.0.0 replaced by $attributesMap
+     *
+     * @var mixed[]
+     */
     protected $profileData;
 
     /**
      * Profile constructor.
      *
-     * @param array $profileData
+     * @param \Yoti\Entity\Attribute[] $attributesList
      */
-    public function __construct(array $profileData)
+    public function __construct(array $attributesList)
     {
-        $this->profileData = $profileData;
+        $this->setAttributesList($attributesList);
+        $this->setAttributesMap();
+
+        /** @deprecated 3.0.0 Set profileData property for backwards compatibility. */
+        $this->profileData = $attributesList;
+    }
+
+    /**
+     * Set attributes list.
+     *
+     * @param \Yoti\Entity\Attribute[] $attributesList
+     */
+    private function setAttributesList($attributesList)
+    {
+        $this->attributesList = array_filter(
+            array_values($attributesList),
+            function ($attribute) {
+                return $attribute instanceof Attribute;
+            }
+        );
+    }
+
+    /**
+     * Set attributes map keyed by attribute name.
+     */
+    private function setAttributesMap()
+    {
+        $this->attributesMap = array_reduce(
+            $this->getAttributesList(),
+            function ($carry, Attribute $attr) {
+                $carry[$attr->getName()][] = $attr;
+                return $carry;
+            },
+            []
+        );
     }
 
     /**
      * @param $attributeName.
      *
-     * @return null|Attribute
+     * @return \Yoti\Entity\Attribute[]
+     */
+    public function getAttributesByName($attributeName)
+    {
+        if (isset($this->attributesMap[$attributeName])) {
+            return $this->attributesMap[$attributeName];
+        }
+        return [];
+    }
+
+    /**
+     * @param $attributeName.
+     *
+     * @return \Yoti\Entity\Attribute|null
      */
     public function getProfileAttribute($attributeName)
     {
-        if (isset($this->profileData[$attributeName])) {
-            $attributeObj = $this->profileData[$attributeName];
-            return $attributeObj instanceof Attribute ? $attributeObj : null;
+        $attributes = $this->getAttributesByName($attributeName);
+        if (!empty($attributes)) {
+            return reset($attributes);
         }
         return null;
     }
 
+    /**
+     * Get attributes array keyed by name.
+     *
+     * @deprecated 3.0.0 replaced by ::getAttributesList()
+     *
+     * @return \Yoti\Entity\Attribute[]
+     */
     public function getAttributes()
     {
-        $attributesMap = $this->profileData;
-        // Remove age_verifications
-        unset($attributesMap[Profile::ATTR_AGE_VERIFICATIONS]);
-        return $attributesMap;
+        return array_reduce(
+            $this->attributesMap,
+            function ($carry, $attributes) {
+                $attribute = reset($attributes);
+                $carry[$attribute->getName()] = $attribute;
+                return $carry;
+            },
+            []
+        );
+    }
+
+    /**
+     * Get all attributes.
+     *
+     * @return \Yoti\Entity\Attribute[]
+     */
+    public function getAttributesList()
+    {
+        return $this->attributesList;
     }
 }

--- a/src/Yoti/Entity/Profile.php
+++ b/src/Yoti/Entity/Profile.php
@@ -26,7 +26,7 @@ class Profile extends BaseProfile
     const ATTR_DOCUMENT_IMAGES = 'document_images';
     const ATTR_STRUCTURED_POSTAL_ADDRESS = 'structured_postal_address';
 
-    /** @deprecated 3.0.0 No longer used to store age verifcations. */
+    /** @deprecated 3.0.0 No longer used to store age verifications. */
     const ATTR_AGE_VERIFICATIONS = 'age_verifications';
 
     /** @var \Yoti\Entity\AgeVerification[] */

--- a/src/Yoti/ShareUrl/Policy/DynamicPolicyBuilder.php
+++ b/src/Yoti/ShareUrl/Policy/DynamicPolicyBuilder.php
@@ -43,8 +43,13 @@ class DynamicPolicyBuilder
     public function withWantedAttribute(WantedAttribute $wantedAttribute)
     {
         $key = $wantedAttribute->getName();
-        if ($wantedAttribute->getDerivation()) {
+
+        if ($wantedAttribute->getDerivation() !== null) {
             $key = $wantedAttribute->getDerivation();
+        }
+
+        if ($wantedAttribute->getConstraints() !== null) {
+            $key .= '-' . md5(json_encode($wantedAttribute->getConstraints()));
         }
 
         $this->wantedAttributes[$key] = $wantedAttribute;

--- a/src/Yoti/Util/Profile/AttributeListConverter.php
+++ b/src/Yoti/Util/Profile/AttributeListConverter.php
@@ -3,29 +3,53 @@
 namespace Yoti\Util\Profile;
 
 use Attrpubapi\AttributeList;
-use Attrpubapi\Attribute as ProtobufAttribute;
+use Yoti\Entity\Attribute;
 
 class AttributeListConverter
 {
     /**
-     * Convert Protobuf AttributeList to Yoti Attributes map.
+     * Convert Protobuf AttributeList to array of Yoti Attributes.
      *
      * @param AttributeList $attributeList
      *
-     * @return array
+     * @return \Yoti\Entity\Attribute[]
      */
-    public static function convertToYotiAttributesMap(AttributeList $attributeList)
+    public static function convertToYotiAttributesList(AttributeList $attributeList)
     {
         $yotiAttributes = [];
 
-        foreach ($attributeList->getAttributes() as $attr) { /** @var ProtobufAttribute $attr */
-            $attrName = $attr->getName();
-            if (null === $attrName) {
+        foreach ($attributeList->getAttributes() as $attr) { /** @var \Attrpubapi\Attribute $attr */
+            if ($attr->getName() === null) {
                 continue;
             }
-            $yotiAttributes[$attr->getName()] = AttributeConverter::convertToYotiAttribute($attr);
+            $yotiAttribute = AttributeConverter::convertToYotiAttribute($attr);
+            if (!($yotiAttribute instanceof Attribute)) {
+                continue;
+            }
+            $yotiAttributes[] = $yotiAttribute;
         }
         return $yotiAttributes;
+    }
+
+    /**
+     * Convert Protobuf AttributeList to Yoti Attributes map.
+     *
+     * @deprecated 3.0.0 Replaced by ::convertToYotiAttributesList
+     *
+     * @param AttributeList $attributeList
+     *
+     * @return \Yoti\Entity\Attribute[]
+     */
+    public static function convertToYotiAttributesMap(AttributeList $attributeList)
+    {
+        return array_reduce(
+            self::convertToYotiAttributesList($attributeList),
+            function ($carry, Attribute $attr) {
+                $carry[$attr->getName()] = $attr;
+                return $carry;
+            },
+            []
+        );
     }
 
     /**

--- a/tests/Entity/BaseProfileTest.php
+++ b/tests/Entity/BaseProfileTest.php
@@ -11,26 +11,118 @@ use Yoti\Entity\BaseProfile;
  */
 class BaseProfileTest extends TestCase
 {
+    const SOME_ATTRIBUTE = 'some_attribute';
+    const SOME_OTHER_ATTRIBUTE = 'some_other_attribute';
+    const SOME_INVALID_ATTRIBUTE = 'some_invalid_attribute';
+    const SOME_MISSING_ATTRIBUTE = 'some_missing_attribute';
+
+    /**
+     * @var \Yoti\Entity\BaseProfile
+     */
+    private $baseProfile;
+
+    /**
+     * @var \Yoti\Entity\Attribute
+     */
+    private $someAttribute;
+
+    /**
+     * @var \Yoti\Entity\Attribute
+     */
+    private $someOtherAttribute;
+
+    /**
+     * @var \Yoti\Entity\Attribute
+     */
+    private $someOtherAttributeWithSameName;
+
+    /**
+     * Setup mocks.
+     */
+    public function setup()
+    {
+        $this->someAttribute = $this->createMock(Attribute::class);
+        $this->someAttribute
+            ->method('getName')
+            ->willReturn(self::SOME_ATTRIBUTE);
+
+        $this->someOtherAttributeWithSameName = $this->createMock(Attribute::class);
+        $this->someOtherAttributeWithSameName
+            ->method('getName')
+            ->willReturn(self::SOME_ATTRIBUTE);
+
+        $this->someOtherAttribute = $this->createMock(Attribute::class);
+        $this->someOtherAttribute
+            ->method('getName')
+            ->willReturn(self::SOME_OTHER_ATTRIBUTE);
+
+        $someAttributeWithNullName = $this->createMock(Attribute::class);
+        $someAttributeWithNullName
+            ->method('getName')
+            ->willReturn(null);
+
+        $this->baseProfile = new BaseProfile([
+            $this->someAttribute,
+            $this->someOtherAttributeWithSameName,
+            $this->someOtherAttribute,
+            $someAttributeWithNullName,
+            self::SOME_INVALID_ATTRIBUTE => 'invalid',
+        ]);
+    }
+
     /**
      * @covers ::__construct
      * @covers ::getProfileAttribute
      */
-    public function testAttributeGetters()
+    public function testGetProfileAttribute()
     {
-        $someAttributeName = 'some_attribute';
-        $someAttribute = $this->createMock(Attribute::class);
+        $this->assertSame($this->someAttribute, $this->baseProfile->getProfileAttribute(self::SOME_ATTRIBUTE));
+        $this->assertNull($this->baseProfile->getProfileAttribute(self::SOME_INVALID_ATTRIBUTE));
+        $this->assertNull($this->baseProfile->getProfileAttribute(self::SOME_MISSING_ATTRIBUTE));
+    }
 
-        $someInvalidAttributeName = 'some_invalid_attribute';
+    /**
+     * @covers ::__construct
+     * @covers ::getAttributesList
+     */
+    public function testGetAttributesList()
+    {
+        $attributesList = $this->baseProfile->getAttributesList(self::SOME_ATTRIBUTE);
+        $this->assertCount(4, $attributesList);
+        $this->assertContainsOnlyInstancesOf(Attribute::class, $attributesList);
+    }
 
-        $someProfileData = [
-            $someAttributeName => $someAttribute,
-            $someInvalidAttributeName => 'invalid',
-        ];
+    /**
+     * @covers ::__construct
+     * @covers ::getAttributes
+     */
+    public function testGetAttributes()
+    {
+        $attributesMap = $this->baseProfile->getAttributes(self::SOME_ATTRIBUTE);
+        $this->assertCount(3, $attributesMap);
+        $this->assertContainsOnlyInstancesOf(Attribute::class, $attributesMap);
 
-        $baseProfile = new BaseProfile($someProfileData);
+        // Map should contain first attribute when there are multiple with the same name.
+        $this->assertSame($attributesMap[self::SOME_ATTRIBUTE], $this->someAttribute);
+    }
 
-        $this->assertSame($someAttribute, $baseProfile->getProfileAttribute($someAttributeName));
-        $this->assertNull($baseProfile->getProfileAttribute($someInvalidAttributeName));
-        $this->assertNull($baseProfile->getProfileAttribute('some_missing_attribute'));
+    /**
+     * @covers ::__construct
+     * @covers ::getAttributesByName
+     */
+    public function testGetAttributesByName()
+    {
+        $attributes = $this->baseProfile->getAttributesByName(self::SOME_ATTRIBUTE);
+        $this->assertCount(2, $attributes);
+        $this->assertSame($this->someAttribute, $attributes[0]);
+        $this->assertSame($this->someOtherAttributeWithSameName, $attributes[1]);
+
+        $invalidAttributes = $this->baseProfile->getAttributesByName(self::SOME_INVALID_ATTRIBUTE);
+        $this->assertIsArray($invalidAttributes);
+        $this->assertEmpty($invalidAttributes);
+
+        $missingAttributes = $this->baseProfile->getAttributesByName(self::SOME_MISSING_ATTRIBUTE);
+        $this->assertIsArray($missingAttributes);
+        $this->assertEmpty($missingAttributes);
     }
 }

--- a/tests/Entity/ProfileTest.php
+++ b/tests/Entity/ProfileTest.php
@@ -57,7 +57,6 @@ class ProfileTest extends TestCase
             [ 'given_names' , 'getGivenNames' ],
             [ 'full_name', 'getFullName' ],
             [ 'date_of_birth', 'getDateOfBirth' ],
-            [ 'age_verifications', 'getAgeVerifications' ],
             [ 'gender', 'getGender' ],
             [ 'nationality', 'getNationality' ],
             [ 'phone_number', 'getPhoneNumber' ],
@@ -124,27 +123,27 @@ class ProfileTest extends TestCase
     }
 
     /**
-     * Should not return age_verifications in the array
+     * @covers ::getAgeVerifications
      *
-     * @covers ::getAttributes
-     *
-     * @dataProvider getDummyProfileDataWithAgeVerifications
+     * @dataProvider profileDataWithAgeVerificationsDataProvider
      */
-    public function testGetAttributes($profileData)
+    public function testGetAgeVerifications($profileData)
     {
         $profile = new Profile($profileData);
-
-        $this->assertArrayNotHasKey(Profile::ATTR_AGE_VERIFICATIONS, $profile->getAttributes());
+        foreach ($profile->getAgeVerifications() as $ageVerification) {
+            $this->assertInstanceOf(AgeVerification::class, $ageVerification);
+        }
     }
 
     /**
      * @covers ::findAgeOverVerification
      * @covers ::getAgeVerificationByAttribute
+     * @covers ::findAllAgeVerifications
      * @covers \Yoti\Entity\AgeVerification::getCheckType
      * @covers \Yoti\Entity\AgeVerification::getAge
      * @covers \Yoti\Entity\AgeVerification::getResult
      *
-     * @dataProvider getDummyProfileDataWithAgeVerifications
+     * @dataProvider profileDataWithAgeVerificationsDataProvider
      */
     public function testFindAgeOverVerification($profileData)
     {
@@ -160,11 +159,12 @@ class ProfileTest extends TestCase
     /**
      * @covers ::findAgeUnderVerification
      * @covers ::getAgeVerificationByAttribute
+     * @covers ::findAllAgeVerifications
      * @covers \Yoti\Entity\AgeVerification::getCheckType
      * @covers \Yoti\Entity\AgeVerification::getAge
      * @covers \Yoti\Entity\AgeVerification::getResult
      *
-     * @dataProvider getDummyProfileDataWithAgeVerifications
+     * @dataProvider profileDataWithAgeVerificationsDataProvider
      */
     public function testFindAgeUnderVerification($profileData)
     {
@@ -180,31 +180,19 @@ class ProfileTest extends TestCase
     /**
      * Profile data provider with age verifications.
      */
-    public function getDummyProfileDataWithAgeVerifications()
+    public function profileDataWithAgeVerificationsDataProvider()
     {
         $profileData = [
-            Profile::ATTR_AGE_VERIFICATIONS => [
-                'age_under:18' => new AgeVerification(
-                    new Attribute(
-                        'age_under:18',
-                        'false',
-                        []
-                    ),
-                    'age_under',
-                    18,
-                    false
-                ),
-                'age_over:35' => new AgeVerification(
-                    new Attribute(
-                        'age_over:35',
-                        'true',
-                        []
-                    ),
-                    'age_over',
-                    35,
-                    true
-                ),
-            ],
+            sprintf(Profile::AGE_UNDER_FORMAT, '18') => new Attribute(
+                sprintf(Profile::AGE_UNDER_FORMAT, '18'),
+                'false',
+                []
+            ),
+            sprintf(Profile::AGE_OVER_FORMAT, '35') => new Attribute(
+                sprintf(Profile::AGE_OVER_FORMAT, '35'),
+                'true',
+                []
+            ),
             Profile::ATTR_GIVEN_NAMES => new Attribute(
                 Profile::ATTR_GIVEN_NAMES,
                 'TEST GIVEN NAMES',
@@ -224,12 +212,15 @@ class ProfileTest extends TestCase
      */
     public function testGetDocumentImages()
     {
-        $mockAttr = $this->getMockBuilder(\Yoti\Entity\Attribute::class)
-            ->disableOriginalConstructor()
-            ->getMock();
+        $attributeName = 'document_images';
+
+        $someAttribute = $this->createMock(\Yoti\Entity\Attribute::class);
+        $someAttribute
+            ->method('getName')
+            ->willReturn($attributeName);
 
         $profileData = [
-            'document_images' => $mockAttr,
+            $attributeName => $someAttribute,
         ];
         $profile = new Profile($profileData);
         $this->assertSame($profileData['document_images'], $profile->getDocumentImages());

--- a/tests/Entity/ReceiptTest.php
+++ b/tests/Entity/ReceiptTest.php
@@ -110,7 +110,7 @@ class ReceiptTest extends TestCase
             Receipt::ATTR_OTHER_PARTY_PROFILE_CONTENT,
             $this->pem
         );
-        $yotiAttributesList = AttributeListConverter::convertToYotiAttributesMap(
+        $yotiAttributesList = AttributeListConverter::convertToYotiAttributesList(
             $protobufAttributesList
         );
         $profile = new Profile($yotiAttributesList);
@@ -126,7 +126,7 @@ class ReceiptTest extends TestCase
             Receipt::ATTR_PROFILE_CONTENT,
             $this->pem
         );
-        $yotiAttributesList = AttributeListConverter::convertToYotiAttributesMap(
+        $yotiAttributesList = AttributeListConverter::convertToYotiAttributesList(
             $protobufAttributesList
         );
         $applicationProfile = new ApplicationProfile($yotiAttributesList);

--- a/tests/ShareUrl/Policy/DynamicPolicyBuilderTest.php
+++ b/tests/ShareUrl/Policy/DynamicPolicyBuilderTest.php
@@ -2,7 +2,9 @@
 
 namespace YotiTest\ShareUrl\Policy;
 
+use Yoti\ShareUrl\Policy\ConstraintsBuilder;
 use Yoti\ShareUrl\Policy\DynamicPolicyBuilder;
+use Yoti\ShareUrl\Policy\SourceConstraintBuilder;
 use Yoti\ShareUrl\Policy\WantedAttributeBuilder;
 use YotiTest\TestCase;
 
@@ -97,6 +99,42 @@ class DynamicPolicyBuilderTest extends TestCase
         ];
 
         $this->assertEquals(json_encode($expectedWantedAttributeData), json_encode($dynamicPolicy));
+    }
+
+    /**
+     * @covers ::withWantedAttribute
+     * @covers ::withFamilyName
+     */
+    public function testWithDuplicateAttributeDifferentConstraints()
+    {
+        $passportConstraints = (new ConstraintsBuilder())
+            ->withSourceConstraint(
+                (new SourceConstraintBuilder())
+                    ->withPassport()
+                    ->build()
+            )
+            ->build();
+
+        $drivingLicenseConstraints = (new ConstraintsBuilder())
+            ->withSourceConstraint(
+                (new SourceConstraintBuilder())
+                    ->withDrivingLicence()
+                    ->build()
+            )
+            ->build();
+
+        $dynamicPolicy = (new DynamicPolicyBuilder())
+            ->withFamilyName()
+            ->withFamilyName($passportConstraints)
+            ->withFamilyName($drivingLicenseConstraints)
+            ->build();
+
+        $jsonData = $dynamicPolicy->jsonSerialize();
+
+        $this->assertCount(3, $jsonData['wanted']);
+        foreach ($jsonData['wanted'] as $wantedAttribute) {
+            $this->assertEquals('family_name', $wantedAttribute->getName());
+        }
     }
 
     /**

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,4 +36,14 @@ class TestCase extends PHPUnit_Framework_TestCase
         $this->assertFileExists(ini_get('error_log'));
         $this->assertContains($str, file_get_contents(ini_get('error_log')));
     }
+
+    /**
+     * Assert value is array.
+     *
+     * @param mixed $value
+     */
+    protected function assertIsArray($value)
+    {
+        $this->assertTrue(is_array($value), 'Value is not an array');
+    }
 }

--- a/tests/Util/Profile/AttributeListConverterTest.php
+++ b/tests/Util/Profile/AttributeListConverterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace YotiTest\Util\Profile;
+
+use Attrpubapi\Attribute;
+use Attrpubapi\AttributeList;
+use Compubapi\EncryptedData;
+use Yoti\Util\Profile\AttributeConverter;
+use Yoti\Util\Profile\AttributeListConverter;
+use YotiTest\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\Util\Profile\AttributeListConverter
+ */
+class AttributeListConverterTest extends TestCase
+{
+    const SOME_NAME = 'some name';
+    const SOME_VALUE = 'some value';
+
+    public function setup()
+    {
+        $someAttribute = $this->createMock(Attribute::class);
+        $someAttribute
+            ->method('getName')
+            ->willReturn(self::SOME_NAME);
+        $someAttribute
+            ->method('getValue')
+            ->willReturn(self::SOME_VALUE);
+        $someAttribute
+            ->method('getContentType')
+            ->willReturn(AttributeConverter::CONTENT_TYPE_STRING);
+        $someAttribute
+            ->method('getAnchors')
+            ->willReturn($this->createMock(\Traversable::class));
+
+        $this->someAttributeList = $this->createMock(AttributeList::class);
+        $this->someAttributeList
+            ->method('getAttributes')
+            ->willReturn([
+                $someAttribute,
+                $this->createMock(Attribute::class),
+            ]);
+    }
+
+    /**
+     * @covers ::convertToYotiAttributesMap
+     */
+    public function testConvertToYotiAttributesMap()
+    {
+        $yotiAttributesList = AttributeListConverter::convertToYotiAttributesMap($this->someAttributeList);
+
+        $this->assertCount(1, $yotiAttributesList);
+        $this->assertEquals(self::SOME_VALUE, $yotiAttributesList[self::SOME_NAME]->getValue());
+    }
+
+    /**
+     * @covers ::convertToYotiAttributesList
+     */
+    public function testConvertToYotiAttributesList()
+    {
+        $yotiAttributesList = AttributeListConverter::convertToYotiAttributesList($this->someAttributeList);
+
+        $this->assertCount(1, $yotiAttributesList);
+        $this->assertEquals(self::SOME_VALUE, $yotiAttributesList[0]->getValue());
+    }
+
+    /**
+     * @covers ::convertToProtobufAttributeList
+     * @covers ::decryptCipherText
+     */
+    public function testConvertToProtobufAttributeList()
+    {
+        $receiptArr = json_decode(file_get_contents(RECEIPT_JSON), true)['receipt'];
+
+        $encryptedData = new EncryptedData();
+        $encryptedData->mergeFromString(base64_decode($receiptArr['profile_content']));
+
+        $protoAttributeList = AttributeListConverter::convertToProtobufAttributeList(
+            $encryptedData,
+            $receiptArr['wrapped_receipt_key'],
+            file_get_contents(PEM_FILE)
+        );
+
+        $this->assertInstanceOf(AttributeList::class, $protoAttributeList);
+        $this->assertCount(4, $protoAttributeList->getAttributes());
+    }
+}


### PR DESCRIPTION
### Added
- `\Yoti\Entity\BaseProfile`
  - `::getAttributesByName()` - returns `\Yoti\Entity\Attribute[]`
  - `::getAttributesList()` - returns `\Yoti\Entity\Attribute[]`
     > Note: `::getAttributes()` - continues to return `\Yoti\Entity\Attribute[]` map keyed by attribute name.
- `\Yoti\Util\Profile\AttributeListConverter`
  - `::convertToYotiAttributesList()` - Converts Protobuf AttributeList to array of Yoti Attributes.

### Deprecated
- `\Yoti\Entity\BaseProfile::getAttributes()`
  > Replaced by `::getAttributesList()`
- `\Yoti\Entity\Profile::ATTR_AGE_VERIFICATIONS`
  > Age verifications are no longer appended to attributes list.
- `\Yoti\Util\Profile\AttributeListConverter::convertToYotiAttributesMap()`
  > Replaced by `::convertToYotiAttributesList()`

### Changed
- `\Yoti\Util\Profile\AttributeListConverter::convertToYotiAttributesMap()` will no longer include `null` items (attributes that could not be parsed) &dagger;
- Example project now supports multiple attributes
- Example project now supports new/unknown attributes

> &dagger; Although it's very unlikely that this class would be used outside the SDK, the behaviour has changed slightly in the following way:
> 
> Without `null` array item:
> ```php
> $some_array = ['key 1' => 'value 1'];
> 
> var_dump(isset($some_array['key 2']));
> // Output: bool(false)
> 
> var_dump($some_array['key 2'] === null);
> // Notice: Undefined index: key 2
> // Output: bool(true)
> 
> var_dump(array_key_exists('key 2', $some_array));
> // Output: bool(false)
> ```
> 
> With `null` array item:
> ```php
> $some_array = ['key 1' => 'value 1', 'key 2' => null];
> 
> var_dump(isset($some_array['key 2']));
> // Output: bool(false)
> 
> var_dump($some_array['key 2'] === null);
> // Output: bool(true)
> 
> var_dump(array_key_exists('key 2', $some_array));
> // Output: bool(true)
> ```
> 
> The current implementation requires that the value is always checked it is not `null`, so very unlikely to be a breaking change. There is a chance a notice would be generated if checked using `$some_array['key 2'] === null`