### PR TITLE
SDK-1276: Add headers getter to HTTP response object

### DIFF
--- a/examples/composer.lock
+++ b/examples/composer.lock
@@ -69,7 +69,7 @@
             "dist": {
                 "type": "path",
                 "url": "./sdk",
-                "reference": "18a5d5ecc6d61e97bc9599b78d2eacd216487bb6"
+                "reference": "9d6bc090647b99cf1bcd0c560d6f5c216b674995"
             },
             "require": {
                 "php": ">=5.5.19"
@@ -85,10 +85,7 @@
             "type": "library",
             "extra": {
                 "hooks": {
-                    "pre-commit": [
-                        "composer test",
-                        "composer lint"
-                    ]
+                    "pre-commit": "composer test && composer lint"
                 }
             },
             "autoload": {

--- a/src/Yoti/Http/Curl/RequestHandler.php
+++ b/src/Yoti/Http/Curl/RequestHandler.php
@@ -20,6 +20,22 @@ class RequestHandler implements RequestHandlerInterface
     private $options = [];
 
     /**
+     * Response headers.
+     *
+     * @var array
+     */
+    private $responseHeaders = [];
+
+    /**
+     * Current resourceID.
+     *
+     * Will increment per request.
+     *
+     * @var int
+     */
+    private $resourceCount = 0;
+
+    /**
      * Execute HTTP request.
      *
      * @param Request $request
@@ -36,9 +52,11 @@ class RequestHandler implements RequestHandlerInterface
         }
 
         $ch = curl_init($request->getUrl());
+
         curl_setopt_array($ch, [
             CURLOPT_HTTPHEADER => $headers,
             CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_HEADERFUNCTION => [$this, 'setResponseHeader'],
         ]);
 
         curl_setopt($ch, CURLOPT_CUSTOMREQUEST, $request->getMethod());
@@ -48,24 +66,31 @@ class RequestHandler implements RequestHandlerInterface
             curl_setopt($ch, $option, $value);
         }
 
+        // Set a resource ID unique to this request handler instance.
+        $this->setResourceId($ch);
+
         // Only send payload data for methods that need it.
         if ($request->getPayload()) {
             // Send payload data as a JSON string
             curl_setopt($ch, CURLOPT_POSTFIELDS, $request->getPayload()->getPayloadJSON());
         }
 
-        // Set response data
+        // Get response data.
         $response = curl_exec($ch);
 
-        // Set response code
+        // Get response code.
         $statusCode = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+
+        // Get the response headers.
+        $responseHeadersMap = $this->getResponseHeadersMap($ch);
+        $this->unsetResponseHeaders($ch);
 
         // Check if any related Curl error occurred.
         if ($response === false) {
             $error = curl_error($ch);
         }
 
-        // Close the session
+        // Close the session.
         curl_close($ch);
 
         // Throw if there was an error.
@@ -73,7 +98,106 @@ class RequestHandler implements RequestHandlerInterface
             throw new RequestException($error);
         }
 
-        return new Response($response, $statusCode);
+        return new Response($response, $statusCode, $responseHeadersMap);
+    }
+
+    /**
+     * Get response headers as a map.
+     *
+     * @return string[]
+     */
+    private function getResponseHeadersMap($ch)
+    {
+        $headersMap = [];
+
+        foreach ($this->getResponseHeaders($ch) as $header) {
+            $parts = array_map('trim', explode(':', $header));
+            if (count($parts) === 2) {
+                list($key, $value) = $parts;
+                $headersMap[$key] = $value;
+            }
+        }
+
+        return $headersMap;
+    }
+
+    /**
+     * Unset response headers for provided resource.
+     *
+     * @param resource $ch
+     */
+    private function unsetResponseHeaders($ch)
+    {
+        $resourceId = $this->getResourceId($ch);
+        unset($this->responseHeaders[$resourceId]);
+    }
+
+    /**
+     * Get response headers.
+     *
+     * @param resource $ch
+     *
+     * @return string[]
+     */
+    private function getResponseHeaders($ch)
+    {
+        $resourceId = $this->getResourceId($ch);
+
+        if (isset($this->responseHeaders[$resourceId])) {
+            return $this->responseHeaders[$resourceId];
+        }
+
+        return [];
+    }
+
+    /**
+     * Callback to set response headers.
+     *
+     * @param resource $ch
+     *   cURL handler.
+     * @param string $header
+     *   Response header.
+     *
+     * @return int
+     */
+    private function setResponseHeader($ch, $header)
+    {
+        $chKey = $this->getResourceId($ch);
+
+        // Handle multi-line headers - see RFC2616 section 4.
+        if (isset($this->responseHeaders[$chKey]) && ($header[0] == ' ' || $header[0] == "\t")) {
+            $this->responseHeaders[$chKey][] = array_pop($this->responseHeaders[$chKey]) . ' ' . trim($header);
+        } else {
+            $this->responseHeaders[$chKey][] = trim($header);
+        }
+
+        return strlen($header);
+    }
+
+    /**
+     * Set a resource ID unique to this request handler instance.
+     *
+     * @param resource $ch
+     *
+     * @return int
+     */
+    private function setResourceId($ch)
+    {
+        $resourceId = $this->resourceCount++;
+        curl_setopt($ch, CURLOPT_PRIVATE, $resourceId);
+        return $resourceId;
+    }
+
+    /**
+     * Get resource ID unique to this request handler instance.
+     *
+     * @param resource $ch
+     *
+     * @return int
+     */
+    private function getResourceId($ch)
+    {
+        return curl_getinfo($ch, CURLOPT_PRIVATE);
     }
 
     /**

--- a/src/Yoti/Http/Response.php
+++ b/src/Yoti/Http/Response.php
@@ -2,6 +2,8 @@
 
 namespace Yoti\Http;
 
+use Yoti\Util\Validation;
+
 class Response
 {
     /**
@@ -15,15 +17,24 @@ class Response
     private $statusCode;
 
     /**
+     * @var string[]
+     */
+    private $headers;
+
+    /**
      * @param string $body
      * @param int $statusCode
      */
     public function __construct(
         $body,
-        $statusCode
+        $statusCode,
+        array $headers = []
     ) {
         $this->body = (string) $body;
         $this->statusCode = (int) $statusCode;
+
+        Validation::isArrayOfStrings($headers, 'headers');
+        $this->headers = $headers;
     }
 
     /**
@@ -40,5 +51,13 @@ class Response
     public function getStatusCode()
     {
         return $this->statusCode;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getHeaders()
+    {
+        return $this->headers;
     }
 }

--- a/src/Yoti/Util/Validation.php
+++ b/src/Yoti/Util/Validation.php
@@ -146,6 +146,24 @@ class Validation
 
     /**
      * @param array $values
+     * @param string $name
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function isArrayOfStrings(array $values, $name)
+    {
+        foreach ($values as $value) {
+            if (!is_string($value)) {
+                throw new \InvalidArgumentException(sprintf(
+                    '%s must be array of strings',
+                    $name
+                ));
+            }
+        }
+    }
+
+    /**
+     * @param array $values
      * @param array $types
      * @param string $name
      *

--- a/tests/Http/ResponseTest.php
+++ b/tests/Http/ResponseTest.php
@@ -14,22 +14,14 @@ class ResponseTest extends TestCase
     const SOME_STATUS_CODE = '200';
 
     /**
-     * @var \Yoti\Http\Response
-     */
-    public $response;
-
-    public function setup()
-    {
-        $this->response = new Response(self::SOME_BODY, self::SOME_STATUS_CODE);
-    }
-
-    /**
      * @covers ::__construct
      * @covers ::getBody
      */
     public function testGetBody()
     {
-        $this->assertEquals(self::SOME_BODY, $this->response->getBody());
+        $response = new Response(self::SOME_BODY, self::SOME_STATUS_CODE);
+
+        $this->assertEquals(self::SOME_BODY, $response->getBody());
     }
 
     /**
@@ -38,7 +30,44 @@ class ResponseTest extends TestCase
      */
     public function testGetStatusCode()
     {
-        $this->assertEquals(self::SOME_STATUS_CODE, $this->response->getStatusCode());
-        $this->assertTrue(is_int($this->response->getStatusCode()));
+        $response = new Response(self::SOME_BODY, self::SOME_STATUS_CODE);
+
+        $this->assertEquals(self::SOME_STATUS_CODE, $response->getStatusCode());
+        $this->assertTrue(is_int($response->getStatusCode()));
+    }
+
+    /**
+     * @covers ::__construct
+     * @covers ::getHeaders
+     */
+    public function testGetHeaders()
+    {
+        $expectedHeaders = [
+            'Some-Header' => 'some value',
+            'Some-Other-Header' => 'some other value',
+        ];
+        $response = new Response(self::SOME_BODY, self::SOME_STATUS_CODE, $expectedHeaders);
+
+        $this->assertEquals($expectedHeaders, $response->getHeaders());
+    }
+
+    /**
+     * @covers ::__construct
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage headers must be array of strings
+     */
+    public function testInvalidHeaders()
+    {
+        new Response(self::SOME_BODY, self::SOME_STATUS_CODE, [['invalid header value']]);
+    }
+
+    /**
+     * @covers ::__construct
+     */
+    public function testEmptyHeaders()
+    {
+        $response = new Response(self::SOME_BODY, self::SOME_STATUS_CODE);
+        $this->assertEquals([], $response->getHeaders());
     }
 }

--- a/tests/Util/ValidationTest.php
+++ b/tests/Util/ValidationTest.php
@@ -287,6 +287,27 @@ class ValidationTest extends TestCase
     }
 
     /**
+     * @covers ::isArrayOfStrings
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testIsArrayOfStrings()
+    {
+        Validation::isArrayOfStrings(['', self::SOME_STRING], self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::isArrayOfStrings
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage some_name must be array of strings
+     */
+    public function testIsArrayOfStringsInvalid()
+    {
+        Validation::isArrayOfStrings([1, [], self::SOME_STRING], self::SOME_NAME);
+    }
+
+    /**
      * @covers ::isArrayOfType
      * @covers ::isOneOfType
      *


### PR DESCRIPTION
### Added
- `Yoti\Http\Response::getHeaders()` returns map of response headers
- `Yoti\Util\Validation::isArrayOfStrings()`