### PR TITLE
SDK-1280: Prevent empty wanted attribute name

### DIFF
--- a/src/Yoti/ShareUrl/Policy/WantedAttribute.php
+++ b/src/Yoti/ShareUrl/Policy/WantedAttribute.php
@@ -37,7 +37,7 @@ class WantedAttribute implements \JsonSerializable
      */
     public function __construct($name, $derivation = null, $acceptSelfAsserted = null, Constraints $constraints = null)
     {
-        Validation::isString($name, 'name');
+        Validation::notEmptyString($name, 'name');
         $this->name = $name;
 
         if ($derivation !== null) {

--- a/src/Yoti/Util/Validation.php
+++ b/src/Yoti/Util/Validation.php
@@ -83,6 +83,20 @@ class Validation
     }
 
     /**
+     * @param mixed $value
+     * @param string $name
+     *
+     * @throws \InvalidArgumentException
+     */
+    public static function notEmptyString($value, $name)
+    {
+        Validation::isString($value, $name);
+        if (strlen($value) === 0) {
+            throw new \InvalidArgumentException("{$name} cannot be empty");
+        }
+    }
+
+    /**
      * @param int|float $value
      * @param int|float $limit
      * @param string $name

--- a/tests/ShareUrl/Policy/WantedAttributeBuilderTest.php
+++ b/tests/ShareUrl/Policy/WantedAttributeBuilderTest.php
@@ -43,7 +43,36 @@ class WantedAttributeBuilderTest extends TestCase
     }
 
     /**
+     * @covers ::build
+     * @covers ::withName
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage name cannot be empty
+     */
+    public function testEmptyName()
+    {
+        (new WantedAttributeBuilder())
+            ->withName('')
+            ->build();
+    }
+
+    /**
+     * @covers ::build
+     * @covers ::withName
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage name must be a string
+     */
+    public function testNonStringName()
+    {
+        (new WantedAttributeBuilder())
+            ->withName(['some array'])
+            ->build();
+    }
+
+    /**
      * @covers ::withAcceptSelfAsserted
+     * @covers \Yoti\ShareUrl\Policy\WantedAttribute::__construct
      * @covers \Yoti\ShareUrl\Policy\WantedAttribute::jsonSerialize
      * @covers \Yoti\ShareUrl\Policy\WantedAttribute::getAcceptSelfAsserted
      */
@@ -76,6 +105,7 @@ class WantedAttributeBuilderTest extends TestCase
 
     /**
      * @covers ::withAcceptSelfAsserted
+     * @covers \Yoti\ShareUrl\Policy\WantedAttribute::__construct
      * @covers \Yoti\ShareUrl\Policy\WantedAttribute::jsonSerialize
      * @covers \Yoti\ShareUrl\Policy\WantedAttribute::getAcceptSelfAsserted
      */

--- a/tests/Util/ValidationTest.php
+++ b/tests/Util/ValidationTest.php
@@ -28,10 +28,12 @@ class ValidationTest extends TestCase
      *
      * @expectedException \InvalidArgumentException
      * @expectedExceptionMessage some_name must be a string
+     *
+     * @dataProvider nonStringDataProvider
      */
-    public function testIsStringInvalid()
+    public function testIsStringInvalid($nonStringValue)
     {
-        Validation::isString(['some array'], self::SOME_NAME);
+        Validation::isString($nonStringValue, self::SOME_NAME);
     }
 
     /**
@@ -323,5 +325,54 @@ class ValidationTest extends TestCase
             \DateTime::class,
         ];
         Validation::isArrayOfType($arrayOfTypes, $allowedTypes, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::notEmptyString
+     *
+     * @doesNotPerformAssertions
+     */
+    public function testNotEmptyString()
+    {
+        Validation::notEmptyString(self::SOME_STRING, self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::notEmptyString
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage some_name cannot be empty
+     */
+    public function testNotEmptyStringWithEmptyValue()
+    {
+        Validation::notEmptyString('', self::SOME_NAME);
+    }
+
+    /**
+     * @covers ::notEmptyString
+     *
+     * @expectedException \InvalidArgumentException
+     * @expectedExceptionMessage some_name must be a string
+     *
+     * @dataProvider nonStringDataProvider
+     */
+    public function testNotEmptyStringWithNonStringValue($nonStringValue)
+    {
+        Validation::notEmptyString($nonStringValue, self::SOME_NAME);
+    }
+
+    /**
+     * Provides non-string values.
+     */
+    public function nonStringDataProvider()
+    {
+        return [
+            [ [] ],
+            [ false ],
+            [ true ],
+            [ 1 ],
+            [ 0 ],
+            [ (object)[] ],
+        ];
     }
 }


### PR DESCRIPTION
### Fixed
- Preventing empty wanted attribute name

### Added
- `Validation::notEmptyString()`