### PR TITLE
SDK-1304: PHP 7.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ jobs:
     - <<: *compatibility
       php: "7.2"
     - <<: *compatibility
-      php: "7.1"
+      php: "7.4snapshot"
     - <<: *test
       stage: Coverage
       name: Coveralls

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
   },
   "require-dev": {
     "php": ">=5.6.0",
-    "phpunit/phpunit": "^5.7",
+    "phpunit/phpunit": "^5.7 || ^7.5",
     "squizlabs/php_codesniffer": "^3.4",
     "friendsofphp/php-cs-fixer": "^2.15",
     "brainmaestro/composer-git-hooks": "^2.8",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -4,8 +4,7 @@
          convertNoticesToExceptions="false"
          convertWarningsToExceptions="false"
          bootstrap="tests/bootstrap.php"
-         stopOnFailure="false"
-         syntaxCheck="true">
+         stopOnFailure="false">
     <testsuites>
         <testsuite name="Yoti Test Suite">
             <directory>tests/</directory>

--- a/tests/Http/Curl/RequestHandlerTest.php
+++ b/tests/Http/Curl/RequestHandlerTest.php
@@ -159,7 +159,7 @@ class RequestHandlerTest extends TestCase
             ->expects($this->any())
             ->method('curl_setopt')
             ->withConsecutive(
-                $this->any(),
+                [$this->someCurlResource, CURLOPT_CUSTOMREQUEST],
                 [$this->someCurlResource, CURLOPT_VERBOSE, true]
             );
 
@@ -229,13 +229,19 @@ class RequestHandlerTest extends TestCase
             ->expects($this->any())
             ->method('curl_setopt')
             ->withConsecutive(
-                $this->any(),
+                [
+                    $this->someCurlResource,
+                    CURLOPT_CUSTOMREQUEST
+                ],
                 [
                     $this->someCurlResource,
                     CURLOPT_HEADERFUNCTION,
                     $this->curlHeadersCallback($someHeaders),
                 ],
-                $this->any(),
+                [
+                    $this->someCurlResource,
+                    CURLOPT_CUSTOMREQUEST
+                ],
                 [
                     $this->someCurlResource,
                     CURLOPT_HEADERFUNCTION,

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,9 +2,7 @@
 
 namespace YotiTest;
 
-use PHPUnit_Framework_TestCase;
-
-class TestCase extends PHPUnit_Framework_TestCase
+class TestCase extends \PHPUnit_Framework_TestCase
 {
     /**
      * Restores ini settings after tests run.

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -6,3 +6,14 @@
 
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/config.php';
+
+/**
+ * Disable deprecated-to-exception conversion in PHP 7.4
+ *
+ * PHPUnit 5.7 is needed whilst we support PHP 5.6, but
+ * uses ReflectionType::__toString(), which will throw
+ * an exception as of PHP 7.4
+ */
+if (version_compare(PHP_VERSION, '7.4.0', '>=')) {
+    PHPUnit_Framework_Error_Deprecated::$enabled = false;
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -7,13 +7,12 @@
 require_once __DIR__ . '/../vendor/autoload.php';
 require_once __DIR__ . '/config.php';
 
+
 /**
- * Disable deprecated-to-exception conversion in PHP 7.4
- *
- * PHPUnit 5.7 is needed whilst we support PHP 5.6, but
- * uses ReflectionType::__toString(), which will throw
- * an exception as of PHP 7.4
+ * Allow tests to run with:
+ * - PHPUnit 5 for PHP 5.6
+ * - PHPUnit 7 for PHP 7
  */
-if (version_compare(PHP_VERSION, '7.4.0', '>=')) {
-    PHPUnit_Framework_Error_Deprecated::$enabled = false;
+if (!class_exists('\PHPUnit_Framework_TestCase')) {
+    class_alias(\PHPUnit\Framework\TestCase::class, '\PHPUnit_Framework_TestCase');
 }


### PR DESCRIPTION
### Added
- Travis now runs tests with _PHP 7.4_

### Removed
- Travis no longer runs tests with _PHP 7.1_

### Changed
- PHPUnit dev requirement is now `"^5.7 || ^7.5"` ( _PHP 7_ will use `^7.5`)
  > Added class alias to support both PHPUnit versions
