### PR TITLE
SDK-1245: Implement JsonSerializable

### DIFF
--- a/src/Entity/AmlAddress.php
+++ b/src/Entity/AmlAddress.php
@@ -2,7 +2,7 @@
 
 namespace Yoti\Entity;
 
-class AmlAddress
+class AmlAddress implements \JsonSerializable
 {
     const POSTCODE_ATTR = 'post_code';
     const COUNTRY_ATTR = 'country';
@@ -66,7 +66,7 @@ class AmlAddress
      *
      * @return array
      */
-    public function getData()
+    public function jsonSerialize()
     {
         return [
             self::POSTCODE_ATTR => $this->postcode,
@@ -79,6 +79,6 @@ class AmlAddress
      */
     public function __toString()
     {
-        return json_encode($this->getData());
+        return json_encode($this);
     }
 }

--- a/src/Entity/AmlProfile.php
+++ b/src/Entity/AmlProfile.php
@@ -2,7 +2,7 @@
 
 namespace Yoti\Entity;
 
-class AmlProfile
+class AmlProfile implements \JsonSerializable
 {
     const GIVEN_NAMES_ATTR  = 'given_names';
     const FAMILY_NAME_ATTR  = 'family_name';
@@ -122,13 +122,13 @@ class AmlProfile
      *
      * @return array
      */
-    public function getData()
+    public function jsonSerialize()
     {
         return [
             self::GIVEN_NAMES_ATTR  => $this->givenNames,
             self::FAMILY_NAME_ATTR  => $this->familyName,
             self::SSN_ATTR => $this->ssn,
-            self::ADDRESS_ATTR => $this->amlAddress->getData(),
+            self::ADDRESS_ATTR => $this->amlAddress,
         ];
     }
 
@@ -137,6 +137,6 @@ class AmlProfile
      */
     public function __toString()
     {
-        return json_encode($this->getData());
+        return json_encode($this);
     }
 }

--- a/src/YotiClient.php
+++ b/src/YotiClient.php
@@ -165,7 +165,7 @@ class YotiClient
     public function performAmlCheck(AmlProfile $amlProfile)
     {
         // Get payload data from amlProfile
-        $amlPayload = new Payload($amlProfile->getData());
+        $amlPayload = new Payload($amlProfile);
 
         $response = $this->sendRequest(
             self::AML_CHECK_ENDPOINT,

--- a/tests/Entity/AmlAddressTest.php
+++ b/tests/Entity/AmlAddressTest.php
@@ -64,10 +64,10 @@ class AmlAddressTest extends TestCase
     }
 
     /**
-     * @covers ::getData
+     * @covers ::jsonSerialize
      * @covers ::__toString
      */
-    public function testGetData()
+    public function testJsonSerialize()
     {
         $someCountry = $this->createMock(Country::class);
         $someCountry
@@ -81,7 +81,8 @@ class AmlAddressTest extends TestCase
             'country' => self::SOME_COUNTRY_CODE,
         ];
 
-        $this->assertEquals($expectedData, $amlAddress->getData());
+        $this->assertEquals($expectedData, $amlAddress->jsonSerialize());
+        $this->assertEquals(json_encode($expectedData), json_encode($amlAddress));
         $this->assertEquals(json_encode($expectedData), (string) $amlAddress);
     }
 }

--- a/tests/Entity/AmlProfileTest.php
+++ b/tests/Entity/AmlProfileTest.php
@@ -130,10 +130,10 @@ class AmlProfileTest extends TestCase
 
     /**
      * @covers ::__construct
-     * @covers ::getData
+     * @covers ::jsonSerialize
      * @covers ::__toString
      */
-    public function testGetData()
+    public function testJsonSerialize()
     {
         $expectedData = [
             'given_names' => self::SOME_GIVEN_NAMES,
@@ -145,7 +145,7 @@ class AmlProfileTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expectedData, $this->amlProfile->getData());
+        $this->assertEquals(json_encode($expectedData), json_encode($this->amlProfile));
         $this->assertEquals(json_encode($expectedData), (string) $this->amlProfile);
     }
 }

--- a/tests/Http/CurlRequestHandlerTest.php
+++ b/tests/Http/CurlRequestHandlerTest.php
@@ -42,7 +42,7 @@ class CurlRequestHandlerTest extends TestCase
         $endpoint = '/aml-check';
         $amlAddress = new AmlAddress(new Country('GBR'));
         $amlProfile = new AmlProfile('Edward Richard George', 'Heath', $amlAddress);
-        $this->payload = new Payload($amlProfile->getData());
+        $this->payload = new Payload($amlProfile);
         $this->pem = file_get_contents(PEM_FILE);
 
         $this->requestSigner = new RequestSigner(

--- a/tests/Http/PayloadTest.php
+++ b/tests/Http/PayloadTest.php
@@ -32,7 +32,7 @@ class PayloadTest extends TestCase
     {
         $amlAddress = new AmlAddress(new Country('GBR'));
         $amlProfile = new AmlProfile('Edward Richard George', 'Heath', $amlAddress);
-        $this->payload = new Payload($amlProfile->getData());
+        $this->payload = new Payload($amlProfile);
 
         // Expected test data
         $this->payloadJSON = '{"given_names":"Edward Richard George","family_name":"Heath",' .

--- a/tests/Http/RequestSignerTest.php
+++ b/tests/Http/RequestSignerTest.php
@@ -105,6 +105,6 @@ class RequestSignerTest extends TestCase
     {
         $amlAddress = new AmlAddress(new Country('GBR'));
         $amlProfile = new AmlProfile('Edward Richard George', 'Heath', $amlAddress);
-        return new Payload($amlProfile->getData());
+        return new Payload($amlProfile);
     }
 }


### PR DESCRIPTION
### Changed
- `\Yoti\Entity\AmlProfile` now implements `\JsonSerializable`
- `\Yoti\Entity\AmlAddress` now implements `\JsonSerializable`

### Removed
- `\Yoti\Entity\AmlProfile::getData()`
- `\Yoti\Entity\AmlAddress::getData()`

> Note: `Yoti\Http\Payload` hasn't been updated to implement `\JsonSerializable` as this will be replaced with [PSR-7 implementation](https://www.php-fig.org/psr/psr-7/#34-psrhttpmessagestreaminterface)