### PR TITLE
SDK-1304: PHP 7.4 stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ jobs:
   include:
     - &test
       stage: Test
-      php: "7.3"
+      php: "7.4"
       os: linux
       install:
         - travis_retry composer self-update
@@ -22,7 +22,7 @@ jobs:
     - <<: *compatibility
       php: "7.2"
     - <<: *compatibility
-      php: "7.4snapshot"
+      php: "7.3"
     - <<: *test
       stage: Coverage
       name: Coveralls


### PR DESCRIPTION
> PHP 7.4 stable was made available since #103: https://changelog.travis-ci.com/php-7-4-is-available-for-linux-builds-129656

### Changed
- Default test stage uses _PHP 7.4_
