### PR TITLE
SDK-988: Uppercase anchor type

### DIFF
--- a/src/Entity/Anchor.php
+++ b/src/Entity/Anchor.php
@@ -13,8 +13,8 @@ namespace Yoti\Entity;
  */
 class Anchor
 {
-    const TYPE_SOURCE_NAME = 'Source';
-    const TYPE_VERIFIER_NAME = 'Verifier';
+    const TYPE_SOURCE_NAME = 'SOURCE';
+    const TYPE_VERIFIER_NAME = 'VERIFIER';
     const TYPE_UNKNOWN_NAME = 'UNKNOWN';
     const TYPE_SOURCE_OID = '1.3.6.1.4.1.47127.1.1.1';
     const TYPE_VERIFIER_OID = '1.3.6.1.4.1.47127.1.1.2';

--- a/tests/Util/Profile/AnchorConverterTest.php
+++ b/tests/Util/Profile/AnchorConverterTest.php
@@ -24,7 +24,7 @@ class AnchorConverterTest extends TestCase
     {
         $anchor = $this->parseFromBase64String(TestAnchors::SOURCE_PP_ANCHOR);
 
-        $this->assertEquals('Source', $anchor->getType());
+        $this->assertEquals('SOURCE', $anchor->getType());
         $this->assertEquals('OCR', $anchor->getSubtype());
         $this->assertEquals(
             '2018-04-12 13:14:32.835537',
@@ -49,7 +49,7 @@ class AnchorConverterTest extends TestCase
     {
         $anchor = $this->parseFromBase64String(TestAnchors::VERIFIER_YOTI_ADMIN_ANCHOR);
 
-        $this->assertEquals('Verifier', $anchor->getType());
+        $this->assertEquals('VERIFIER', $anchor->getType());
         $this->assertEquals('', $anchor->getSubtype());
         $this->assertEquals(
             '2018-04-11 12:13:04.095238',

--- a/tests/Util/Profile/AnchorListConverterTest.php
+++ b/tests/Util/Profile/AnchorListConverterTest.php
@@ -41,11 +41,11 @@ class AnchorListConverterTest extends TestCase
         ]));
 
         $anchorSource = $anchorsData[Anchor::TYPE_SOURCE_OID][0];
-        $this->assertEquals('Source', $anchorSource->getType());
+        $this->assertEquals('SOURCE', $anchorSource->getType());
         $this->assertEquals('DRIVING_LICENCE', $anchorSource->getValue());
 
         $anchorVerifier = $anchorsData[Anchor::TYPE_VERIFIER_OID][0];
-        $this->assertEquals('Verifier', $anchorVerifier->getType());
+        $this->assertEquals('VERIFIER', $anchorVerifier->getType());
         $this->assertEquals('YOTI_ADMIN', $anchorVerifier->getValue());
 
         $anchorUnknown = $anchorsData[Anchor::TYPE_UNKNOWN_NAME][0];


### PR DESCRIPTION
### Changed
- Anchor type is now uppercase `SOURCE`/`VERIFIER`