### PR TITLE
SDK-1345: Remove plugin name validation

### DIFF
--- a/src/Http/RequestBuilder.php
+++ b/src/Http/RequestBuilder.php
@@ -11,18 +11,6 @@ use Yoti\Util\Validation;
 
 class RequestBuilder
 {
-    /**
-     * Accepted HTTP header values for X-Yoti-SDK-Integration header.
-     *
-     * @var array
-     */
-    private $acceptedsdkIdentifiers = [
-        'PHP',
-        'WordPress',
-        'Drupal',
-        'Joomla',
-    ];
-
     /** Digest HTTP header key. */
     const YOTI_DIGEST_HEADER_KEY = 'X-Yoti-Auth-Digest';
 
@@ -196,13 +184,7 @@ class RequestBuilder
      */
     public function withSdkIdentifier($sdkIdentifier)
     {
-        if (!in_array($sdkIdentifier, $this->acceptedsdkIdentifiers, true)) {
-            throw new \InvalidArgumentException(sprintf(
-                "'%s' is not in the list of accepted identifiers: %s",
-                $sdkIdentifier,
-                implode(', ', $this->acceptedsdkIdentifiers)
-            ));
-        }
+        Validation::isString($sdkIdentifier, 'SDK identifier');
         $this->sdkIdentifier = $sdkIdentifier;
         return $this;
     }

--- a/src/YotiClient.php
+++ b/src/YotiClient.php
@@ -91,8 +91,6 @@ class YotiClient
      *   PEM file path or string
      * @param string $connectApi (optional)
      *   Connect API address
-     * @param string $sdkIdentifier (optional)
-     *   SDK or Plugin identifier - deprecated - use ::setSdkIdentifier() instead.
      *
      * @throws \Yoti\Exception\RequestException
      * @throws \Yoti\Exception\YotiClientException
@@ -100,18 +98,13 @@ class YotiClient
     public function __construct(
         $sdkId,
         $pem,
-        $connectApi = self::DEFAULT_CONNECT_API,
-        $sdkIdentifier = null
+        $connectApi = self::DEFAULT_CONNECT_API
     ) {
         $this->checkRequiredModules();
         $this->extractPemContent($pem);
         $this->setSdkId($sdkId);
 
         $this->connectApi = $connectApi;
-
-        if (isset($sdkIdentifier)) {
-            $this->sdkIdentifier = $sdkIdentifier;
-        }
     }
 
     /**

--- a/tests/Http/RequestBuilderTest.php
+++ b/tests/Http/RequestBuilderTest.php
@@ -142,14 +142,14 @@ class RequestBuilderTest extends TestCase
      * @covers ::withSdkIdentifier
      *
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage 'Invalid' is not in the list of accepted identifiers: PHP, WordPress, Drupal, Joomla
+     * @expectedExceptionMessage SDK identifier must be a string
      */
     public function testBuildWithInvalidSdkIdentifier()
     {
         (new RequestBuilder())
           ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(PEM_FILE)
-          ->withSdkIdentifier('Invalid')
+          ->withSdkIdentifier(['Invalid'])
           ->build();
     }
 

--- a/tests/YotiClientTest.php
+++ b/tests/YotiClientTest.php
@@ -303,30 +303,10 @@ class YotiClientTest extends TestCase
     /**
      * Test invalid http header value for X-Yoti-SDK
      *
-     * @covers ::__construct
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage 'Invalid' is not in the list of accepted identifiers: PHP, WordPress, Drupal, Joomla
-     */
-    public function testInvalidSdkIdentifierConstructor()
-    {
-        $yotiClient = new YotiClient(
-            SDK_ID,
-            $this->pem,
-            YotiClient::DEFAULT_CONNECT_API,
-            'Invalid'
-        );
-        $amlProfile = $this->createMock(AmlProfile::class);
-        $yotiClient->performAmlCheck($amlProfile);
-    }
-
-    /**
-     * Test invalid http header value for X-Yoti-SDK
-     *
      * @covers ::setSdkIdentifier
      *
      * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage 'Invalid' is not in the list of accepted identifiers: PHP, WordPress, Drupal, Joomla
+     * @expectedExceptionMessage SDK identifier must be a string
      */
     public function testInvalidSdkIdentifier()
     {
@@ -335,7 +315,7 @@ class YotiClientTest extends TestCase
             $this->pem,
             YotiClient::DEFAULT_CONNECT_API
         );
-        $yotiClient->setSdkIdentifier('Invalid');
+        $yotiClient->setSdkIdentifier(['Invalid']);
 
         $amlProfile = $this->createMock(AmlProfile::class);
         $yotiClient->performAmlCheck($amlProfile);


### PR DESCRIPTION
### Removed
- Hard-coded plugin name validation (now only checks that the provided plugin name is a string)