### PR TITLE
SDK-1364: Fully support RFC3339 date format

### DIFF
--- a/src/Yoti/ActivityDetails.php
+++ b/src/Yoti/ActivityDetails.php
@@ -7,7 +7,7 @@ use Yoti\Entity\Receipt;
 use Attrpubapi\AttributeList;
 use Yoti\Entity\ApplicationProfile;
 use Yoti\Util\Age\AgeVerificationConverter;
-use Yoti\Util\Profile\AttributeConverter;
+use Yoti\Util\DateTime;
 use Yoti\Util\Profile\AttributeListConverter;
 
 /**
@@ -91,7 +91,7 @@ class ActivityDetails
     {
         try {
             $timestamp = $this->receipt->getTimestamp();
-            $this->timestamp = AttributeConverter::convertTimestampToDate($timestamp);
+            $this->timestamp = DateTime::stringToDateTime($timestamp);
         } catch (\Exception $e) {
             $this->timestamp = null;
             error_log("Warning: {$e->getMessage()}", 0);

--- a/src/Yoti/Exception/DateTimeException.php
+++ b/src/Yoti/Exception/DateTimeException.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Yoti\Exception;
+
+class DateTimeException extends \Exception
+{
+}

--- a/src/Yoti/ShareUrl/Extension/ThirdPartyAttributeContent.php
+++ b/src/Yoti/ShareUrl/Extension/ThirdPartyAttributeContent.php
@@ -3,7 +3,7 @@
 namespace Yoti\ShareUrl\Extension;
 
 use Yoti\Entity\AttributeDefinition;
-use Yoti\Util\Constants;
+use Yoti\Util\DateTime;
 use Yoti\Util\Validation;
 
 /**
@@ -43,7 +43,7 @@ class ThirdPartyAttributeContent implements \JsonSerializable
         return [
             'expiry_date' => $this->expiryDate
                 ->setTimezone(new \DateTimeZone('UTC'))
-                ->format(Constants::DATE_FORMAT_RFC3339),
+                ->format(DateTime::RFC3339),
             'definitions' => $this->definitions,
         ];
     }

--- a/src/Yoti/Util/Constants.php
+++ b/src/Yoti/Util/Constants.php
@@ -7,8 +7,7 @@ class Constants
     /**
      * RFC3339 format with microseconds.
      *
-     * This will be replaced by \DateTime::RFC3339_EXTENDED
-     * once PHP 5.6 is no longer supported.
+     * @deprecated 3.0.0 Replaced by \Yoti\Util\DateTime::RFC3339
      */
-    const DATE_FORMAT_RFC3339 = 'Y-m-d\TH:i:s.uP';
+    const DATE_FORMAT_RFC3339 = DateTime::RFC3339;
 }

--- a/src/Yoti/Util/DateTime.php
+++ b/src/Yoti/Util/DateTime.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Yoti\Util;
+
+class DateTime
+{
+    /**
+     * RFC3339 format with microseconds.
+     */
+    const RFC3339 = 'Y-m-d\TH:i:s.uP';
+
+    /**
+     * @param $value
+     *
+     * @return \DateTime
+     */
+    public static function stringToDateTime($value)
+    {
+        Validation::notEmptyString($value, 'value');
+
+        return new \DateTime(
+            $value,
+            new \DateTimeZone("UTC")
+        );
+    }
+}

--- a/src/Yoti/Util/DateTime.php
+++ b/src/Yoti/Util/DateTime.php
@@ -2,6 +2,8 @@
 
 namespace Yoti\Util;
 
+use Yoti\Exception\DateTimeException;
+
 class DateTime
 {
     /**
@@ -18,9 +20,13 @@ class DateTime
     {
         Validation::notEmptyString($value, 'value');
 
-        return new \DateTime(
-            $value,
-            new \DateTimeZone("UTC")
-        );
+        try {
+            return new \DateTime(
+                $value,
+                new \DateTimeZone("UTC")
+            );
+        } catch (\Exception $e) {
+            throw new DateTimeException('Could not parse string to DateTime', null, $e);
+        }
     }
 }

--- a/src/Yoti/Util/ExtraData/ThirdPartyAttributeConverter.php
+++ b/src/Yoti/Util/ExtraData/ThirdPartyAttributeConverter.php
@@ -5,9 +5,9 @@ namespace Yoti\Util\ExtraData;
 use Yoti\Entity\AttributeDefinition;
 use Yoti\Entity\AttributeIssuanceDetails;
 use Yoti\Exception\ExtraDataException;
-use Yoti\Util\Constants;
 use Sharepubapi\IssuingAttributes;
 use Sharepubapi\ThirdPartyAttribute as ThirdPartyAttributeProto;
+use Yoti\Util\DateTime;
 
 class ThirdPartyAttributeConverter
 {
@@ -28,15 +28,9 @@ class ThirdPartyAttributeConverter
         $issuingAttributesProto = $thirdPartyAttributeProto->getIssuingAttributes();
 
         if ($issuingAttributesProto instanceof IssuingAttributes) {
-            $parsedDateTime = \DateTime::createFromFormat(
-                Constants::DATE_FORMAT_RFC3339,
-                $issuingAttributesProto->getExpiryDate(),
-                new \DateTimeZone("UTC")
-            );
-
-            if ($parsedDateTime !== false) {
-                $expiryDate = $parsedDateTime;
-            } else {
+            try {
+                $expiryDate = DateTime::stringToDateTime($issuingAttributesProto->getExpiryDate());
+            } catch (\Exception $e) {
                 error_log("Failed to parse expiry date from ThirdPartyAttribute", 0);
             }
 

--- a/src/Yoti/Util/Profile/AttributeConverter.php
+++ b/src/Yoti/Util/Profile/AttributeConverter.php
@@ -11,6 +11,7 @@ use Compubapi\EncryptedData;
 use Yoti\Exception\AttributeException;
 use Yoti\Entity\MultiValue;
 use Yoti\Entity\ApplicationProfile;
+use Yoti\Util\DateTime;
 
 class AttributeConverter
 {
@@ -205,12 +206,14 @@ class AttributeConverter
     }
 
     /**
+     * @deprecated 3.0.0 Replaced by \Yoti\Util\DateTime::stringToDateTime
+     *
      * @param $value
      *
      * @return \DateTime
      */
     public static function convertTimestampToDate($value)
     {
-        return (new \DateTime())->setTimestamp(strtotime($value));
+        return DateTime::stringToDateTime($value);
     }
 }

--- a/tests/Util/DateTimeTest.php
+++ b/tests/Util/DateTimeTest.php
@@ -47,8 +47,8 @@ class DateTimeTest extends TestCase
     /**
      * @covers ::stringToDateTime
      *
-     * @expectedException \Exception
-     * @expectedExceptionMessage Failed to parse time string (some-invalid-date)
+     * @expectedException \Yoti\Exception\DateTimeException
+     * @expectedExceptionMessage Could not parse string to DateTime
      */
     public function testInvalidTimestamp()
     {

--- a/tests/Util/DateTimeTest.php
+++ b/tests/Util/DateTimeTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace YotiTest\Util;
+
+use YotiTest\TestCase;
+use Yoti\Util\DateTime;
+
+/**
+ * @coversDefaultClass \Yoti\Util\DateTime
+ */
+class DateTimeTest extends TestCase
+{
+    /**
+     * @covers ::stringToDateTime
+     *
+     * @dataProvider validDateStringProvider
+     */
+    public function testStringToDateTime($timeStampString, $expectedOutput)
+    {
+        $dateTime = DateTime::stringToDateTime($timeStampString);
+
+        $this->assertEquals(
+            $expectedOutput,
+            $dateTime->format(DateTime::RFC3339)
+        );
+    }
+
+    /**
+     * Provides valid dates and their expected RFC3339 representation with microseconds.
+     */
+    public function validDateStringProvider()
+    {
+        return [
+            [ '2006-01-02', '2006-01-02T00:00:00.000000+00:00' ],
+            [ '2006-01-02T22:04:05Z', '2006-01-02T22:04:05.000000+00:00' ],
+            [ '2006-01-02T22:04:05.1Z', '2006-01-02T22:04:05.100000+00:00' ],
+            [ '2006-01-02T22:04:05.12Z', '2006-01-02T22:04:05.120000+00:00' ],
+            [ '2006-01-02T22:04:05.123Z', '2006-01-02T22:04:05.123000+00:00' ],
+            [ '2006-01-02T22:04:05.1234Z', '2006-01-02T22:04:05.123400+00:00' ],
+            [ '2006-01-02T22:04:05.12345Z', '2006-01-02T22:04:05.123450+00:00' ],
+            [ '2006-01-02T22:04:05.123456Z', '2006-01-02T22:04:05.123456+00:00' ],
+            [ '2002-10-02T10:00:00-05:00', '2002-10-02T10:00:00.000000-05:00' ],
+            [ '2002-10-02T10:00:00+11:00', '2002-10-02T10:00:00.000000+11:00' ],
+        ];
+    }
+
+    /**
+     * @covers ::stringToDateTime
+     *
+     * @expectedException \Exception
+     * @expectedExceptionMessage Failed to parse time string (some-invalid-date)
+     */
+    public function testInvalidTimestamp()
+    {
+        DateTime::stringToDateTime('some-invalid-date');
+    }
+
+    /**
+     * @covers ::stringToDateTime
+     *
+     * @expectedException \InvalidArgumentException
+     *
+     * @dataProvider emptyTimestampProvider
+     */
+    public function testEmptyTimestamp($emptyDateString, $exceptionMessage)
+    {
+        $this->expectExceptionMessage($exceptionMessage);
+        DateTime::stringToDateTime($emptyDateString);
+    }
+
+    /**
+     * Provides empty timestamps
+     */
+    public function emptyTimestampProvider()
+    {
+        return [
+            [ null, 'value must be a string' ],
+            [ '', 'value cannot be empty' ],
+        ];
+    }
+}

--- a/tests/Util/ExtraData/ThirdPartyAttributeConverterTest.php
+++ b/tests/Util/ExtraData/ThirdPartyAttributeConverterTest.php
@@ -20,6 +20,7 @@ class ThirdPartyAttributeConverterTest extends TestCase
 
     /**
      * @covers ::convertValue
+     * @covers ::parseToken
      */
     public function testConvertValue()
     {
@@ -116,9 +117,6 @@ class ThirdPartyAttributeConverterTest extends TestCase
             [ '' ],
             [ 1 ],
             [ 'invalid date' ],
-            [ '2019-12-02' ],
-            [ '2019-12-02' ],
-            [ '2019-12-02T12:00:00Z' ],
         ];
     }
 


### PR DESCRIPTION
### Added
- `Yoti\Util\DateTime` used for converting strings to `\DateTime` objects
- `Yoti\Exception\DateTimeException`

### Changed
- `ThirdPartyAttributeConverter::convertValue()` now uses `Yoti\Util\DateTime::stringToDateTime()`, which supports all `RFC3339` date formats

### Deprecated
- `Yoti\Util\Constants::DATE_FORMAT_RFC3339` - replaced by `Yoti\Util\DateTime::RFC3339`
