### PR TITLE
SDK-1313: Upgrade to PHPUnit 8

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,8 @@ composer.lock
 .phpcs.xml
 phpcs.xml
 
+.phpunit.result.cache
+
 logs
 
 coverage

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   "homepage": "https://yoti.com",
   "license": "MIT",
   "require": {
-    "php": ">=5.5.19",
+    "php": "^7.1",
     "google/protobuf": "^3.10",
     "phpseclib/phpseclib": "^2.0",
     "guzzlehttp/guzzle": "^6.4",
@@ -23,9 +23,8 @@
     }
   },
   "require-dev": {
-    "php": ">=5.6.0",
     "ext-json": "*",
-    "phpunit/phpunit": "^5.7 || ^7.5",
+    "phpunit/phpunit": "^7.5 || ^8.5",
     "squizlabs/php_codesniffer": "^3.4",
     "friendsofphp/php-cs-fixer": "^2.15",
     "brainmaestro/composer-git-hooks": "^2.8",

--- a/sandbox/tests/Entity/SandboxAgeVerificationTest.php
+++ b/sandbox/tests/Entity/SandboxAgeVerificationTest.php
@@ -16,7 +16,7 @@ class SandboxAgeVerificationTest extends TestCase
      */
     public $ageVerification;
 
-    public function setUp()
+    public function setup(): void
     {
         $dateTime = (new \DateTime())->setTimestamp(1171502725);
         $this->ageVerification = new SandboxAgeVerification(

--- a/sandbox/tests/Entity/SandboxAnchorTest.php
+++ b/sandbox/tests/Entity/SandboxAnchorTest.php
@@ -15,7 +15,7 @@ class SandboxAnchorTest extends TestCase
      */
     public $anchor;
 
-    public function setUp()
+    public function setup(): void
     {
         $this->anchor = new SandboxAnchor(
             'Source',

--- a/sandbox/tests/Entity/SandboxAttributeTest.php
+++ b/sandbox/tests/Entity/SandboxAttributeTest.php
@@ -16,7 +16,7 @@ class SandboxAttributeTest extends TestCase
      */
     public $attribute;
 
-    public function setUp()
+    public function setup(): void
     {
         $this->attribute = new SandboxAttribute(
             Profile::ATTR_FAMILY_NAME,

--- a/sandbox/tests/Http/SandboxPathManagerTest.php
+++ b/sandbox/tests/Http/SandboxPathManagerTest.php
@@ -20,7 +20,7 @@ class SandboxPathManagerTest extends TestCase
     /**
      * Setup SandboxPathManager
      */
-    public function setup()
+    public function setup(): void
     {
         $this->sandboxPathManager = new SandboxPathManager(
             self::SOME_TOKEN_PATH

--- a/sandbox/tests/Http/TokenRequestBuilderTest.php
+++ b/sandbox/tests/Http/TokenRequestBuilderTest.php
@@ -27,7 +27,7 @@ class TokenRequestBuilderTest extends TestCase
      */
     private $requestBuilder;
 
-    public function setUp()
+    public function setup(): void
     {
         $this->requestBuilder = new TokenRequestBuilder();
     }

--- a/sandbox/tests/Http/TokenRequestTest.php
+++ b/sandbox/tests/Http/TokenRequestTest.php
@@ -28,7 +28,7 @@ class TokenRequestTest extends TestCase
     /**
      * Setup TokenRequest
      */
-    public function setUp()
+    public function setup(): void
     {
         $this->someSandboxAttributes = [
             [

--- a/sandbox/tests/Http/TokenResponseTest.php
+++ b/sandbox/tests/Http/TokenResponseTest.php
@@ -41,12 +41,11 @@ class TokenResponseTest extends TestCase
      * @covers ::__construct
      * @covers ::processData
      * @covers ::checkJsonError
-     *
-     * @expectedException \YotiSandbox\Exception\ResponseException
-     * @expectedExceptionMessage Token key is missing
      */
     public function testGetTokenEmpty()
     {
+        $this->expectException(\YotiSandbox\Exception\ResponseException::class, 'Token key is missing');
+
         $someResponse = $this->createMock(ResponseInterface::class);
         $someResponse->method('getStatusCode')->willReturn(201);
         $someResponse->method('getBody')->willReturn('{}');
@@ -56,12 +55,11 @@ class TokenResponseTest extends TestCase
 
     /**
      * @covers ::checkResponseStatus
-     *
-     * @expectedException \YotiSandbox\Exception\ResponseException
-     * @expectedExceptionMessage Server responded with 500
      */
     public function testBadResponseStatusCode()
     {
+        $this->expectException(\YotiSandbox\Exception\ResponseException::class, 'Server responded with 500');
+
         $someResponse = $this->createMock(ResponseInterface::class);
         $someResponse->method('getStatusCode')->willReturn(500);
         $someResponse->method('getBody')->willReturn('{}');
@@ -71,12 +69,11 @@ class TokenResponseTest extends TestCase
 
     /**
      * @covers ::checkJsonError
-     *
-     * @expectedException \YotiSandbox\Exception\ResponseException
-     * @expectedExceptionMessage JSON response was invalid
      */
     public function testInvalidJson()
     {
+        $this->expectException(\YotiSandbox\Exception\ResponseException::class, 'JSON response was invalid');
+
         $someResponse = $this->createMock(ResponseInterface::class);
         $someResponse->method('getStatusCode')->willReturn(201);
         $someResponse->method('getBody')->willReturn('invalid json');

--- a/tests/Aml/ProfileTest.php
+++ b/tests/Aml/ProfileTest.php
@@ -36,7 +36,7 @@ class ProfileTest extends TestCase
     /**
      * Create test Aml Profile.
      */
-    public function setup()
+    public function setup(): void
     {
         $this->country = new Country(self::SOME_COUNTRY_CODE);
         $this->amlAddress = new Address($this->country, self::SOME_POSTCODE);

--- a/tests/Aml/ResultTest.php
+++ b/tests/Aml/ResultTest.php
@@ -17,7 +17,7 @@ class ResultTest extends TestCase
      */
     public $amlResult;
 
-    public function setup()
+    public function setup(): void
     {
         $this->amlResult = new Result(Json::decode(file_get_contents(TestData::AML_CHECK_RESULT_JSON)));
     }
@@ -56,11 +56,14 @@ class ResultTest extends TestCase
     }
 
     /**
-     * @expectedException \Yoti\Exception\AmlException
-     * @expectedExceptionMessage Missing attributes from the result: on_pep_list,on_watch_list,on_watch_list
      */
     public function testMissingAttributes()
     {
+        $this->expectException(
+            \Yoti\Exception\AmlException::class,
+            'Missing attributes from the result: on_pep_list,on_watch_list,on_watch_list'
+        );
+
         new Result([]);
     }
 

--- a/tests/Aml/ServiceTest.php
+++ b/tests/Aml/ServiceTest.php
@@ -77,11 +77,11 @@ class ServiceTest extends TestCase
      * @covers ::getErrorMessage
      *
      * @dataProvider httpErrorStatusCodeProvider
-     *
-     * @expectedException \Yoti\Exception\AmlException
      */
     public function testPerformAmlCheckFailure($statusCode)
     {
+        $this->expectException(\Yoti\Exception\AmlException::class);
+
         $this->expectExceptionMessage("Server responded with {$statusCode}");
         $amlService = $this->createServiceWithErrorResponse($statusCode);
         $amlService->performCheck($this->createMock(Profile::class));
@@ -93,12 +93,11 @@ class ServiceTest extends TestCase
      * @covers ::getErrorMessage
      *
      * @dataProvider httpErrorStatusCodeProvider
-     *
-     * @expectedException \Yoti\Exception\AmlException
-     * @expectedExceptionMessage Error - some property: some message
      */
     public function testPerformAmlCheckFailureWithErrorMessage($statusCode)
     {
+        $this->expectException(\Yoti\Exception\AmlException::class, 'Error - some property: some message');
+
         $amlService = $this->createServiceWithErrorResponse(
             $statusCode,
             json_encode([

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -42,12 +42,11 @@ class ClientTest extends TestCase
     /**
      * @covers ::sendRequest
      * @covers ::__construct
-     *
-     * @expectedException \Yoti\Http\Exception\NetworkException
-     * @expectedExceptionMessage some network exception
      */
     public function testSendRequestThrowsNetworkException()
     {
+        $this->expectException(\Yoti\Http\Exception\NetworkException::class, 'some network exception');
+
         $someHandler = new MockHandler([
             new ConnectException(
                 'some network exception',
@@ -65,12 +64,13 @@ class ClientTest extends TestCase
      * @covers ::sendRequest
      * @covers ::__construct
      *
-     * @expectedException \Yoti\Http\Exception\RequestException
      *
      * @dataProvider requestExceptionDataProvider
      */
     public function testSendRequestThrowsRequestException(\Exception $someRequestException)
     {
+        $this->expectException(\Yoti\Http\Exception\RequestException::class);
+
         $this->expectExceptionMessage($someRequestException->getMessage());
 
         $someHandler = new MockHandler([$someRequestException]);

--- a/tests/Http/RequestBuilderTest.php
+++ b/tests/Http/RequestBuilderTest.php
@@ -259,12 +259,11 @@ class RequestBuilderTest extends TestCase
     /**
      * @covers ::build
      * @covers ::validateMethod
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage HTTP Method must be specified
      */
     public function testWithoutMethod()
     {
+        $this->expectException(\InvalidArgumentException::class, 'HTTP Method must be specified');
+
         (new RequestBuilder())
           ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(TestData::PEM_FILE)
@@ -275,12 +274,11 @@ class RequestBuilderTest extends TestCase
      * @covers ::build
      * @covers ::withMethod
      * @covers ::validateMethod
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Unsupported HTTP Method SOME_METHOD
      */
     public function testWithUnsupportedMethod()
     {
+        $this->expectException(\InvalidArgumentException::class, 'Unsupported HTTP Method SOME_METHOD');
+
         (new RequestBuilder())
           ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(TestData::PEM_FILE)
@@ -292,12 +290,11 @@ class RequestBuilderTest extends TestCase
      * @covers ::build
      * @covers ::withHeader
      * @covers ::validateHeaders
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Header value for 'Custom' must be a string
      */
     public function testWithHeaderInvalidValue()
     {
+        $this->expectException(\InvalidArgumentException::class, 'Header value for \'Custom\' must be a string');
+
         (new RequestBuilder())
           ->withBaseUrl(self::SOME_BASE_URL)
           ->withPemFilePath(TestData::PEM_FILE)
@@ -308,12 +305,14 @@ class RequestBuilderTest extends TestCase
 
     /**
      * @covers ::build
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Base URL must be provided to Yoti\Http\RequestBuilder
      */
     public function testBuildWithoutBaseUrl()
     {
+        $this->expectException(
+            \InvalidArgumentException::class,
+            'Base URL must be provided to Yoti\\Http\\RequestBuilder'
+        );
+
         (new RequestBuilder())
           ->withPemFilePath(TestData::PEM_FILE)
           ->build();
@@ -321,12 +320,14 @@ class RequestBuilderTest extends TestCase
 
     /**
      * @covers ::build
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage Pem file must be provided to Yoti\Http\RequestBuilder
      */
     public function testBuildWithoutPem()
     {
+        $this->expectException(
+            \InvalidArgumentException::class,
+            'Pem file must be provided to Yoti\\Http\\RequestBuilder'
+        );
+
         (new RequestBuilder())
             ->withBaseUrl(self::SOME_BASE_URL)
             ->build();
@@ -347,7 +348,10 @@ class RequestBuilderTest extends TestCase
           ->withMethod('GET')
           ->build();
 
-        $this->assertContains(self::SOME_BASE_URL . self::SOME_ENDPOINT, (string) $request->getMessage()->getUri());
+        $this->assertStringContainsString(
+            self::SOME_BASE_URL . self::SOME_ENDPOINT,
+            (string) $request->getMessage()->getUri()
+        );
     }
 
     /**
@@ -365,7 +369,10 @@ class RequestBuilderTest extends TestCase
           ->withMethod('GET')
           ->build();
 
-        $this->assertContains(self::SOME_BASE_URL . self::SOME_ENDPOINT, (string) $request->getMessage()->getUri());
+        $this->assertStringContainsString(
+            self::SOME_BASE_URL . self::SOME_ENDPOINT,
+            (string) $request->getMessage()->getUri()
+        );
     }
 
     /**
@@ -383,7 +390,10 @@ class RequestBuilderTest extends TestCase
           ->withMethod('GET')
           ->build();
 
-        $this->assertContains(self::SOME_BASE_URL . self::SOME_ENDPOINT, (string) $request->getMessage()->getUri());
+        $this->assertStringContainsString(
+            self::SOME_BASE_URL . self::SOME_ENDPOINT,
+            (string) $request->getMessage()->getUri()
+        );
     }
 
     /**

--- a/tests/Http/RequestSignerTest.php
+++ b/tests/Http/RequestSignerTest.php
@@ -35,7 +35,7 @@ class RequestSignerTest extends TestCase
      */
     private $publicKey;
 
-    public function setup()
+    public function setup(): void
     {
         $this->pem = file_get_contents(TestData::AML_PRIVATE_KEY);
         $this->publicKey = file_get_contents(TestData::AML_PUBLIC_KEY);
@@ -66,12 +66,11 @@ class RequestSignerTest extends TestCase
     /**
      * @covers ::sign
      * @covers ::validateSignedMessage
-     *
-     * @expectedException \Yoti\Http\Exception\RequestSignerException
-     * @expectedExceptionMessage Could not sign request
      */
     public function testValidateSignedMessage()
     {
+        $this->expectException(\Yoti\Http\Exception\RequestSignerException::class, 'Could not sign request');
+
         $this->captureExpectedLogs();
 
         $somePemFile = $this->createMock(PemFile::class);

--- a/tests/Media/ImageTest.php
+++ b/tests/Media/ImageTest.php
@@ -17,7 +17,7 @@ class ImageTest extends TestCase
      */
     public $dummyImage;
 
-    public function setup()
+    public function setup(): void
     {
         $this->dummyImage = new Image(self::SOME_IMAGE_DATA, 'png');
     }
@@ -53,12 +53,11 @@ class ImageTest extends TestCase
      * @covers ::__construct
      * @covers ::imageTypeToMimeType
      * @covers ::validateImageExtension
-     *
-     * @expectedException \Yoti\Media\Exception\InvalidImageTypeException
-     * @expectedExceptionMessage bmp extension not supported
      */
     public function testShouldThrowExceptionForUnsupportedExtension()
     {
+        $this->expectException(\Yoti\Media\Exception\InvalidImageTypeException::class, 'bmp extension not supported');
+
         new Image(self::SOME_IMAGE_DATA, 'bmp');
     }
 }

--- a/tests/Profile/ActivityDetailsTest.php
+++ b/tests/Profile/ActivityDetailsTest.php
@@ -43,7 +43,7 @@ class ActivityDetailsTest extends TestCase
      */
     private $receiptArr;
 
-    public function setUp()
+    public function setup(): void
     {
         $this->pem = file_get_contents(TestData::PEM_FILE);
         $this->receiptArr = json_decode(file_get_contents(TestData::RECEIPT_JSON), true)['receipt'];

--- a/tests/Profile/ApplicationProfileTest.php
+++ b/tests/Profile/ApplicationProfileTest.php
@@ -17,7 +17,7 @@ class ApplicationProfileTest extends TestCase
      */
     private $dummyProfile;
 
-    public function setup()
+    public function setup(): void
     {
         $dummyData = [
             'application_name' => new Attribute('application_name', 'Test PHP SDK', []),

--- a/tests/Profile/Attribute/AttributeTest.php
+++ b/tests/Profile/Attribute/AttributeTest.php
@@ -21,7 +21,7 @@ class AttributeTest extends TestCase
      */
     public $dummyAttribute;
 
-    public function setup()
+    public function setup(): void
     {
         $protobufAnchors[] = $this->convertToProtobufAnchor(TestAnchors::SOURCE_DL_ANCHOR);
         $protobufAnchors[] = $this->convertToProtobufAnchor(TestAnchors::SOURCE_PP_ANCHOR);

--- a/tests/Profile/Attribute/DocumentDetailsTest.php
+++ b/tests/Profile/Attribute/DocumentDetailsTest.php
@@ -15,7 +15,7 @@ class DocumentDetailsTest extends TestCase
      */
     public $dummyDocumentDetails;
 
-    public function setup()
+    public function setup(): void
     {
         $dummyValue = 'PASSPORT GBR 01234567 2020-01-01';
         $this->dummyDocumentDetails = new DocumentDetails($dummyValue);

--- a/tests/Profile/Attribute/MultiValueTest.php
+++ b/tests/Profile/Attribute/MultiValueTest.php
@@ -16,7 +16,7 @@ class MultiValueTest extends TestCase
      */
     private $multiValue;
 
-    public function setup()
+    public function setup(): void
     {
         $this->multiValue = new MultiValue([
             'string 1',
@@ -125,12 +125,11 @@ class MultiValueTest extends TestCase
      * @covers ::filter
      * @covers ::applyFilters
      * @covers ::assertMutable
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Attempting to filter immutable array
      */
     public function testImmutableFilter()
     {
+        $this->expectException(\LogicException::class, 'Attempting to filter immutable array');
+
         $this->multiValue->immutable()->filter(function ($item) {
             return $item instanceof MultiValue;
         });
@@ -141,12 +140,11 @@ class MultiValueTest extends TestCase
      * @covers ::allowType
      * @covers ::applyFilters
      * @covers ::assertMutable
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Attempting to filter immutable array
      */
     public function testImmutableAllowType()
     {
+        $this->expectException(\LogicException::class, 'Attempting to filter immutable array');
+
         $this->multiValue->immutable()->allowType('string');
     }
 
@@ -155,12 +153,11 @@ class MultiValueTest extends TestCase
      * @covers ::allowInstance
      * @covers ::applyFilters
      * @covers ::assertMutable
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Attempting to filter immutable array
      */
     public function testImmutableAllowInstance()
     {
+        $this->expectException(\LogicException::class, 'Attempting to filter immutable array');
+
         $this->multiValue->immutable()->allowInstance(Image::class);
     }
 
@@ -169,12 +166,11 @@ class MultiValueTest extends TestCase
      * @covers ::immutable
      * @covers ::applyFilters
      * @covers ::assertMutable
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Attempting to append to immutable array
      */
     public function testImmutableAppend()
     {
+        $this->expectException(\LogicException::class, 'Attempting to append to immutable array');
+
         $this->multiValue->append('allowed');
         $this->assertEquals('allowed', $this->multiValue[8]);
 
@@ -185,12 +181,11 @@ class MultiValueTest extends TestCase
      * @covers ::exchangeArray
      * @covers ::immutable
      * @covers ::assertMutable
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Attempting to change immutable array
      */
     public function testImmutableExchangeArray()
     {
+        $this->expectException(\LogicException::class, 'Attempting to change immutable array');
+
         $this->multiValue->exchangeArray([]);
         $this->assertEquals([], $this->multiValue->getArrayCopy());
 
@@ -200,12 +195,11 @@ class MultiValueTest extends TestCase
      * @covers ::offsetSet
      * @covers ::immutable
      * @covers ::assertMutable
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Attempting to add to immutable array
      */
     public function testImmutableOffsetSet()
     {
+        $this->expectException(\LogicException::class, 'Attempting to add to immutable array');
+
         $this->multiValue[0] = 'allowed';
         $this->assertEquals('allowed', $this->multiValue[0]);
 
@@ -216,12 +210,11 @@ class MultiValueTest extends TestCase
      * @covers ::offsetUnset
      * @covers ::immutable
      * @covers ::assertMutable
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Attempting to remove from immutable array
      */
     public function testImmutableOffsetUnset()
     {
+        $this->expectException(\LogicException::class, 'Attempting to remove from immutable array');
+
         unset($this->multiValue[0]);
         $this->assertFalse(isset($this->multiValue[0]));
 
@@ -232,12 +225,11 @@ class MultiValueTest extends TestCase
      * @covers ::offsetUnset
      * @covers ::immutable
      * @covers ::assertMutable
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Attempting to remove from immutable array
      */
     public function testImmutableOffsetUnsetNested()
     {
+        $this->expectException(\LogicException::class, 'Attempting to remove from immutable array');
+
         unset($this->multiValue->immutable()[6][0]);
     }
 }

--- a/tests/Profile/Attribute/SignedTimestampTest.php
+++ b/tests/Profile/Attribute/SignedTimestampTest.php
@@ -25,7 +25,7 @@ class SignedTimeStampTest extends TestCase
     /**
      * Create SignedTimeStamp.
      */
-    public function setup()
+    public function setup(): void
     {
         $this->timestamp = new \DateTime();
         $this->signedTimestamp =  new SignedTimeStamp(

--- a/tests/Profile/ExtraData/AttributeDefinitionTest.php
+++ b/tests/Profile/ExtraData/AttributeDefinitionTest.php
@@ -17,7 +17,7 @@ class AttributeDefinitionTest extends TestCase
      */
     private $attributeDefinition;
 
-    public function setup()
+    public function setup(): void
     {
         $this->attributeDefinition = new AttributeDefinition(self::SOME_NAME);
     }
@@ -35,12 +35,11 @@ class AttributeDefinitionTest extends TestCase
      * @covers ::__construct
      *
      * @dataProvider invalidNameDataProvider
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage name must be a string
      */
     public function testInvalidName($invalidName)
     {
+        $this->expectException(\InvalidArgumentException::class, 'name must be a string');
+
         new AttributeDefinition($invalidName);
     }
 

--- a/tests/Profile/ExtraData/AttributeIssuanceDetailsTest.php
+++ b/tests/Profile/ExtraData/AttributeIssuanceDetailsTest.php
@@ -20,7 +20,7 @@ class AttributeIssuanceDetailsTest extends TestCase
      */
     private $attributeIssuanceDetails;
 
-    public function setup()
+    public function setup(): void
     {
         $mockAttributeDefinition = $this->createMock(AttributeDefinition::class);
         $mockAttributeDefinition
@@ -73,13 +73,13 @@ class AttributeIssuanceDetailsTest extends TestCase
     /**
      * @covers ::__construct
      *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage token must be a string
      *
      * @dataProvider invalidTokenDataProvider
      */
     public function testInvalidToken($invalidToken)
     {
+        $this->expectException(\InvalidArgumentException::class, 'token must be a string');
+
         new AttributeIssuanceDetails($invalidToken);
     }
 
@@ -99,12 +99,14 @@ class AttributeIssuanceDetailsTest extends TestCase
 
     /**
      * @covers ::__construct
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage issuingAttributes must be array of Yoti\Profile\ExtraData\AttributeDefinition
      */
     public function testInvalidIssuingAttributes()
     {
+        $this->expectException(
+            \InvalidArgumentException::class,
+            'issuingAttributes must be array of Yoti\\Profile\\ExtraData\\AttributeDefinition'
+        );
+
         new AttributeIssuanceDetails(
             'some token',
             new \DateTime(),

--- a/tests/Profile/ReceiptTest.php
+++ b/tests/Profile/ReceiptTest.php
@@ -31,7 +31,7 @@ class ReceiptTest extends TestCase
      */
     public $receipt;
 
-    public function setup()
+    public function setup(): void
     {
         $this->pem = file_get_contents(TestData::PEM_FILE);
         $this->receiptArr = json_decode(file_get_contents(TestData::RECEIPT_JSON), true)['receipt'];
@@ -41,11 +41,11 @@ class ReceiptTest extends TestCase
     /**
      * @covers ::__construct
      * @covers ::validateReceipt
-     *
-     * @expectedException \Yoti\Exception\ReceiptException
      */
     public function testShouldThrowExceptionForInvalidReceipt()
     {
+        $this->expectException(\Yoti\Exception\ReceiptException::class);
+
         new Receipt([]);
     }
 

--- a/tests/Profile/ServiceTest.php
+++ b/tests/Profile/ServiceTest.php
@@ -102,11 +102,11 @@ class ServiceTest extends TestCase
      * @covers ::getActivityDetails
      *
      * @dataProvider httpErrorStatusCodeProvider
-     *
-     * @expectedException \Yoti\Exception\ActivityDetailsException
      */
     public function testGetActivityDetailsFailure($statusCode)
     {
+        $this->expectException(\Yoti\Exception\ActivityDetailsException::class);
+
         $this->expectExceptionMessage("Server responded with {$statusCode}");
         $profileService = $this->createProfileServiceWithResponse($statusCode);
         $profileService->getActivityDetails(file_get_contents(TestData::YOTI_CONNECT_TOKEN));
@@ -116,12 +116,11 @@ class ServiceTest extends TestCase
      * Test invalid Token
      *
      * @covers ::getActivityDetails
-     *
-     * @expectedException \Yoti\Exception\ActivityDetailsException
-     * @expectedExceptionMessage Could not decrypt connect token
      */
     public function testInvalidConnectToken()
     {
+        $this->expectException(\Yoti\Exception\ActivityDetailsException::class, 'Could not decrypt connect token');
+
         $profileService = new Service(
             TestData::SDK_ID,
             PemFile::fromFilePath(TestData::PEM_FILE),
@@ -133,12 +132,11 @@ class ServiceTest extends TestCase
 
     /**
      * @covers ::getActivityDetails
-     *
-     * @expectedException \Yoti\Exception\ActivityDetailsException
-     * @expectedExceptionMessage Outcome was unsuccessful
      */
     public function testSharingOutcomeFailure()
     {
+        $this->expectException(\Yoti\Exception\ActivityDetailsException::class, 'Outcome was unsuccessful');
+
         $json = json_decode(file_get_contents(TestData::RECEIPT_JSON), true);
         $json['receipt']['sharing_outcome'] = 'FAILURE';
 
@@ -149,12 +147,11 @@ class ServiceTest extends TestCase
     /**
      * @covers ::getActivityDetails
      * @covers ::checkForReceipt
-     *
-     * @expectedException \Yoti\Exception\ReceiptException
-     * @expectedExceptionMessage Receipt not found in response
      */
     public function testMissingReceipt()
     {
+        $this->expectException(\Yoti\Exception\ReceiptException::class, 'Receipt not found in response');
+
         $profileService = $this->createProfileServiceWithResponse(200);
         $profileService->getActivityDetails(file_get_contents(TestData::YOTI_CONNECT_TOKEN));
     }

--- a/tests/Profile/Util/EncryptedDataTest.php
+++ b/tests/Profile/Util/EncryptedDataTest.php
@@ -26,7 +26,7 @@ class EncrypedDataTest extends TestCase
     /**
      * Setup test data.
      */
-    public function setup()
+    public function setup(): void
     {
         $this->pem = file_get_contents(TestData::PEM_FILE);
         $receiptArr = json_decode(file_get_contents(TestData::RECEIPT_JSON), true);

--- a/tests/Profile/Util/ExtraData/DataEntryConverterTest.php
+++ b/tests/Profile/Util/ExtraData/DataEntryConverterTest.php
@@ -31,12 +31,11 @@ class DataEntryConverterTest extends TestCase
 
     /**
      * @covers ::convertValue
-     *
-     * @expectedException \Yoti\Exception\ExtraDataException
-     * @expectedExceptionMessage Value is empty
      */
     public function testConvertValueThirdPartyAttributeEmptyValue()
     {
+        $this->expectException(\Yoti\Exception\ExtraDataException::class, 'Value is empty');
+
         $thirdPartyAttribute = DataEntryConverter::convertValue(
             self::TYPE_THIRD_PARTY_ATTRIBUTE,
             (new ThirdPartyAttribute())->serializeToString()
@@ -47,12 +46,11 @@ class DataEntryConverterTest extends TestCase
 
     /**
      * @covers ::convertValue
-     *
-     * @expectedException \Yoti\Exception\ExtraDataException
-     * @expectedExceptionMessage Value is empty
      */
     public function testConvertValueEmpty()
     {
+        $this->expectException(\Yoti\Exception\ExtraDataException::class, 'Value is empty');
+
         DataEntryConverter::convertValue(
             self::TYPE_THIRD_PARTY_ATTRIBUTE,
             ''
@@ -61,12 +59,11 @@ class DataEntryConverterTest extends TestCase
 
     /**
      * @covers ::convertValue
-     *
-     * @expectedException \Yoti\Exception\ExtraDataException
-     * @expectedExceptionMessage Unsupported data entry
      */
     public function testConvertValueUnknown()
     {
+        $this->expectException(\Yoti\Exception\ExtraDataException::class, 'Unsupported data entry');
+
         DataEntryConverter::convertValue(
             'Some unknown type',
             'Some value'

--- a/tests/Profile/Util/ExtraData/ThirdPartyAttributeConverterTest.php
+++ b/tests/Profile/Util/ExtraData/ThirdPartyAttributeConverterTest.php
@@ -53,11 +53,12 @@ class ThirdPartyAttributeConverterTest extends TestCase
      *
      * @dataProvider invalidTokenProvider
      *
-     * @expectedException \Yoti\Exception\ExtraDataException
      * @expectedExceptionMessafe Failed to retrieve token from ThirdPartyAttribute
      */
     public function testConvertValueEmptyToken($invalidToken)
     {
+        $this->expectException(\Yoti\Exception\ExtraDataException::class);
+
         ThirdPartyAttributeConverter::convertValue(
             $this->createThirdPartyAttribute(
                 $invalidToken,

--- a/tests/ShareUrl/DynamicScenarioBuilderTest.php
+++ b/tests/ShareUrl/DynamicScenarioBuilderTest.php
@@ -88,12 +88,11 @@ class DynamicScenarioBuilderTest extends TestCase
     /**
      * @covers ::build
      * @covers \Yoti\ShareUrl\DynamicScenario::__construct
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage callbackEndpoint must be a string
      */
     public function testBuildWithoutCallback()
     {
+        $this->expectException(\InvalidArgumentException::class, 'callbackEndpoint must be a string');
+
         (new DynamicScenarioBuilder())
             ->withPolicy($this->createMock(DynamicPolicy::class))
             ->build();

--- a/tests/ShareUrl/Extension/LocationConstraintExtensionBuilderTest.php
+++ b/tests/ShareUrl/Extension/LocationConstraintExtensionBuilderTest.php
@@ -16,12 +16,11 @@ class LocationConstraintExtensionBuilderTest extends TestCase
 
     /**
      * @covers ::withLatitude
-     *
-     * @expectedException \RangeException
-     * @expectedExceptionMessage 'latitude' value '-91' is less than '-90'
      */
     public function testLatitudeTooLow()
     {
+        $this->expectException(\RangeException::class, '\'latitude\' value \'-91\' is less than \'-90\'');
+
         (new LocationConstraintExtensionBuilder())
             ->withLatitude(-91)
             ->withLongitude(0)
@@ -30,12 +29,11 @@ class LocationConstraintExtensionBuilderTest extends TestCase
 
     /**
      * @covers ::withLatitude
-     *
-     * @expectedException \RangeException
-     * @expectedExceptionMessage 'latitude' value '91' is greater than '90'
      */
     public function testLatitudeTooHigh()
     {
+        $this->expectException(\RangeException::class, '\'latitude\' value \'91\' is greater than \'90\'');
+
         (new LocationConstraintExtensionBuilder())
             ->withLatitude(91)
             ->withLongitude(0)
@@ -44,12 +42,11 @@ class LocationConstraintExtensionBuilderTest extends TestCase
 
     /**
      * @covers ::withLongitude
-     *
-     * @expectedException \RangeException
-     * @expectedExceptionMessage 'longitude' value '-181' is less than '-180'
      */
     public function testLongitudeTooLow()
     {
+        $this->expectException(\RangeException::class, '\'longitude\' value \'-181\' is less than \'-180\'');
+
         (new LocationConstraintExtensionBuilder())
             ->withLatitude(0)
             ->withLongitude(-181)
@@ -58,12 +55,11 @@ class LocationConstraintExtensionBuilderTest extends TestCase
 
     /**
      * @covers ::withLongitude
-     *
-     * @expectedException \RangeException
-     * @expectedExceptionMessage 'longitude' value '181' is greater than '180'
      */
     public function testLongitudeTooHigh()
     {
+        $this->expectException(\RangeException::class, '\'longitude\' value \'181\' is greater than \'180\'');
+
         (new LocationConstraintExtensionBuilder())
             ->withLatitude(0)
             ->withLongitude(181)
@@ -72,12 +68,11 @@ class LocationConstraintExtensionBuilderTest extends TestCase
 
     /**
      * @covers ::withRadius
-     *
-     * @expectedException \RangeException
-     * @expectedExceptionMessage 'radius' value '-1' is less than '0'
      */
     public function testRadiusLessThanZero()
     {
+        $this->expectException(\RangeException::class, '\'radius\' value \'-1\' is less than \'0\'');
+
         (new LocationConstraintExtensionBuilder())
             ->withLatitude(0)
             ->withLongitude(0)
@@ -87,12 +82,11 @@ class LocationConstraintExtensionBuilderTest extends TestCase
 
     /**
      * @covers ::withMaxUncertainty
-     *
-     * @expectedException \RangeException
-     * @expectedExceptionMessage 'maxUncertainty' value '-1' is less than '0'
      */
     public function testMaxUncertaintyLessThanZero()
     {
+        $this->expectException(\RangeException::class, '\'maxUncertainty\' value \'-1\' is less than \'0\'');
+
         (new LocationConstraintExtensionBuilder())
             ->withLatitude(0)
             ->withLongitude(0)

--- a/tests/ShareUrl/Extension/TransactionalFlowExtensionBuilderTest.php
+++ b/tests/ShareUrl/Extension/TransactionalFlowExtensionBuilderTest.php
@@ -36,12 +36,11 @@ class TransactionalFlowExtensionBuilderTest extends TestCase
     /**
      * @covers ::build
      * @covers ::withContent
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage content cannot be null
      */
     public function testNullContent()
     {
+        $this->expectException(\InvalidArgumentException::class, 'content cannot be null');
+
         (new TransactionalFlowExtensionBuilder())
             ->withContent(null)
             ->build();

--- a/tests/ShareUrl/Policy/DynamicPolicyBuilderTest.php
+++ b/tests/ShareUrl/Policy/DynamicPolicyBuilderTest.php
@@ -186,12 +186,11 @@ class DynamicPolicyBuilderTest extends TestCase
 
     /**
      * @covers ::withAgeOver
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage age must be an integer
      */
     public function testWithAgeOverIntegersOnly()
     {
+        $this->expectException(\InvalidArgumentException::class, 'age must be an integer');
+
         (new DynamicPolicyBuilder())
             ->withDateOfBirth()
             ->withAgeOver('18')
@@ -200,12 +199,11 @@ class DynamicPolicyBuilderTest extends TestCase
 
     /**
      * @covers ::withAgeUnder
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage age must be an integer
      */
     public function testWithAgeUnderIntegersOnly()
     {
+        $this->expectException(\InvalidArgumentException::class, 'age must be an integer');
+
         (new DynamicPolicyBuilder())
             ->withDateOfBirth()
             ->withAgeUnder('18')
@@ -409,12 +407,11 @@ class DynamicPolicyBuilderTest extends TestCase
 
     /**
      * @covers ::withWantedAuthType
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage wantedAuthType must be an integer
      */
     public function testWithNonIntegerAuthType()
     {
+        $this->expectException(\InvalidArgumentException::class, 'wantedAuthType must be an integer');
+
         (new DynamicPolicyBuilder())
             ->withWantedAuthType('99')
             ->build();

--- a/tests/ShareUrl/Policy/WantedAttributeBuilderTest.php
+++ b/tests/ShareUrl/Policy/WantedAttributeBuilderTest.php
@@ -45,12 +45,11 @@ class WantedAttributeBuilderTest extends TestCase
     /**
      * @covers ::build
      * @covers ::withName
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage name cannot be empty
      */
     public function testEmptyName()
     {
+        $this->expectException(\InvalidArgumentException::class, 'name cannot be empty');
+
         (new WantedAttributeBuilder())
             ->withName('')
             ->build();
@@ -59,12 +58,11 @@ class WantedAttributeBuilderTest extends TestCase
     /**
      * @covers ::build
      * @covers ::withName
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage name must be a string
      */
     public function testNonStringName()
     {
+        $this->expectException(\InvalidArgumentException::class, 'name must be a string');
+
         (new WantedAttributeBuilder())
             ->withName(['some array'])
             ->build();

--- a/tests/ShareUrl/ResultTest.php
+++ b/tests/ShareUrl/ResultTest.php
@@ -33,12 +33,11 @@ class ResultTest extends TestCase
     /**
      * @covers ::__construct
      * @covers ::getResultValue
-     *
-     * @expectedException \Yoti\Exception\ShareUrlException
-     * @expectedExceptionMessage JSON result does not contain 'qrcode'
      */
     public function testInvalidResponseNoQr()
     {
+        $this->expectException(\Yoti\Exception\ShareUrlException::class, 'JSON result does not contain \'qrcode\'');
+
         new Result([
             'ref_id' => self::SOME_REF_ID,
         ]);
@@ -47,12 +46,11 @@ class ResultTest extends TestCase
     /**
      * @covers ::__construct
      * @covers ::getResultValue
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage qrcode must be a string
      */
     public function testInvalidResponseInvalidQr()
     {
+        $this->expectException(\InvalidArgumentException::class, 'qrcode must be a string');
+
         new Result([
             'qrcode' => [self::SOME_SHARE_URL],
         ]);
@@ -61,12 +59,11 @@ class ResultTest extends TestCase
     /**
      * @covers ::__construct
      * @covers ::getResultValue
-     *
-     * @expectedException \Yoti\Exception\ShareUrlException
-     * @expectedExceptionMessage JSON result does not contain 'ref_id'
      */
     public function testInvalidResponseNoRefId()
     {
+        $this->expectException(\Yoti\Exception\ShareUrlException::class, 'JSON result does not contain \'ref_id\'');
+
         new Result([
             'qrcode' => self::SOME_SHARE_URL,
         ]);
@@ -75,12 +72,11 @@ class ResultTest extends TestCase
     /**
      * @covers ::__construct
      * @covers ::getResultValue
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage ref_id must be a string
      */
     public function testInvalidResponseInvalidRefId()
     {
+        $this->expectException(\InvalidArgumentException::class, 'ref_id must be a string');
+
         new Result([
             'qrcode' => self::SOME_SHARE_URL,
             'ref_id' => [self::SOME_REF_ID],

--- a/tests/ShareUrl/ServiceTest.php
+++ b/tests/ShareUrl/ServiceTest.php
@@ -80,11 +80,11 @@ class ServiceTest extends TestCase
      * @covers ::createShareUrl
      *
      * @dataProvider httpErrorStatusCodeProvider
-     *
-     * @expectedException \Yoti\Exception\ShareUrlException
      */
     public function testCreateShareUrlFailure($statusCode)
     {
+        $this->expectException(\Yoti\Exception\ShareUrlException::class);
+
         $this->expectExceptionMessage("Server responded with {$statusCode}");
         $yotiClient = $this->createServiceWithErrorResponse($statusCode);
         $yotiClient->createShareUrl($this->createMock(DynamicScenario::class));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,12 +2,14 @@
 
 namespace YotiTest;
 
-class TestCase extends \PHPUnit_Framework_TestCase
+use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+
+class TestCase extends PHPUnitTestCase
 {
     /**
      * Restores ini settings after tests run.
      */
-    public function teardown()
+    public function teardown(): void
     {
         parent::teardown();
         ini_restore('error_log');
@@ -34,7 +36,7 @@ class TestCase extends \PHPUnit_Framework_TestCase
     protected function assertLogContains($str)
     {
         $this->assertFileExists(ini_get('error_log'));
-        $this->assertContains($str, file_get_contents(ini_get('error_log')));
+        $this->assertStringContainsString($str, file_get_contents(ini_get('error_log')));
     }
 
 

--- a/tests/Util/ConfigTest.php
+++ b/tests/Util/ConfigTest.php
@@ -117,12 +117,14 @@ class ConfigTest extends TestCase
 
     /**
      * @covers ::setHttpClient
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage http.client configuration value must be of type Psr\Http\Client\ClientInterface
      */
     public function testInvalidHttpClient()
     {
+        $this->expectException(
+            \InvalidArgumentException::class,
+            'http.client configuration value must be of type Psr\\Http\\Client\\ClientInterface'
+        );
+
         new Config([
             self::HTTP_CLIENT_KEY => 'some invalid http client',
         ]);
@@ -139,12 +141,14 @@ class ConfigTest extends TestCase
     /**
      * @covers ::__construct
      * @covers ::validateKeys
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage The following configuration keys are not allowed: some.invalid.key
      */
     public function testValidateKeys()
     {
+        $this->expectException(
+            \InvalidArgumentException::class,
+            'The following configuration keys are not allowed: some.invalid.key'
+        );
+
         new Config([
             'some.invalid.key' => 'some string',
         ]);

--- a/tests/Util/DateTimeTest.php
+++ b/tests/Util/DateTimeTest.php
@@ -50,24 +50,24 @@ class DateTimeTest extends TestCase
 
     /**
      * @covers ::stringToDateTime
-     *
-     * @expectedException \Yoti\Exception\DateTimeException
-     * @expectedExceptionMessage Could not parse string to DateTime
      */
     public function testInvalidTimestamp()
     {
+        $this->expectException(\Yoti\Exception\DateTimeException::class, 'Could not parse string to DateTime');
+
         DateTime::stringToDateTime('some-invalid-date');
     }
 
     /**
      * @covers ::stringToDateTime
      *
-     * @expectedException \InvalidArgumentException
      *
      * @dataProvider emptyTimestampProvider
      */
     public function testEmptyTimestamp($emptyDateString, $exceptionMessage)
     {
+        $this->expectException(\InvalidArgumentException::class);
+
         $this->expectExceptionMessage($exceptionMessage);
         DateTime::stringToDateTime($emptyDateString);
     }

--- a/tests/Util/JsonTest.php
+++ b/tests/Util/JsonTest.php
@@ -36,12 +36,11 @@ class JsonTest extends TestCase
 
     /**
      * @covers ::decode
-     *
-     * @expectedException \Yoti\Exception\JsonException
-     * @expectedExceptionMessage Syntax error
      */
     public function testDecodeExceptionSyntax()
     {
+        $this->expectException(\Yoti\Exception\JsonException::class, 'Syntax error');
+
         Json::decode('some invalid json');
     }
 }

--- a/tests/Util/PemFileTest.php
+++ b/tests/Util/PemFileTest.php
@@ -19,7 +19,7 @@ class PemFileTest extends TestCase
     /**
      * Setup tests.
      */
-    public function setup()
+    public function setup(): void
     {
         $this->pemContent = file_get_contents(TestData::PEM_FILE);
     }
@@ -84,12 +84,11 @@ class PemFileTest extends TestCase
      * @covers ::resolveFromString
      * @covers ::isPemString
      * @covers ::__toString
-     *
-     * @expectedException \Yoti\Exception\PemFileException
-     * @expectedExceptionMessage PEM file was not found
      */
     public function testResolveFromStringWithInvalidFilePath()
     {
+        $this->expectException(\Yoti\Exception\PemFileException::class, 'PEM file was not found');
+
         PemFile::resolveFromString('file://invalid_file_path.pem');
     }
 
@@ -97,12 +96,11 @@ class PemFileTest extends TestCase
      * @covers ::resolveFromString
      * @covers ::isPemString
      * @covers ::__toString
-     *
-     * @expectedException \Yoti\Exception\PemFileException
-     * @expectedExceptionMessage PEM content is invalid
      */
     public function testResolveFromStringWithInvalidStringContent()
     {
+        $this->expectException(\Yoti\Exception\PemFileException::class, 'PEM content is invalid');
+
         PemFile::resolveFromString(file_get_contents(TestData::INVALID_PEM_FILE));
     }
 
@@ -111,12 +109,11 @@ class PemFileTest extends TestCase
      *
      * @covers ::__construct
      * @covers ::fromFilePath
-     *
-     * @expectedException \Yoti\Exception\PemFileException
-     * @expectedExceptionMessage PEM file was not found
      */
     public function testInvalidPemFileStreamWrapperPath()
     {
+        $this->expectException(\Yoti\Exception\PemFileException::class, 'PEM file was not found');
+
         PemFile::fromFilePath('file://invalid_file_path.pem');
     }
 
@@ -125,12 +122,11 @@ class PemFileTest extends TestCase
      *
      * @covers ::__construct
      * @covers ::fromFilePath
-     *
-     * @expectedException \Yoti\Exception\PemFileException
-     * @expectedExceptionMessage PEM content is invalid
      */
     public function testInvalidPemFileContents()
     {
+        $this->expectException(\Yoti\Exception\PemFileException::class, 'PEM content is invalid');
+
         PemFile::fromFilePath(TestData::INVALID_PEM_FILE);
     }
 
@@ -139,12 +135,11 @@ class PemFileTest extends TestCase
      *
      * @covers ::__construct
      * @covers ::fromString
-     *
-     * @expectedException \Yoti\Exception\PemFileException
-     * @expectedExceptionMessage PEM content is invalid
      */
     public function testInvalidPemString()
     {
+        $this->expectException(\Yoti\Exception\PemFileException::class, 'PEM content is invalid');
+
         PemFile::fromString('invalid_pem_string');
     }
 

--- a/tests/Util/ValidationTest.php
+++ b/tests/Util/ValidationTest.php
@@ -24,13 +24,13 @@ class ValidationTest extends TestCase
     /**
      * @covers ::isString
      *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage some_name must be a string
      *
      * @dataProvider nonStringDataProvider
      */
     public function testIsStringInvalid($nonStringValue)
     {
+        $this->expectException(\InvalidArgumentException::class, 'some_name must be a string');
+
         Validation::isString($nonStringValue, self::SOME_NAME);
     }
 
@@ -46,12 +46,11 @@ class ValidationTest extends TestCase
 
     /**
      * @covers ::isBoolean
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage some_name must be a boolean
      */
     public function testIsBooleanInvalid()
     {
+        $this->expectException(\InvalidArgumentException::class, 'some_name must be a boolean');
+
         Validation::isBoolean(self::SOME_STRING, self::SOME_NAME);
     }
 
@@ -80,12 +79,11 @@ class ValidationTest extends TestCase
 
     /**
      * @covers ::isInteger
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage some_name must be an integer
      */
     public function testIsIntegerInvalid()
     {
+        $this->expectException(\InvalidArgumentException::class, 'some_name must be an integer');
+
         Validation::isInteger(self::SOME_STRING, self::SOME_NAME);
     }
 
@@ -115,12 +113,11 @@ class ValidationTest extends TestCase
 
     /**
      * @covers ::isFloat
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage some_name must be a float
      */
     public function testIsFloatInvalid()
     {
+        $this->expectException(\InvalidArgumentException::class, 'some_name must be a float');
+
         Validation::isFloat(self::SOME_STRING, self::SOME_NAME);
     }
 
@@ -151,12 +148,11 @@ class ValidationTest extends TestCase
 
     /**
      * @covers ::isNumeric
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage some_name must be numeric
      */
     public function testIsNumericInvalid()
     {
+        $this->expectException(\InvalidArgumentException::class, 'some_name must be numeric');
+
         Validation::isNumeric(self::SOME_STRING, self::SOME_NAME);
     }
 
@@ -170,12 +166,11 @@ class ValidationTest extends TestCase
 
     /**
      * @covers ::notNull
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage some_name cannot be null
      */
     public function testNotNullInvalid()
     {
+        $this->expectException(\InvalidArgumentException::class, 'some_name cannot be null');
+
         Validation::notNull(null, self::SOME_NAME);
     }
 
@@ -190,12 +185,11 @@ class ValidationTest extends TestCase
 
     /**
      * @covers ::notGreaterThan
-     *
-     * @expectedException \RangeException
-     * @expectedExceptionMessage 'some_name' value '2' is greater than '1'
      */
     public function testNotGreaterThanInvalid()
     {
+        $this->expectException(\RangeException::class, '\'some_name\' value \'2\' is greater than \'1\'');
+
         Validation::notGreaterThan(2, 1, self::SOME_NAME);
     }
 
@@ -210,12 +204,11 @@ class ValidationTest extends TestCase
 
     /**
      * @covers ::notLessThan
-     *
-     * @expectedException \RangeException
-     * @expectedExceptionMessage 'some_name' value '1' is less than '2'
      */
     public function testNotLessThanInvalid()
     {
+        $this->expectException(\RangeException::class, '\'some_name\' value \'1\' is less than \'2\'');
+
         Validation::notLessThan(1, 2, self::SOME_NAME);
     }
 
@@ -229,23 +222,21 @@ class ValidationTest extends TestCase
 
     /**
      * @covers ::withinRange
-     *
-     * @expectedException \RangeException
-     * @expectedExceptionMessage 'some_name' value '4' is greater than '3'
      */
     public function testWithinRangeGreaterThan()
     {
+        $this->expectException(\RangeException::class, '\'some_name\' value \'4\' is greater than \'3\'');
+
         Validation::withinRange(4, 1, 3, self::SOME_NAME);
     }
 
     /**
      * @covers ::withinRange
-     *
-     * @expectedException \RangeException
-     * @expectedExceptionMessage 'some_name' value '1' is less than '2'
      */
     public function testWithinRangeLessThan()
     {
+        $this->expectException(\RangeException::class, '\'some_name\' value \'1\' is less than \'2\'');
+
         Validation::withinRange(1, 2, 4, self::SOME_NAME);
     }
 
@@ -259,12 +250,11 @@ class ValidationTest extends TestCase
 
     /**
      * @covers ::isArrayOfIntegers
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage some_name must be array of integers
      */
     public function testIsArrayOfIntegersInvalid()
     {
+        $this->expectException(\InvalidArgumentException::class, 'some_name must be array of integers');
+
         Validation::isArrayOfIntegers([1, self::SOME_STRING], self::SOME_NAME);
     }
 
@@ -278,12 +268,11 @@ class ValidationTest extends TestCase
 
     /**
      * @covers ::isArrayOfStrings
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage some_name must be array of strings
      */
     public function testIsArrayOfStringsInvalid()
     {
+        $this->expectException(\InvalidArgumentException::class, 'some_name must be array of strings');
+
         Validation::isArrayOfStrings([1, [], self::SOME_STRING], self::SOME_NAME);
     }
 
@@ -307,12 +296,11 @@ class ValidationTest extends TestCase
     /**
      * @covers ::isArrayOfType
      * @covers ::isOneOfType
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage some_name must be array of ArrayObject, DateTime
      */
     public function testIsArrayOfTypeInvalid()
     {
+        $this->expectException(\InvalidArgumentException::class, 'some_name must be array of ArrayObject, DateTime');
+
         $arrayOfTypes = [
             new \stdClass(),
             new \ArrayObject(),
@@ -334,25 +322,24 @@ class ValidationTest extends TestCase
 
     /**
      * @covers ::notEmptyString
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage some_name cannot be empty
      */
     public function testNotEmptyStringWithEmptyValue()
     {
+        $this->expectException(\InvalidArgumentException::class, 'some_name cannot be empty');
+
         Validation::notEmptyString('', self::SOME_NAME);
     }
 
     /**
      * @covers ::notEmptyString
      *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage some_name must be a string
      *
      * @dataProvider nonStringDataProvider
      */
     public function testNotEmptyStringWithNonStringValue($nonStringValue)
     {
+        $this->expectException(\InvalidArgumentException::class, 'some_name must be a string');
+
         Validation::notEmptyString($nonStringValue, self::SOME_NAME);
     }
 

--- a/tests/YotiClientTest.php
+++ b/tests/YotiClientTest.php
@@ -26,12 +26,11 @@ class YotiClientTest extends TestCase
      * Test empty SDK ID
      *
      * @covers ::__construct
-     *
-     * @expectedException \InvalidArgumentException
-     * @expectedExceptionMessage SDK ID cannot be empty
      */
     public function testEmptySdkId()
     {
+        $this->expectException(\InvalidArgumentException::class, 'SDK ID cannot be empty');
+
         new YotiClient('', TestData::PEM_FILE);
     }
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -5,12 +5,3 @@
  */
 
 require_once __DIR__ . '/../vendor/autoload.php';
-
-/**
- * Allow tests to run with:
- * - PHPUnit 5 for PHP 5.6
- * - PHPUnit 7 for PHP 7
- */
-if (!class_exists('\PHPUnit_Framework_TestCase')) {
-    class_alias(\PHPUnit\Framework\TestCase::class, '\PHPUnit_Framework_TestCase');
-}


### PR DESCRIPTION
### Changed
- PHPUnit dev dependency to `^7.5 || ^8.5`
  >Note: `^7.5` has been included in order to test _PHP 7.1_ - you can see the different version being installed in Travis builds
- Exception annotations _(which have been deprecated)_ now use `::expectException()` method instead

### Removed
- Dropped _PHP 5.6_ support in `composer.json` _(now ^7.1)_
  > Note: this should have been dropped in #107
