### PR TITLE
SDK-1376: Exception chaining

### DIFF
--- a/src/Aml/Result.php
+++ b/src/Aml/Result.php
@@ -116,7 +116,7 @@ class Result
 
         // Throw an error if any expected attribute is missing.
         if (!empty($missingAttr)) {
-            throw new AmlException('Missing attributes from the result: ' . implode(',', $missingAttr), 106);
+            throw new AmlException('Missing attributes from the result: ' . implode(',', $missingAttr));
         }
     }
 

--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -2,12 +2,14 @@
 
 namespace Yoti\Http;
 
-use GuzzleHttp\Exception\ConnectException;
+use GuzzleHttp\Exception\ConnectException as GuzzleConnectException;
 use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException as GuzzleRequestException;
 use GuzzleHttp\RequestOptions;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Yoti\Http\Exception\ClientException;
 use Yoti\Http\Exception\NetworkException;
 use Yoti\Http\Exception\RequestException;
 
@@ -43,10 +45,12 @@ class Client implements ClientInterface
     {
         try {
             return $this->httpClient->send($request);
-        } catch (ConnectException $e) {
-            throw new NetworkException($e->getMessage(), $request);
+        } catch (GuzzleConnectException $e) {
+            throw new NetworkException($e->getMessage(), $request, null, $e);
+        } catch (GuzzleRequestException $e) {
+            throw new RequestException($e->getMessage(), $request, null, $e);
         } catch (GuzzleException $e) {
-            throw new RequestException($e->getMessage(), $request);
+            throw new ClientException($e->getMessage(), null, $e);
         }
     }
 }

--- a/src/Http/Exception/ClientException.php
+++ b/src/Http/Exception/ClientException.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Yoti\Http\Exception;
+
+use Psr\Http\Client\ClientExceptionInterface;
+
+class ClientException extends \RuntimeException implements ClientExceptionInterface
+{
+}

--- a/src/Http/Exception/NetworkException.php
+++ b/src/Http/Exception/NetworkException.php
@@ -5,17 +5,19 @@ namespace Yoti\Http\Exception;
 use Psr\Http\Client\NetworkExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 
-class NetworkException extends \Exception implements NetworkExceptionInterface
+class NetworkException extends ClientException implements NetworkExceptionInterface
 {
     use RequestAwareTrait;
 
     /**
      * @param string $message
      * @param \Psr\Http\Client\RequestExceptionInterface $request
+     * @param integer $code
+     * @param \Throwable $previous
      */
-    public function __construct($message, RequestInterface $request)
+    public function __construct($message, RequestInterface $request, $code = null, \Throwable $previous = null)
     {
         $this->setRequest($request);
-        parent::__construct($message);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Http/Exception/RequestException.php
+++ b/src/Http/Exception/RequestException.php
@@ -5,17 +5,19 @@ namespace Yoti\Http\Exception;
 use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 
-class RequestException extends \Exception implements RequestExceptionInterface
+class RequestException extends ClientException implements RequestExceptionInterface
 {
     use RequestAwareTrait;
 
     /**
      * @param string $message
      * @param \Psr\Http\Client\RequestExceptionInterface $request
+     * @param integer $code
+     * @param \Throwable $previous
      */
-    public function __construct($message, RequestInterface $request)
+    public function __construct($message, RequestInterface $request, $code = 0, \Throwable $previous = null)
     {
         $this->setRequest($request);
-        parent::__construct($message);
+        parent::__construct($message, $code, $previous);
     }
 }

--- a/src/Http/RequestBuilder.php
+++ b/src/Http/RequestBuilder.php
@@ -247,7 +247,7 @@ class RequestBuilder
                 true
             )
         ) {
-            throw new \InvalidArgumentException("Unsupported HTTP Method {$this->method}", 400);
+            throw new \InvalidArgumentException("Unsupported HTTP Method {$this->method}");
         }
     }
 

--- a/src/Http/RequestSigner.php
+++ b/src/Http/RequestSigner.php
@@ -47,7 +47,7 @@ class RequestSigner
     {
         // Check signed message
         if (!$signedMessage) {
-            throw new RequestSignerException('Could not sign request.', 401);
+            throw new RequestSignerException('Could not sign request.');
         }
     }
 }


### PR DESCRIPTION
### Changed
- Custom exceptions are now passed the previous exception

### Added
- `Yoti\Http\Exception\ClientException` implements `\Psr\Http\Client\ClientExceptionInterface`
  > Note: this should have been implemented in #107 

### Removed
- Exception codes using HTTP statuses - these could be misleading