### PR TITLE
SDK-1380: Remove public setters from AML classes

### DIFF
--- a/src/Aml/Address.php
+++ b/src/Aml/Address.php
@@ -23,40 +23,24 @@ class Address implements \JsonSerializable
      * @param \Yoti\Aml\Country $country
      * @param null|string $postcode
      */
-    public function __construct(Country $country, $postcode = null)
+    public function __construct(Country $country, string $postcode = null)
     {
         $this->country = $country;
         $this->postcode = $postcode;
     }
 
     /**
-     * @param Country $country
+     * @return Yoti\Aml\Country
      */
-    public function setCountry(Country $country)
-    {
-        $this->country = $country;
-    }
-
-    /**
-     * @return Country
-     */
-    public function getCountry()
+    public function getCountry(): Country
     {
         return $this->country;
     }
 
     /**
-     * @param $postcode
-     */
-    public function setPostcode($postcode)
-    {
-        $this->postcode = $postcode;
-    }
-
-    /**
      * @return null|string
      */
-    public function getPostcode()
+    public function getPostcode(): string
     {
         return $this->postcode;
     }
@@ -66,7 +50,7 @@ class Address implements \JsonSerializable
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             self::POSTCODE_ATTR => $this->postcode,
@@ -77,7 +61,7 @@ class Address implements \JsonSerializable
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode($this);
     }

--- a/src/Aml/Country.php
+++ b/src/Aml/Country.php
@@ -11,15 +11,10 @@ class Country
      */
     private $code;
 
-    public function __construct($code)
-    {
-        $this->code = $code;
-    }
-
     /**
-     * @param $code
+     * @param string $code
      */
-    public function setCode($code)
+    public function __construct(string $code)
     {
         $this->code = $code;
     }
@@ -27,7 +22,7 @@ class Country
     /**
      * @return string
      */
-    public function getCode()
+    public function getCode(): string
     {
         return $this->code;
     }

--- a/src/Aml/Profile.php
+++ b/src/Aml/Profile.php
@@ -45,7 +45,7 @@ class Profile implements \JsonSerializable
      * @param \Yoti\Aml\Address $amlAddress
      * @param null|string $ssn
      */
-    public function __construct($givenNames, $familyName, Address $amlAddress, $ssn = null)
+    public function __construct($givenNames, $familyName, Address $amlAddress, string $ssn = null)
     {
         $this->givenNames = $givenNames;
         $this->familyName = $familyName;
@@ -56,7 +56,7 @@ class Profile implements \JsonSerializable
     /**
      * @return string
      */
-    public function getGivenNames()
+    public function getGivenNames(): string
     {
         return $this->givenNames;
     }
@@ -64,57 +64,25 @@ class Profile implements \JsonSerializable
     /**
      * @return string
      */
-    public function getFamilyName()
+    public function getFamilyName(): string
     {
         return $this->familyName;
     }
 
     /**
-     * @return null|string
+     * @return string|null
      */
-    public function getSsn()
+    public function getSsn(): ?string
     {
         return $this->ssn;
     }
 
     /**
-     * @return AmlAddress
+     * @return Yoti\Aml\Address
      */
-    public function getAmlAddress()
+    public function getAmlAddress(): Address
     {
         return $this->amlAddress;
-    }
-
-    /**
-     * @param $givenNames
-     */
-    public function setGivenNames($givenNames)
-    {
-        $this->givenNames = $givenNames;
-    }
-
-    /**
-     * @param $familyName
-     */
-    public function setFamilyName($familyName)
-    {
-        $this->familyName = $familyName;
-    }
-
-    /**
-     * @param $ssn
-     */
-    public function setSsn($ssn)
-    {
-        $this->ssn = $ssn;
-    }
-
-    /**
-     * @param AmlAddress $amlAddress
-     */
-    public function setAmlAddress(Address $amlAddress)
-    {
-        $this->amlAddress = $amlAddress;
     }
 
     /**
@@ -122,7 +90,7 @@ class Profile implements \JsonSerializable
      *
      * @return array
      */
-    public function jsonSerialize()
+    public function jsonSerialize(): array
     {
         return [
             self::GIVEN_NAMES_ATTR  => $this->givenNames,
@@ -135,7 +103,7 @@ class Profile implements \JsonSerializable
     /**
      * @return string
      */
-    public function __toString()
+    public function __toString(): string
     {
         return json_encode($this);
     }

--- a/tests/Aml/AddressTest.php
+++ b/tests/Aml/AddressTest.php
@@ -27,18 +27,6 @@ class AddressTest extends TestCase
     }
 
     /**
-     * @covers ::setCountry
-     */
-    public function testSetCountry()
-    {
-        $amlAddress = new Address($this->createMock(Country::class));
-        $someCountry = $this->createMock(Country::class);
-        $amlAddress->setCountry($someCountry);
-
-        $this->assertSame($someCountry, $amlAddress->getCountry());
-    }
-
-    /**
      * @covers ::__construct
      * @covers ::getPostcode
      */
@@ -48,17 +36,6 @@ class AddressTest extends TestCase
             $this->createMock(Country::class),
             self::SOME_POSTCODE
         );
-
-        $this->assertEquals(self::SOME_POSTCODE, $amlAddress->getPostcode());
-    }
-
-    /**
-     * @covers ::setPostcode
-     */
-    public function testSetPostcode()
-    {
-        $amlAddress = new Address($this->createMock(Country::class));
-        $amlAddress->setPostcode(self::SOME_POSTCODE);
 
         $this->assertEquals(self::SOME_POSTCODE, $amlAddress->getPostcode());
     }

--- a/tests/Aml/CountryTest.php
+++ b/tests/Aml/CountryTest.php
@@ -22,15 +22,4 @@ class CountryTest extends TestCase
 
         $this->assertEquals(self::SOME_COUNTRY_CODE, $country->getCode());
     }
-
-    /**
-     * @covers ::setCode
-     */
-    public function testSetCode()
-    {
-        $country = new Country('');
-        $country->setCode(self::SOME_COUNTRY_CODE);
-
-        $this->assertEquals(self::SOME_COUNTRY_CODE, $country->getCode());
-    }
 }

--- a/tests/Aml/ProfileTest.php
+++ b/tests/Aml/ProfileTest.php
@@ -40,7 +40,7 @@ class ProfileTest extends TestCase
     {
         $this->country = new Country(self::SOME_COUNTRY_CODE);
         $this->amlAddress = new Address($this->country, self::SOME_POSTCODE);
-        $this->amlProfile =  new Profile(
+        $this->amlProfile = new Profile(
             self::SOME_GIVEN_NAMES,
             self::SOME_FAMILY_NAME,
             $this->amlAddress,
@@ -59,33 +59,11 @@ class ProfileTest extends TestCase
 
     /**
      * @covers ::__construct
-     * @covers ::setGivenNames
-     */
-    public function testSetGivenNames()
-    {
-        $someGivenNames = 'some given names';
-        $this->amlProfile->setGivenNames($someGivenNames);
-        $this->assertEquals($someGivenNames, $this->amlProfile->getGivenNames());
-    }
-
-    /**
-     * @covers ::__construct
      * @covers ::getFamilyName
      */
     public function testGetFamilyName()
     {
         $this->assertEquals(self::SOME_FAMILY_NAME, $this->amlProfile->getFamilyName());
-    }
-
-    /**
-     * @covers ::__construct
-     * @covers ::setFamilyName
-     */
-    public function testSetFamilyName()
-    {
-        $someFamilyName = 'some family name';
-        $this->amlProfile->setFamilyName($someFamilyName);
-        $this->assertEquals($someFamilyName, $this->amlProfile->getFamilyName());
     }
 
     /**
@@ -99,13 +77,16 @@ class ProfileTest extends TestCase
 
     /**
      * @covers ::__construct
-     * @covers ::setSsn
+     * @covers ::getSsn
      */
-    public function testSetSsn()
+    public function testGetSsnNull()
     {
-        $someSsn = 'some ssn';
-        $this->amlProfile->setSsn($someSsn);
-        $this->assertEquals($someSsn, $this->amlProfile->getSsn());
+        $amlProfile = new Profile(
+            self::SOME_GIVEN_NAMES,
+            self::SOME_FAMILY_NAME,
+            $this->amlAddress
+        );
+        $this->assertNull($amlProfile->getSsn());
     }
 
     /**
@@ -115,17 +96,6 @@ class ProfileTest extends TestCase
     public function testGetAmlAddress()
     {
         $this->assertSame($this->amlAddress, $this->amlProfile->getAmlAddress());
-    }
-
-    /**
-     * @covers ::__construct
-     * @covers ::setAmlAddress
-     */
-    public function testSetAmlAddress()
-    {
-        $someAmlAddress = $this->createMock(Address::class);
-        $this->amlProfile->setAmlAddress($someAmlAddress);
-        $this->assertSame($someAmlAddress, $this->amlProfile->getAmlAddress());
     }
 
     /**


### PR DESCRIPTION
### Removed
- `\Yoti\Aml\Address`
  - `::setCountry()`
  - `::setPostcode()`
- `\Yoti\Aml\Country`
  - `::setCode()`
- `\Yoti\Aml\Profile`
  - `::setGivenNames()`
  - `::setFamilyName()`
  - `::setSsn()`
  - `::setAmlAddress()`
