### PR TITLE
SDK-1382: Simplify anchor converter

### DIFF
--- a/src/Profile/Attribute.php
+++ b/src/Profile/Attribute.php
@@ -21,16 +21,6 @@ class Attribute
     /**
      * @var \Yoti\Profile\Attribute\Anchor[]
      */
-    private $sources;
-
-    /**
-     * @var \Yoti\Profile\Attribute\Anchor[]
-     */
-    private $verifiers;
-
-    /**
-     * @var \Yoti\Profile\Attribute\Anchor[]
-     */
     private $anchors;
 
     /**
@@ -38,16 +28,13 @@ class Attribute
      *
      * @param string $name
      * @param mixed $value
-     * @param array<string, array> $anchorsMap
+     * @param \Yoti\Profile\Attribute\Anchor[] $anchors
      */
-    public function __construct(string $name, $value, array $anchorsMap)
+    public function __construct(string $name, $value, array $anchors)
     {
         $this->name = $name;
         $this->value = $value;
-
-        $this->setSources($anchorsMap);
-        $this->setVerifiers($anchorsMap);
-        $this->setAnchors($anchorsMap);
+        $this->anchors = $anchors;
     }
 
     /**
@@ -71,7 +58,7 @@ class Attribute
      */
     public function getSources(): array
     {
-        return $this->sources;
+        return $this->filterAnchors(Anchor::TYPE_SOURCE_NAME);
     }
 
     /**
@@ -79,7 +66,7 @@ class Attribute
      */
     public function getVerifiers(): array
     {
-        return $this->verifiers;
+        return $this->filterAnchors(Anchor::TYPE_VERIFIER_NAME);
     }
 
     /**
@@ -98,48 +85,19 @@ class Attribute
     }
 
     /**
-     * @param array<string, array> $anchorsMap
-     */
-    private function setSources(array $anchorsMap): void
-    {
-        $this->sources = $this->getAnchorType(
-            $anchorsMap,
-            Anchor::TYPE_SOURCE_OID
-        );
-    }
-
-    /**
-     * @param array<string, array> $anchorsMap
-     */
-    private function setVerifiers(array $anchorsMap): void
-    {
-        $this->verifiers = $this->getAnchorType(
-            $anchorsMap,
-            Anchor::TYPE_VERIFIER_OID
-        );
-    }
-
-    /**
-     * @param array<string, array> $anchorsMap
-     */
-    private function setAnchors(array $anchorsMap): void
-    {
-        // Remove Oids from the anchorsMap
-        $anchors = [];
-        array_walk($anchorsMap, function ($val) use (&$anchors): void {
-            $anchors = array_merge($anchors, array_values($val));
-        });
-        $this->anchors = $anchors;
-    }
-
-    /**
-     * @param array<string, array> $anchorsMap
-     * @param string $anchorType
+     * @param string $type
      *
      * @return \Yoti\Profile\Attribute\Anchor[]
      */
-    private function getAnchorType(array $anchorsMap, string $anchorType): array
+    private function filterAnchors(string $type): array
     {
-        return isset($anchorsMap[$anchorType]) ? $anchorsMap[$anchorType] : [];
+        return array_values(
+            array_filter(
+                $this->anchors,
+                function (Anchor $anchor) use ($type): bool {
+                    return $anchor->getType() === $type;
+                }
+            )
+        );
     }
 }

--- a/src/Profile/UserProfile.php
+++ b/src/Profile/UserProfile.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yoti\Profile;
 
 use Yoti\Profile\Attribute\AgeVerification;
-use Yoti\Profile\Attribute\Anchor;
 
 /**
  * Profile of a human user with convenience methods to access well-known attributes.
@@ -274,28 +273,10 @@ class UserProfile extends BaseProfile
                 $postalAddress = new Attribute(
                     self::ATTR_POSTAL_ADDRESS,
                     $postalAddressValue,
-                    $this->getAttributeAnchorMap($structuredPostalAddress)
+                    $structuredPostalAddress->getAnchors()
                 );
             }
         }
         return $postalAddress;
-    }
-
-    /**
-     * Get anchor map for provided anchor.
-     *
-     * @param \Yoti\Profile\Attribute $attribute
-     *
-     * @return array<string, array> attribute map
-     */
-    private function getAttributeAnchorMap(Attribute $attribute): array
-    {
-        return [
-            Anchor::TYPE_UNKNOWN_NAME => array_filter($attribute->getAnchors(), function ($anchor): bool {
-                return $anchor->getType() == Anchor::TYPE_UNKNOWN_NAME;
-            }),
-            Anchor::TYPE_VERIFIER_OID => $attribute->getVerifiers(),
-            Anchor::TYPE_SOURCE_OID => $attribute->getSources(),
-        ];
     }
 }

--- a/src/Profile/Util/Attribute/AnchorConverter.php
+++ b/src/Profile/Util/Attribute/AnchorConverter.php
@@ -15,13 +15,13 @@ use Yoti\Util\Json;
 class AnchorConverter
 {
     /**
-     * Convert Protobuf Anchor to a map of oid -> Yoti Anchor
+     * Convert Protobuf Anchor to Yoti Anchor
      *
      * @param \Yoti\Protobuf\Attrpubapi\Anchor $protobufAnchor
      *
-     * @return array<string, mixed>
+     * @return \Yoti\Profile\Attribute\Anchor
      */
-    public static function convert(ProtobufAnchor $protobufAnchor): array
+    public static function convert(ProtobufAnchor $protobufAnchor): Anchor
     {
         $anchorSubType = $protobufAnchor->getSubType();
         $yotiSignedTimeStamp = self::convertToYotiSignedTimestamp($protobufAnchor);
@@ -31,30 +31,24 @@ class AnchorConverter
             foreach ($certX509Obj->tbsCertificate->extensions as $extObj) {
                 $anchorType = self::getAnchorTypeByOid($extObj->extnId);
                 if ($anchorType !== Anchor::TYPE_UNKNOWN_NAME) {
-                    return [
-                        'oid' => $extObj->extnId,
-                        'yoti_anchor' => new Anchor(
-                            self::decodeAnchorValue($extObj->extnValue),
-                            $anchorType,
-                            $anchorSubType,
-                            $yotiSignedTimeStamp,
-                            $X509CertsList
-                        ),
-                    ];
+                    return new Anchor(
+                        self::decodeAnchorValue($extObj->extnValue),
+                        $anchorType,
+                        $anchorSubType,
+                        $yotiSignedTimeStamp,
+                        $X509CertsList
+                    );
                 }
             }
         }
 
-        return [
-            'oid' => Anchor::TYPE_UNKNOWN_NAME,
-            'yoti_anchor' => new Anchor(
-                '',
-                Anchor::TYPE_UNKNOWN_NAME,
-                $anchorSubType,
-                $yotiSignedTimeStamp,
-                $X509CertsList
-            ),
-        ];
+        return new Anchor(
+            '',
+            Anchor::TYPE_UNKNOWN_NAME,
+            $anchorSubType,
+            $yotiSignedTimeStamp,
+            $X509CertsList
+        );
     }
 
     /**

--- a/src/Profile/Util/Attribute/AnchorListConverter.php
+++ b/src/Profile/Util/Attribute/AnchorListConverter.php
@@ -4,24 +4,21 @@ declare(strict_types=1);
 
 namespace Yoti\Profile\Util\Attribute;
 
-use Traversable;
-
 class AnchorListConverter
 {
     /**
-     * @param Traversable<\Yoti\Protobuf\Attrpubapi\Anchor> $anchorList
+     * @param \Traversable<\Yoti\Protobuf\Attrpubapi\Anchor> $protobufAnchors
      *
-     * @return array<string, array<int, mixed>>.
+     * @return \Yoti\Profile\Attribute\Anchor[]
      */
-    public static function convert(Traversable $anchorList): array
+    public static function convert(\Traversable $protobufAnchors): array
     {
-        $yotiAnchorsMap = [];
+        $yotiAnchors = [];
 
-        foreach ($anchorList as $protobufAnchor) {
-            $parsedAnchor = AnchorConverter::convert($protobufAnchor);
-            $yotiAnchorsMap[(string) $parsedAnchor['oid']][] = $parsedAnchor['yoti_anchor'];
+        foreach ($protobufAnchors as $protobufAnchor) {
+            $yotiAnchors[] = AnchorConverter::convert($protobufAnchor);
         }
 
-        return $yotiAnchorsMap;
+        return $yotiAnchors;
     }
 }

--- a/src/Profile/Util/Attribute/AttributeConverter.php
+++ b/src/Profile/Util/Attribute/AttributeConverter.php
@@ -135,7 +135,7 @@ class AttributeConverter
         }
 
         try {
-            $yotiAnchorsMap = AnchorListConverter::convert(
+            $yotiAnchors = AnchorListConverter::convert(
                 $protobufAttribute->getAnchors()
             );
             $attrValue = AttributeConverter::convertValueBasedOnContentType(
@@ -150,7 +150,7 @@ class AttributeConverter
             $yotiAttribute = new Attribute(
                 $attrName,
                 $attrValue,
-                $yotiAnchorsMap
+                $yotiAnchors
             );
         } catch (AttributeException $e) {
             error_log("{$e->getMessage()} (Attribute: {$protobufAttribute->getName()})", 0);

--- a/src/Util/Validation.php
+++ b/src/Util/Validation.php
@@ -46,13 +46,14 @@ class Validation
     }
 
     /**
-     * @param string $value
+     * @param mixed $value
      * @param string $name
      *
      * @throws \InvalidArgumentException
      */
-    public static function notEmptyString(string $value, string $name): void
+    public static function notEmptyString($value, string $name): void
     {
+        Validation::isString($value, $name);
         if (strlen($value) === 0) {
             throw new \InvalidArgumentException("{$name} cannot be empty");
         }

--- a/tests/Profile/Attribute/AnchorTest.php
+++ b/tests/Profile/Attribute/AnchorTest.php
@@ -30,17 +30,14 @@ class AnchorTest extends TestCase
      * @covers ::getOriginServerCerts
      * @covers ::__construct
      */
-    public function testYotiAnchorEndpoints()
+    public function testAnchorGetters()
     {
         $dlAnchor = new \Yoti\Protobuf\Attrpubapi\Anchor();
         $dlAnchor->mergeFromString(base64_decode(TestAnchors::SOURCE_DL_ANCHOR));
         $collection = new \ArrayObject([$dlAnchor]);
         $anchorList = AnchorListConverter::convert($collection);
 
-        /**
-         * @var Anchor $sourceAnchor
-         */
-        $sourceAnchor = $anchorList[Anchor::TYPE_SOURCE_OID][0];
+        $sourceAnchor = $anchorList[0];
 
         $this->assertEquals(Anchor::TYPE_SOURCE_NAME, $sourceAnchor->getType());
         $this->assertEquals('', $sourceAnchor->getSubtype());

--- a/tests/Profile/AttributeTest.php
+++ b/tests/Profile/AttributeTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Attribute;
+namespace YotiTest\Profile;
 
 use Yoti\Profile\Attribute;
 use Yoti\Profile\Attribute\Anchor as YotiAnchor;
@@ -30,12 +30,12 @@ class AttributeTest extends TestCase
         $protobufAnchors[] = $this->convertToProtobufAnchor(TestAnchors::VERIFIER_YOTI_ADMIN_ANCHOR);
         $protobufAnchors[] = $this->convertToProtobufAnchor(TestAnchors::UNKNOWN_ANCHOR);
         $collection = new \ArrayObject($protobufAnchors);
-        $yotiAnchorsMap = AnchorListConverter::convert($collection);
+        $anchors = AnchorListConverter::convert($collection);
 
         $this->dummyAttribute = new Attribute(
             UserProfile::ATTR_FULL_NAME,
             self::ATTR_VALUE,
-            $yotiAnchorsMap
+            $anchors
         );
     }
 
@@ -59,6 +59,7 @@ class AttributeTest extends TestCase
 
     /**
      * @covers ::getSources
+     * @covers ::filterAnchors
      * @covers ::__construct
      */
     public function testGetSources()
@@ -79,6 +80,7 @@ class AttributeTest extends TestCase
 
     /**
      * @covers ::getVerifiers
+     * @covers ::filterAnchors
      * @covers ::__construct
      */
     public function testVerifiers()
@@ -96,10 +98,6 @@ class AttributeTest extends TestCase
 
     /**
      * @covers ::getAnchors
-     * @covers ::setSources
-     * @covers ::setVerifiers
-     * @covers ::setAnchors
-     * @covers ::getAnchorType
      * @covers ::__construct
      */
     public function testGetAnchors()

--- a/tests/Profile/ExtraDataTest.php
+++ b/tests/Profile/ExtraDataTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\ExtraData;
+namespace YotiTest\Profile;
 
 use Yoti\Profile\ExtraData;
 use Yoti\Profile\ExtraData\AttributeIssuanceDetails;

--- a/tests/Profile/UserProfileTest.php
+++ b/tests/Profile/UserProfileTest.php
@@ -6,7 +6,6 @@ namespace YotiTest\Profile;
 
 use Yoti\Profile\Attribute;
 use Yoti\Profile\Attribute\AgeVerification;
-use Yoti\Profile\Attribute\Anchor;
 use Yoti\Profile\UserProfile;
 use Yoti\Profile\Util\Attribute\AnchorListConverter;
 use YotiTest\Profile\Util\Attribute\TestAnchors;
@@ -15,7 +14,7 @@ use YotiTest\TestCase;
 /**
  * @coversDefaultClass \Yoti\Profile\UserProfile
  */
-class ProfileTest extends TestCase
+class UserProfileTest extends TestCase
 {
     /**
      * @covers ::getGivenNames
@@ -73,7 +72,6 @@ class ProfileTest extends TestCase
     /**
      * @covers ::getPostalAddress
      * @covers ::getFormattedAddress
-     * @covers ::getAttributeAnchorMap
      * @covers ::getGivenNames
      * @covers ::getStructuredPostalAddress
      */
@@ -90,7 +88,7 @@ class ProfileTest extends TestCase
             "formatted_address" => "15a North Street CARSHALTON SM5 2HW UK"
         ];
 
-        $anchorsMap = AnchorListConverter::convert(new \ArrayObject([
+        $anchors = AnchorListConverter::convert(new \ArrayObject([
             $this->parseAnchor(TestAnchors::UNKNOWN_ANCHOR),
             $this->parseAnchor(TestAnchors::VERIFIER_YOTI_ADMIN_ANCHOR),
             $this->parseAnchor(TestAnchors::SOURCE_DL_ANCHOR),
@@ -99,7 +97,7 @@ class ProfileTest extends TestCase
         $structuredPostalAddress = new Attribute(
             UserProfile::ATTR_STRUCTURED_POSTAL_ADDRESS,
             $expectedPostalAddress,
-            $anchorsMap
+            $anchors
         );
 
         $profile = new UserProfile([
@@ -113,13 +111,9 @@ class ProfileTest extends TestCase
         $postalAddress = $profile->getPostalAddress();
 
         $this->assertEquals('15a North Street CARSHALTON SM5 2HW UK', $postalAddress->getValue());
-        $this->assertEquals($anchorsMap[Anchor::TYPE_SOURCE_OID], $postalAddress->getSources());
-        $this->assertEquals($anchorsMap[Anchor::TYPE_VERIFIER_OID], $postalAddress->getVerifiers());
-
-        $anchors = [];
-        array_walk($anchorsMap, function ($val) use (&$anchors) {
-            $anchors = array_merge($anchors, array_values($val));
-        });
+        $this->assertEquals($anchors[1], $postalAddress->getVerifiers()[0]);
+        $this->assertEquals($anchors[2], $postalAddress->getSources()[0]);
+        $this->assertCount(3, $postalAddress->getAnchors());
         $this->assertEquals($anchors, $postalAddress->getAnchors());
     }
 

--- a/tests/Profile/Util/Attribute/AnchorConverterTest.php
+++ b/tests/Profile/Util/Attribute/AnchorConverterTest.php
@@ -91,7 +91,7 @@ class AnchorConverterTest extends TestCase
     {
         $anchor = new \Yoti\Protobuf\Attrpubapi\Anchor();
         $anchor->mergeFromString(base64_decode($anchorString));
-        return AnchorConverter::convert($anchor)['yoti_anchor'];
+        return AnchorConverter::convert($anchor);
     }
 
     /**

--- a/tests/Profile/Util/Attribute/AnchorListConverterTest.php
+++ b/tests/Profile/Util/Attribute/AnchorListConverterTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace YotiTest\Profile\Util\Attribute;
 
-use Yoti\Profile\Attribute\Anchor;
 use Yoti\Profile\Util\Attribute\AnchorListConverter;
 use YotiTest\TestCase;
 
@@ -18,13 +17,13 @@ class AnchorListConverterTest extends TestCase
      */
     public function testConvertingTwoSources()
     {
-        $anchorsData = AnchorListConverter::convert(new \ArrayObject([
+        $anchors = AnchorListConverter::convert(new \ArrayObject([
             $this->parseFromBase64String(TestAnchors::SOURCE_PP_ANCHOR),
             $this->parseFromBase64String(TestAnchors::SOURCE_DL_ANCHOR),
         ]));
 
-        $anchorSource1 = $anchorsData[Anchor::TYPE_SOURCE_OID][0];
-        $anchorSource2 = $anchorsData[Anchor::TYPE_SOURCE_OID][1];
+        $anchorSource1 = $anchors[0];
+        $anchorSource2 = $anchors[1];
 
         $this->assertEquals('PASSPORT', $anchorSource1->getValue());
         $this->assertEquals('DRIVING_LICENCE', $anchorSource2->getValue());
@@ -35,21 +34,21 @@ class AnchorListConverterTest extends TestCase
      */
     public function testConvertingAnyAnchor()
     {
-        $anchorsData = AnchorListConverter::convert(new \ArrayObject([
+        $anchors = AnchorListConverter::convert(new \ArrayObject([
             $this->parseFromBase64String(TestAnchors::SOURCE_DL_ANCHOR),
             $this->parseFromBase64String(TestAnchors::VERIFIER_YOTI_ADMIN_ANCHOR),
             $this->parseFromBase64String(TestAnchors::UNKNOWN_ANCHOR),
         ]));
 
-        $anchorSource = $anchorsData[Anchor::TYPE_SOURCE_OID][0];
+        $anchorSource = $anchors[0];
         $this->assertEquals('SOURCE', $anchorSource->getType());
         $this->assertEquals('DRIVING_LICENCE', $anchorSource->getValue());
 
-        $anchorVerifier = $anchorsData[Anchor::TYPE_VERIFIER_OID][0];
+        $anchorVerifier = $anchors[1];
         $this->assertEquals('VERIFIER', $anchorVerifier->getType());
         $this->assertEquals('YOTI_ADMIN', $anchorVerifier->getValue());
 
-        $anchorUnknown = $anchorsData[Anchor::TYPE_UNKNOWN_NAME][0];
+        $anchorUnknown = $anchors[2];
         $this->assertEquals('UNKNOWN', $anchorUnknown->getType());
         $this->assertEquals('', $anchorUnknown->getValue());
     }

--- a/tests/Util/ValidationTest.php
+++ b/tests/Util/ValidationTest.php
@@ -262,8 +262,8 @@ class ValidationTest extends TestCase
      */
     public function testNotEmptyStringWithNonStringValue($nonStringValue)
     {
-        $this->expectException(\TypeError::class);
-        $this->expectExceptionMessage('must be of the type string');
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('some_name must be a string');
 
         Validation::notEmptyString($nonStringValue, self::SOME_NAME);
     }


### PR DESCRIPTION
### Changed
- `Yoti\Profile\Util\Attribute\AnchorConverter::convert()` now returns `Yoti\Profile\Attribute\Anchor`
- `Yoti\Profile\Util\Attribute\AnchorListConverter::convert()` now returns `Yoti\Profile\Attribute\Anchor[]` _(array)_
- `Yoti\Profile\Attribute` now expects an array of anchors, instead of `array<string, Yoti\Profile\Attribute\Anchor[]>`. This simplifies how anchors are copied to other attributes and also removes the need to process the map into a flat list for `::getAnchors()`

### Fixed
- `Validation::notEmptyString()` now allows any value and throws exception with validation message when a non-string value is provided (this was changed in #127 to only accept string values, which resulted in unfriendly validation messages)