### PR TITLE
SDK-1402: Update test namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
   },
   "autoload-dev": {
     "psr-4": {
-      "YotiTest\\": "tests/",
+      "Yoti\\Test\\": "tests/",
       "Yoti\\Sandbox\\Test\\": "sandbox/tests/"
     }
   },

--- a/sandbox/tests/Profile/Request/Attribute/SandboxAgeVerificationTest.php
+++ b/sandbox/tests/Profile/Request/Attribute/SandboxAgeVerificationTest.php
@@ -6,7 +6,7 @@ namespace Yoti\Sandbox\Test\Profile\Request\Attribute;
 
 use Yoti\Profile\UserProfile;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxAgeVerification;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Sandbox\Profile\Request\Attribute\SandboxAgeVerification

--- a/sandbox/tests/Profile/Request/Attribute/SandboxAnchorTest.php
+++ b/sandbox/tests/Profile/Request/Attribute/SandboxAnchorTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yoti\Sandbox\Test\Profile\Request\Attribute;
 
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor

--- a/sandbox/tests/Profile/Request/Attribute/SandboxAttributeTest.php
+++ b/sandbox/tests/Profile/Request/Attribute/SandboxAttributeTest.php
@@ -6,7 +6,7 @@ namespace Yoti\Sandbox\Test\Profile\Request\Attribute;
 
 use Yoti\Profile\UserProfile;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxAttribute;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Sandbox\Profile\Request\Attribute\SandboxAttribute

--- a/sandbox/tests/Profile/Request/Attribute/SandboxDocumentDetailsTest.php
+++ b/sandbox/tests/Profile/Request/Attribute/SandboxDocumentDetailsTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Yoti\Sandbox\Test\Profile\Request\Attribute;
 
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxDocumentDetails;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Sandbox\Profile\Request\Attribute\SandboxDocumentDetails

--- a/sandbox/tests/Profile/Request/TokenRequestBuilderTest.php
+++ b/sandbox/tests/Profile/Request/TokenRequestBuilderTest.php
@@ -10,7 +10,7 @@ use Yoti\Sandbox\Profile\Request\Attribute\SandboxAttribute;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxDocumentDetails;
 use Yoti\Sandbox\Profile\Request\TokenRequest;
 use Yoti\Sandbox\Profile\Request\TokenRequestBuilder;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Sandbox\Profile\Request\TokenRequestBuilder

--- a/sandbox/tests/Profile/Request/TokenRequestTest.php
+++ b/sandbox/tests/Profile/Request/TokenRequestTest.php
@@ -7,7 +7,7 @@ namespace Yoti\Sandbox\Test\Profile\Request;
 use Yoti\Http\Payload;
 use Yoti\Profile\UserProfile;
 use Yoti\Sandbox\Profile\Request\TokenRequest;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Sandbox\Profile\Request\TokenRequest

--- a/sandbox/tests/Profile/Response/TokenResponseTest.php
+++ b/sandbox/tests/Profile/Response/TokenResponseTest.php
@@ -6,7 +6,7 @@ namespace Yoti\Sandbox\Test\Profile\Response;
 
 use Psr\Http\Message\ResponseInterface;
 use Yoti\Sandbox\Profile\Response\TokenResponse;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Sandbox\Profile\Response\TokenResponse

--- a/sandbox/tests/Profile/ServiceTest.php
+++ b/sandbox/tests/Profile/ServiceTest.php
@@ -9,10 +9,10 @@ use Psr\Http\Message\ResponseInterface;
 use Yoti\Http\Payload;
 use Yoti\Sandbox\Profile\Request\TokenRequest;
 use Yoti\Sandbox\Profile\Service;
+use Yoti\Test\TestCase;
+use Yoti\Test\TestData;
 use Yoti\Util\Config;
 use Yoti\Util\PemFile;
-use YotiTest\TestCase;
-use YotiTest\TestData;
 
 /**
  * @coversDefaultClass \Yoti\Sandbox\Profile\Service

--- a/sandbox/tests/SandboxClientTest.php
+++ b/sandbox/tests/SandboxClientTest.php
@@ -9,9 +9,9 @@ use Psr\Http\Message\ResponseInterface;
 use Yoti\Http\Payload;
 use Yoti\Sandbox\Profile\Request\TokenRequest;
 use Yoti\Sandbox\SandboxClient;
+use Yoti\Test\TestCase;
+use Yoti\Test\TestData;
 use Yoti\Util\Config;
-use YotiTest\TestCase;
-use YotiTest\TestData;
 
 /**
  * @coversDefaultClass \Yoti\Sandbox\SandboxClient

--- a/src/Profile/Attribute.php
+++ b/src/Profile/Attribute.php
@@ -91,13 +91,12 @@ class Attribute
      */
     private function filterAnchors(string $type): array
     {
-        return array_values(
-            array_filter(
-                $this->anchors,
-                function (Anchor $anchor) use ($type): bool {
-                    return $anchor->getType() === $type;
-                }
-            )
+        $filteredAnchors = array_filter(
+            $this->anchors,
+            function (Anchor $anchor) use ($type): bool {
+                return $anchor->getType() === $type;
+            }
         );
+        return array_values($filteredAnchors);
     }
 }

--- a/tests/Aml/AddressTest.php
+++ b/tests/Aml/AddressTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Aml;
+namespace Yoti\Test\Aml;
 
 use Yoti\Aml\Address;
 use Yoti\Aml\Country;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Aml\Address

--- a/tests/Aml/CountryTest.php
+++ b/tests/Aml/CountryTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Aml;
+namespace Yoti\Test\Aml;
 
 use Yoti\Aml\Country;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Aml\Country

--- a/tests/Aml/ProfileTest.php
+++ b/tests/Aml/ProfileTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Aml;
+namespace Yoti\Test\Aml;
 
 use Yoti\Aml\Address;
 use Yoti\Aml\Country;
 use Yoti\Aml\Profile;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Aml\Profile

--- a/tests/Aml/ResultTest.php
+++ b/tests/Aml/ResultTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Aml;
+namespace Yoti\Test\Aml;
 
 use Yoti\Aml\Result;
+use Yoti\Test\TestCase;
+use Yoti\Test\TestData;
 use Yoti\Util\Json;
-use YotiTest\TestCase;
-use YotiTest\TestData;
 
 /**
  * @coversDefaultClass \Yoti\Aml\Result

--- a/tests/Aml/ServiceTest.php
+++ b/tests/Aml/ServiceTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Aml;
+namespace Yoti\Test\Aml;
 
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -11,10 +11,10 @@ use Yoti\Aml\Country;
 use Yoti\Aml\Profile;
 use Yoti\Aml\Result;
 use Yoti\Aml\Service;
+use Yoti\Test\TestCase;
+use Yoti\Test\TestData;
 use Yoti\Util\Config;
 use Yoti\Util\PemFile;
-use YotiTest\TestCase;
-use YotiTest\TestData;
 
 use function GuzzleHttp\Psr7\stream_for;
 

--- a/tests/ConstantsTest.php
+++ b/tests/ConstantsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace YotiTest;
+namespace Yoti\Test;
 
 use Yoti\Constants;
 

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Http;
+namespace Yoti\Test\Http;
 
 use GuzzleHttp\Exception\ConnectException;
 use GuzzleHttp\Exception\RequestException;
@@ -16,7 +16,7 @@ use Psr\Http\Client\RequestExceptionInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Yoti\Http\Client;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Http\Client

--- a/tests/Http/Exception/NetworkExceptionTest.php
+++ b/tests/Http/Exception/NetworkExceptionTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Http\Exception;
+namespace Yoti\Test\Http\Exception;
 
 use Psr\Http\Message\RequestInterface;
 use Yoti\Http\Exception\NetworkException;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Http\Exception\NetworkException

--- a/tests/Http/Exception/RequestExceptionTest.php
+++ b/tests/Http/Exception/RequestExceptionTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Http\Exception;
+namespace Yoti\Test\Http\Exception;
 
 use Psr\Http\Message\RequestInterface;
 use Yoti\Http\Exception\RequestException;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Http\Exception\RequestException

--- a/tests/Http/PayloadTest.php
+++ b/tests/Http/PayloadTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Http;
+namespace Yoti\Test\Http;
 
 use Psr\Http\Message\StreamInterface;
 use Yoti\Http\Payload;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 use function GuzzleHttp\Psr7\stream_for;
 

--- a/tests/Http/RequestBuilderTest.php
+++ b/tests/Http/RequestBuilderTest.php
@@ -2,15 +2,15 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Http;
+namespace Yoti\Test\Http;
 
 use Psr\Http\Client\ClientInterface;
 use Yoti\Http\Payload;
 use Yoti\Http\Request;
 use Yoti\Http\RequestBuilder;
+use Yoti\Test\TestCase;
+use Yoti\Test\TestData;
 use Yoti\Util\Config;
-use YotiTest\TestCase;
-use YotiTest\TestData;
 
 /**
  * @coversDefaultClass \Yoti\Http\RequestBuilder

--- a/tests/Http/RequestSignerTest.php
+++ b/tests/Http/RequestSignerTest.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Http;
+namespace Yoti\Test\Http;
 
 use Yoti\Aml\Address;
 use Yoti\Aml\Country;
 use Yoti\Aml\Profile;
 use Yoti\Http\Payload;
 use Yoti\Http\RequestSigner;
+use Yoti\Test\TestCase;
+use Yoti\Test\TestData;
 use Yoti\Util\PemFile;
-use YotiTest\TestCase;
-use YotiTest\TestData;
 
 /**
  * @coversDefaultClass \Yoti\Http\RequestSigner

--- a/tests/Http/RequestTest.php
+++ b/tests/Http/RequestTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Http;
+namespace Yoti\Test\Http;
 
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\RequestInterface;
 use Psr\Http\Message\ResponseInterface;
 use Yoti\Http\Request;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Http\Request

--- a/tests/Media/ImageTest.php
+++ b/tests/Media/ImageTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Media;
+namespace Yoti\Test\Media;
 
 use Yoti\Media\Image;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Media\Image

--- a/tests/Profile/ActivityDetailsTest.php
+++ b/tests/Profile/ActivityDetailsTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile;
+namespace Yoti\Test\Profile;
 
 use Yoti\Media\Image;
 use Yoti\Profile\ActivityDetails;
@@ -12,9 +12,9 @@ use Yoti\Profile\ExtraData;
 use Yoti\Profile\ExtraData\AttributeIssuanceDetails;
 use Yoti\Profile\Receipt;
 use Yoti\Profile\UserProfile;
+use Yoti\Test\TestCase;
+use Yoti\Test\TestData;
 use Yoti\Util\PemFile;
-use YotiTest\TestCase;
-use YotiTest\TestData;
 
 /**
  * @coversDefaultClass \Yoti\Profile\ActivityDetails

--- a/tests/Profile/ApplicationProfileTest.php
+++ b/tests/Profile/ApplicationProfileTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile;
+namespace Yoti\Test\Profile;
 
 use Yoti\Media\Image;
 use Yoti\Profile\ApplicationProfile;
 use Yoti\Profile\Attribute;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\ApplicationProfile

--- a/tests/Profile/Attribute/AgeVerificationTest.php
+++ b/tests/Profile/Attribute/AgeVerificationTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Attribute;
+namespace Yoti\Test\Profile\Attribute;
 
 use Yoti\Profile\Attribute;
 use Yoti\Profile\Attribute\AgeVerification;
 use Yoti\Profile\UserProfile;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Attribute\AgeVerification

--- a/tests/Profile/Attribute/AnchorTest.php
+++ b/tests/Profile/Attribute/AnchorTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Attribute;
+namespace Yoti\Test\Profile\Attribute;
 
 use Yoti\Profile\Attribute\Anchor;
 use Yoti\Profile\Util\Attribute\AnchorListConverter;
-use YotiTest\Profile\Util\Attribute\TestAnchors;
-use YotiTest\TestCase;
+use Yoti\Test\Profile\Util\Attribute\TestAnchors;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Attribute\Anchor

--- a/tests/Profile/Attribute/DocumentDetailsTest.php
+++ b/tests/Profile/Attribute/DocumentDetailsTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Attribute;
+namespace Yoti\Test\Profile\Attribute;
 
 use Yoti\Profile\Attribute\DocumentDetails;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Attribute\DocumentDetails

--- a/tests/Profile/Attribute/MultiValueTest.php
+++ b/tests/Profile/Attribute/MultiValueTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Attribute;
+namespace Yoti\Test\Profile\Attribute;
 
 use Yoti\Media\Image;
 use Yoti\Profile\Attribute\MultiValue;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Attribute\MultiValue

--- a/tests/Profile/Attribute/SignedTimestampTest.php
+++ b/tests/Profile/Attribute/SignedTimestampTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Attribute;
+namespace Yoti\Test\Profile\Attribute;
 
 use Yoti\Profile\Attribute\SignedTimestamp;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Attribute\SignedTimestamp

--- a/tests/Profile/AttributeTest.php
+++ b/tests/Profile/AttributeTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile;
+namespace Yoti\Test\Profile;
 
 use Yoti\Profile\Attribute;
 use Yoti\Profile\Attribute\Anchor as YotiAnchor;
 use Yoti\Profile\UserProfile;
 use Yoti\Profile\Util\Attribute\AnchorListConverter;
-use YotiTest\Profile\Util\Attribute\TestAnchors;
-use YotiTest\TestCase;
+use Yoti\Test\Profile\Util\Attribute\TestAnchors;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Attribute

--- a/tests/Profile/BaseProfileTest.php
+++ b/tests/Profile/BaseProfileTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile;
+namespace Yoti\Test\Profile;
 
 use Yoti\Profile\Attribute;
 use Yoti\Profile\BaseProfile;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\BaseProfile

--- a/tests/Profile/ExtraData/AttributeDefinitionTest.php
+++ b/tests/Profile/ExtraData/AttributeDefinitionTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\ExtraData;
+namespace Yoti\Test\Profile\ExtraData;
 
 use Yoti\Profile\ExtraData\AttributeDefinition;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\ExtraData\AttributeDefinition

--- a/tests/Profile/ExtraData/AttributeIssuanceDetailsTest.php
+++ b/tests/Profile/ExtraData/AttributeIssuanceDetailsTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\ExtraData;
+namespace Yoti\Test\Profile\ExtraData;
 
 use Yoti\Profile\ExtraData\AttributeDefinition;
 use Yoti\Profile\ExtraData\AttributeIssuanceDetails;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\ExtraData\AttributeIssuanceDetails

--- a/tests/Profile/ExtraDataTest.php
+++ b/tests/Profile/ExtraDataTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile;
+namespace Yoti\Test\Profile;
 
 use Yoti\Profile\ExtraData;
 use Yoti\Profile\ExtraData\AttributeIssuanceDetails;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\ExtraData

--- a/tests/Profile/ReceiptTest.php
+++ b/tests/Profile/ReceiptTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile;
+namespace Yoti\Test\Profile;
 
 use Yoti\Profile\ApplicationProfile;
 use Yoti\Profile\ExtraData;
@@ -11,9 +11,9 @@ use Yoti\Profile\Receipt;
 use Yoti\Profile\UserProfile;
 use Yoti\Profile\Util\Attribute\AttributeListConverter;
 use Yoti\Protobuf\Attrpubapi\AttributeList;
+use Yoti\Test\TestCase;
+use Yoti\Test\TestData;
 use Yoti\Util\PemFile;
-use YotiTest\TestCase;
-use YotiTest\TestData;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Receipt

--- a/tests/Profile/ServiceTest.php
+++ b/tests/Profile/ServiceTest.php
@@ -2,16 +2,16 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile;
+namespace Yoti\Test\Profile;
 
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use Yoti\Profile\ActivityDetails;
 use Yoti\Profile\Service;
+use Yoti\Test\TestCase;
+use Yoti\Test\TestData;
 use Yoti\Util\Config;
 use Yoti\Util\PemFile;
-use YotiTest\TestCase;
-use YotiTest\TestData;
 
 use function GuzzleHttp\Psr7\stream_for;
 

--- a/tests/Profile/UserProfileTest.php
+++ b/tests/Profile/UserProfileTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile;
+namespace Yoti\Test\Profile;
 
 use Yoti\Profile\Attribute;
 use Yoti\Profile\Attribute\AgeVerification;
 use Yoti\Profile\UserProfile;
 use Yoti\Profile\Util\Attribute\AnchorListConverter;
-use YotiTest\Profile\Util\Attribute\TestAnchors;
-use YotiTest\TestCase;
+use Yoti\Test\Profile\Util\Attribute\TestAnchors;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\UserProfile

--- a/tests/Profile/Util/Attribute/AnchorConverterTest.php
+++ b/tests/Profile/Util/Attribute/AnchorConverterTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Util\Attribute;
+namespace Yoti\Test\Profile\Util\Attribute;
 
 use Yoti\Profile\Attribute\Anchor;
 use Yoti\Profile\Util\Attribute\AnchorConverter;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Util\Attribute\AnchorConverter

--- a/tests/Profile/Util/Attribute/AnchorListConverterTest.php
+++ b/tests/Profile/Util/Attribute/AnchorListConverterTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Util\Attribute;
+namespace Yoti\Test\Profile\Util\Attribute;
 
 use Yoti\Profile\Util\Attribute\AnchorListConverter;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Util\Attribute\AnchorListConverter

--- a/tests/Profile/Util/Attribute/AttributeConverterTest.php
+++ b/tests/Profile/Util/Attribute/AttributeConverterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Util\Attribute;
+namespace Yoti\Test\Profile\Util\Attribute;
 
 use Yoti\Media\Image;
 use Yoti\Profile\ActivityDetails;
@@ -10,9 +10,9 @@ use Yoti\Profile\Attribute;
 use Yoti\Profile\Attribute\MultiValue;
 use Yoti\Profile\Receipt;
 use Yoti\Profile\Util\Attribute\AttributeConverter;
+use Yoti\Test\TestCase;
+use Yoti\Test\TestData;
 use Yoti\Util\PemFile;
-use YotiTest\TestCase;
-use YotiTest\TestData;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Util\Attribute\AttributeConverter

--- a/tests/Profile/Util/Attribute/AttributeListConverterTest.php
+++ b/tests/Profile/Util/Attribute/AttributeListConverterTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Util\Attribute;
+namespace Yoti\Test\Profile\Util\Attribute;
 
 use Yoti\Profile\Attribute;
 use Yoti\Profile\Util\Attribute\AttributeConverter;
 use Yoti\Profile\Util\Attribute\AttributeListConverter;
 use Yoti\Protobuf\Attrpubapi\Attribute as AttributeProto;
 use Yoti\Protobuf\Attrpubapi\AttributeList;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Util\Attribute\AttributeListConverter

--- a/tests/Profile/Util/Attribute/TestAnchors.php
+++ b/tests/Profile/Util/Attribute/TestAnchors.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Util\Attribute;
+namespace Yoti\Test\Profile\Util\Attribute;
 
 class TestAnchors
 {

--- a/tests/Profile/Util/EncryptedDataTest.php
+++ b/tests/Profile/Util/EncryptedDataTest.php
@@ -2,14 +2,14 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Util;
+namespace Yoti\Test\Profile\Util;
 
 use Yoti\Exception\EncryptedDataException;
 use Yoti\Profile\Util\EncryptedData;
 use Yoti\Protobuf\Compubapi\EncryptedData as EncryptedDataProto;
+use Yoti\Test\TestCase;
+use Yoti\Test\TestData;
 use Yoti\Util\PemFile;
-use YotiTest\TestCase;
-use YotiTest\TestData;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Util\EncryptedData

--- a/tests/Profile/Util/ExtraData/DataEntryConverterTest.php
+++ b/tests/Profile/Util/ExtraData/DataEntryConverterTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Util\ExtraData;
+namespace Yoti\Test\Profile\Util\ExtraData;
 
 use Yoti\Profile\ExtraData\AttributeIssuanceDetails;
 use Yoti\Profile\Util\ExtraData\DataEntryConverter;
 use Yoti\Protobuf\Sharepubapi\ThirdPartyAttribute;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Util\ExtraData\DataEntryConverter

--- a/tests/Profile/Util/ExtraData/ExtraDataConverterTest.php
+++ b/tests/Profile/Util/ExtraData/ExtraDataConverterTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Util\ExtraData;
+namespace Yoti\Test\Profile\Util\ExtraData;
 
 use Yoti\Profile\ExtraData;
 use Yoti\Profile\ExtraData\AttributeIssuanceDetails;
@@ -11,8 +11,8 @@ use Yoti\Protobuf\Sharepubapi\DataEntry;
 use Yoti\Protobuf\Sharepubapi\ExtraData as ExtraDataProto;
 use Yoti\Protobuf\Sharepubapi\IssuingAttributes;
 use Yoti\Protobuf\Sharepubapi\ThirdPartyAttribute;
-use YotiTest\TestCase;
-use YotiTest\TestData;
+use Yoti\Test\TestCase;
+use Yoti\Test\TestData;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Util\ExtraData\ExtraDataConverter

--- a/tests/Profile/Util/ExtraData/ThirdPartyAttributeConverterTest.php
+++ b/tests/Profile/Util/ExtraData/ThirdPartyAttributeConverterTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Profile\Util\ExtraData;
+namespace Yoti\Test\Profile\Util\ExtraData;
 
 use Yoti\Profile\Util\ExtraData\ThirdPartyAttributeConverter;
 use Yoti\Protobuf\Sharepubapi\Definition;
 use Yoti\Protobuf\Sharepubapi\IssuingAttributes;
 use Yoti\Protobuf\Sharepubapi\ThirdPartyAttribute;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Util\ExtraData\ThirdPartyAttributeConverter

--- a/tests/ShareUrl/DynamicScenarioBuilderTest.php
+++ b/tests/ShareUrl/DynamicScenarioBuilderTest.php
@@ -2,13 +2,13 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\ShareUrl;
+namespace Yoti\Test\ShareUrl;
 
 use Yoti\ShareUrl\DynamicScenarioBuilder;
 use Yoti\ShareUrl\Extension\ExtensionBuilder;
 use Yoti\ShareUrl\Policy\DynamicPolicy;
 use Yoti\ShareUrl\Policy\DynamicPolicyBuilder;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\ShareUrl\DynamicScenarioBuilder

--- a/tests/ShareUrl/Extension/ExtensionBuilderTest.php
+++ b/tests/ShareUrl/Extension/ExtensionBuilderTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\ShareUrl\Extension;
+namespace Yoti\Test\ShareUrl\Extension;
 
 use Yoti\ShareUrl\Extension\ExtensionBuilder;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\ShareUrl\Extension\ExtensionBuilder

--- a/tests/ShareUrl/Extension/LocationConstraintContentTest.php
+++ b/tests/ShareUrl/Extension/LocationConstraintContentTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Test\ShareUrl\Extension;
+
+use Yoti\ShareUrl\Extension\LocationConstraintContent;
+use Yoti\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\ShareUrl\Extension\LocationConstraintContent
+ */
+class LocationConstraintContentTest extends TestCase
+{
+    const TYPE_LOCATION_CONSTRAINT = 'LOCATION_CONSTRAINT';
+    const SOME_LATITUDE = 50.8169;
+    const SOME_LONGITUDE = -0.1367;
+
+    /**
+     * @covers ::__construct
+     * @covers ::jsonSerialize
+     * @covers ::__toString
+     */
+    public function testBuild()
+    {
+        $expectedLatitude = 50.8169;
+        $expectedLongitude = -0.1367;
+        $expectedRadius = 30;
+        $expectedmaxUncertainty = 40;
+
+        $content = new LocationConstraintContent(
+            $expectedLatitude,
+            $expectedLongitude,
+            $expectedRadius,
+            $expectedmaxUncertainty
+        );
+
+        $expectedJson = json_encode([
+            'expected_device_location' => [
+                'latitude' => $expectedLatitude,
+                'longitude' => $expectedLongitude,
+                'radius' => $expectedRadius,
+                'max_uncertainty_radius' => $expectedmaxUncertainty,
+            ],
+        ]);
+
+        $this->assertEquals($expectedJson, json_encode($content));
+        $this->assertEquals($expectedJson, $content);
+    }
+}

--- a/tests/ShareUrl/Extension/LocationConstraintExtensionBuilderTest.php
+++ b/tests/ShareUrl/Extension/LocationConstraintExtensionBuilderTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\ShareUrl\Extension;
+namespace Yoti\Test\ShareUrl\Extension;
 
 use Yoti\ShareUrl\Extension\LocationConstraintExtensionBuilder;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\ShareUrl\Extension\LocationConstraintExtensionBuilder

--- a/tests/ShareUrl/Extension/LocationConstraintExtensionBuilderTest.php
+++ b/tests/ShareUrl/Extension/LocationConstraintExtensionBuilderTest.php
@@ -137,8 +137,6 @@ class LocationConstraintExtensionBuilderTest extends TestCase
 
     /**
      * @covers ::build
-     * @covers \Yoti\ShareUrl\Extension\LocationConstraintContent::__construct
-     * @covers \Yoti\ShareUrl\Extension\LocationConstraintContent::jsonSerialize
      */
     public function testBuildDefaultValues()
     {

--- a/tests/ShareUrl/Extension/ThirdPartyAttributeContentTest.php
+++ b/tests/ShareUrl/Extension/ThirdPartyAttributeContentTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\ShareUrl\Extension;
+namespace Yoti\Test\ShareUrl\Extension;
 
 use Yoti\Profile\ExtraData\AttributeDefinition;
 use Yoti\ShareUrl\Extension\ThirdPartyAttributeContent;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\ShareUrl\Extension\ThirdPartyAttributeContent

--- a/tests/ShareUrl/Extension/ThirdPartyAttributeExtensionBuilderTest.php
+++ b/tests/ShareUrl/Extension/ThirdPartyAttributeExtensionBuilderTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\ShareUrl\Extension;
+namespace Yoti\Test\ShareUrl\Extension;
 
 use Yoti\ShareUrl\Extension\ThirdPartyAttributeExtensionBuilder;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\ShareUrl\Extension\ThirdPartyAttributeExtensionBuilder

--- a/tests/ShareUrl/Extension/TransactionalFlowExtensionBuilderTest.php
+++ b/tests/ShareUrl/Extension/TransactionalFlowExtensionBuilderTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\ShareUrl\Extension;
+namespace Yoti\Test\ShareUrl\Extension;
 
 use Yoti\ShareUrl\Extension\TransactionalFlowExtensionBuilder;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\ShareUrl\Extension\TransactionalFlowExtensionBuilder

--- a/tests/ShareUrl/Policy/ConstraintsBuilderTest.php
+++ b/tests/ShareUrl/Policy/ConstraintsBuilderTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\ShareUrl\Policy;
+namespace Yoti\Test\ShareUrl\Policy;
 
 use Yoti\ShareUrl\Policy\ConstraintsBuilder;
 use Yoti\ShareUrl\Policy\SourceConstraintBuilder;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\ShareUrl\Policy\ConstraintsBuilder

--- a/tests/ShareUrl/Policy/DynamicPolicyBuilderTest.php
+++ b/tests/ShareUrl/Policy/DynamicPolicyBuilderTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\ShareUrl\Policy;
+namespace Yoti\Test\ShareUrl\Policy;
 
 use Yoti\ShareUrl\Policy\DynamicPolicyBuilder;
 use Yoti\ShareUrl\Policy\WantedAttributeBuilder;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\ShareUrl\Policy\DynamicPolicyBuilder

--- a/tests/ShareUrl/Policy/SourceConstraintBuilderTest.php
+++ b/tests/ShareUrl/Policy/SourceConstraintBuilderTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\ShareUrl\Policy;
+namespace Yoti\Test\ShareUrl\Policy;
 
 use Yoti\ShareUrl\Policy\SourceConstraintBuilder;
 use Yoti\ShareUrl\Policy\WantedAnchorBuilder;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\ShareUrl\Policy\SourceConstraintBuilder

--- a/tests/ShareUrl/Policy/WantedAnchorBuilderTest.php
+++ b/tests/ShareUrl/Policy/WantedAnchorBuilderTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\ShareUrl\Policy;
+namespace Yoti\Test\ShareUrl\Policy;
 
 use Yoti\ShareUrl\Policy\WantedAnchorBuilder;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\ShareUrl\Policy\WantedAnchorBuilder

--- a/tests/ShareUrl/Policy/WantedAttributeBuilderTest.php
+++ b/tests/ShareUrl/Policy/WantedAttributeBuilderTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\ShareUrl\Policy;
+namespace Yoti\Test\ShareUrl\Policy;
 
 use Yoti\ShareUrl\Policy\ConstraintsBuilder;
 use Yoti\ShareUrl\Policy\SourceConstraintBuilder;
 use Yoti\ShareUrl\Policy\WantedAttributeBuilder;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\ShareUrl\Policy\WantedAttributeBuilder

--- a/tests/ShareUrl/ResultTest.php
+++ b/tests/ShareUrl/ResultTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Service\ShareUrl;
+namespace Yoti\Test\Service\ShareUrl;
 
 use Yoti\ShareUrl\Result;
-use YotiTest\TestCase;
+use Yoti\Test\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\ShareUrl\Result

--- a/tests/ShareUrl/ServiceTest.php
+++ b/tests/ShareUrl/ServiceTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Service\ShareUrl;
+namespace Yoti\Test\Service\ShareUrl;
 
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -11,10 +11,10 @@ use Yoti\ShareUrl\DynamicScenario;
 use Yoti\ShareUrl\DynamicScenarioBuilder;
 use Yoti\ShareUrl\Policy\DynamicPolicyBuilder;
 use Yoti\ShareUrl\Service;
+use Yoti\Test\TestCase;
+use Yoti\Test\TestData;
 use Yoti\Util\Config;
 use Yoti\Util\PemFile;
-use YotiTest\TestCase;
-use YotiTest\TestData;
 
 use function GuzzleHttp\Psr7\stream_for;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace YotiTest;
+namespace Yoti\Test;
 
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
 

--- a/tests/TestData.php
+++ b/tests/TestData.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace YotiTest;
+namespace Yoti\Test;
 
 class TestData
 {

--- a/tests/Util/ConfigTest.php
+++ b/tests/Util/ConfigTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Util;
+namespace Yoti\Test\Util;
 
 use Psr\Http\Client\ClientInterface;
 use Yoti\Constants;
+use Yoti\Test\TestCase;
 use Yoti\Util\Config;
-use YotiTest\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Util\Config

--- a/tests/Util/DateTimeTest.php
+++ b/tests/Util/DateTimeTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Util;
+namespace Yoti\Test\Util;
 
+use Yoti\Test\TestCase;
 use Yoti\Util\DateTime;
-use YotiTest\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Util\DateTime

--- a/tests/Util/JsonTest.php
+++ b/tests/Util/JsonTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Util;
+namespace Yoti\Test\Util;
 
+use Yoti\Test\TestCase;
 use Yoti\Util\Json;
-use YotiTest\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Util\Json

--- a/tests/Util/PemFileTest.php
+++ b/tests/Util/PemFileTest.php
@@ -2,11 +2,11 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Util;
+namespace Yoti\Test\Util;
 
+use Yoti\Test\TestCase;
+use Yoti\Test\TestData;
 use Yoti\Util\PemFile;
-use YotiTest\TestCase;
-use YotiTest\TestData;
 
 /**
  * @coversDefaultClass \Yoti\Util\PemFile
@@ -205,5 +205,5 @@ namespace Yoti\Util;
  */
 function openssl_pkey_get_details()
 {
-    return \YotiTest\TestCase::callMockFunction(__FUNCTION__, func_get_args());
+    return \Yoti\Test\TestCase::callMockFunction(__FUNCTION__, func_get_args());
 }

--- a/tests/Util/ValidationTest.php
+++ b/tests/Util/ValidationTest.php
@@ -2,10 +2,10 @@
 
 declare(strict_types=1);
 
-namespace YotiTest\Util;
+namespace Yoti\Test\Util;
 
+use Yoti\Test\TestCase;
 use Yoti\Util\Validation;
-use YotiTest\TestCase;
 
 /**
  * @coversDefaultClass \Yoti\Util\Validation

--- a/tests/YotiClientTest.php
+++ b/tests/YotiClientTest.php
@@ -2,7 +2,7 @@
 
 declare(strict_types=1);
 
-namespace YotiTest;
+namespace Yoti\Test;
 
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;


### PR DESCRIPTION
### Changed
- `YotiTest` namespace changed to `Yoti\Test`, where _"Yoti"_ is the vendor (see https://www.php-fig.org/psr/psr-4/)
- `Attribute::filterAnchors()` changed to be more readable and to fix coverage report of `array_filter()` in that method - I believe this could be a bug with PHPUnit, so will investigate.

### Added
- Missing tests for ShareUrl classes
