### PR TITLE
SDK-1420: Add constant visibility

### DIFF
--- a/.phpcs.xml.dist
+++ b/.phpcs.xml.dist
@@ -1,8 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Yoti">
   <rule ref="PSR12">
-    <!-- Excluding constant visibility sniff in order to support PHP 5.6 -->
-    <exclude name="PSR12.Properties.ConstantVisibility"/>
     <!--
     Windows users that have enabled `core.autocrlf` in their git configuration
     can disable the `Generic.Files.LineEndings` rule by copying this file to

--- a/sandbox/src/Profile/Request/Attribute/SandboxAgeVerification.php
+++ b/sandbox/src/Profile/Request/Attribute/SandboxAgeVerification.php
@@ -8,8 +8,8 @@ use Yoti\Profile\UserProfile;
 
 class SandboxAgeVerification extends SandboxAttribute
 {
-    const AGE_OVER_FORMAT = 'age_over:%d';
-    const AGE_UNDER_FORMAT = 'age_under:%d';
+    private const AGE_OVER_FORMAT = 'age_over:%d';
+    private const AGE_UNDER_FORMAT = 'age_under:%d';
 
     /**
      * @param \DateTime $dateObj

--- a/sandbox/src/Profile/Service.php
+++ b/sandbox/src/Profile/Service.php
@@ -12,7 +12,7 @@ use Yoti\Util\PemFile;
 
 class Service
 {
-    const TOKEN_REQUEST_ENDPOINT_FORMAT = "/apps/%s/tokens";
+    private const TOKEN_REQUEST_ENDPOINT_FORMAT = "/apps/%s/tokens";
 
     /**
      * @var string

--- a/sandbox/src/SandboxClient.php
+++ b/sandbox/src/SandboxClient.php
@@ -15,7 +15,7 @@ class SandboxClient
     /**
      * Default sandbox API URL.
      */
-    const SANDBOX_URL = Constants::API_BASE_URL . '/sandbox/v1';
+    private const SANDBOX_URL = Constants::API_BASE_URL . '/sandbox/v1';
 
     /**
      * @var \Yoti\Sandbox\Profile\Service

--- a/sandbox/tests/Profile/Request/TokenRequestBuilderTest.php
+++ b/sandbox/tests/Profile/Request/TokenRequestBuilderTest.php
@@ -17,12 +17,12 @@ use Yoti\Test\TestCase;
  */
 class TokenRequestBuilderTest extends TestCase
 {
-    const SOME_REMEMBER_ME_ID = 'some_remember_me_id';
-    const SOME_NAME = 'some name';
-    const SOME_STRING_VALUE = 'some string';
-    const SOME_TYPE = 'some type';
-    const SOME_SUB_TYPE = 'some sub type';
-    const SOME_TIMESTAMP = 1575998454;
+    private const SOME_REMEMBER_ME_ID = 'some_remember_me_id';
+    private const SOME_NAME = 'some name';
+    private const SOME_STRING_VALUE = 'some string';
+    private const SOME_TYPE = 'some type';
+    private const SOME_SUB_TYPE = 'some sub type';
+    private const SOME_TIMESTAMP = 1575998454;
 
     /**
      * @var \Yoti\Sandbox\Profile\RequestBuilders

--- a/sandbox/tests/Profile/Request/TokenRequestTest.php
+++ b/sandbox/tests/Profile/Request/TokenRequestTest.php
@@ -14,8 +14,8 @@ use Yoti\Test\TestCase;
  */
 class TokenRequestTest extends TestCase
 {
-    const SOME_REMEMBER_ME_ID = 'some_remember_me_id';
-    const SOME_FAMILY_NAME = 'some family name';
+    private const SOME_REMEMBER_ME_ID = 'some_remember_me_id';
+    private const SOME_FAMILY_NAME = 'some family name';
 
     /**
      * @var TokenRequest

--- a/src/Aml/Address.php
+++ b/src/Aml/Address.php
@@ -8,8 +8,8 @@ use Yoti\Util\Json;
 
 class Address implements \JsonSerializable
 {
-    const POSTCODE_ATTR = 'post_code';
-    const COUNTRY_ATTR = 'country';
+    private const POSTCODE_ATTR = 'post_code';
+    private const COUNTRY_ATTR = 'country';
 
     /**
      * @var ?string

--- a/src/Aml/Profile.php
+++ b/src/Aml/Profile.php
@@ -8,10 +8,10 @@ use Yoti\Util\Json;
 
 class Profile implements \JsonSerializable
 {
-    const GIVEN_NAMES_ATTR  = 'given_names';
-    const FAMILY_NAME_ATTR  = 'family_name';
-    const SSN_ATTR          = 'ssn';
-    const ADDRESS_ATTR      = 'address';
+    private const GIVEN_NAMES_ATTR  = 'given_names';
+    private const FAMILY_NAME_ATTR  = 'family_name';
+    private const SSN_ATTR          = 'ssn';
+    private const ADDRESS_ATTR      = 'address';
 
     /**
      * Given Names.

--- a/src/Aml/Result.php
+++ b/src/Aml/Result.php
@@ -9,9 +9,9 @@ use Yoti\Util\Json;
 
 class Result
 {
-    const ON_PEP_LIST_KEY = 'on_pep_list';
-    const ON_FRAUD_LIST_KEY = 'on_fraud_list';
-    const ON_WATCH_LIST_KEY = 'on_watch_list';
+    private const ON_PEP_LIST_KEY = 'on_pep_list';
+    private const ON_FRAUD_LIST_KEY = 'on_fraud_list';
+    private const ON_WATCH_LIST_KEY = 'on_watch_list';
 
     /**
      * Politically exposed person.

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -7,20 +7,20 @@ namespace Yoti;
 class Constants
 {
     /** Default API base URL */
-    const API_BASE_URL = 'https://api.yoti.com';
+    public const API_BASE_URL = 'https://api.yoti.com';
 
     /** Default API URL */
-    const API_URL = self::API_BASE_URL . '/api/v1';
+    public const API_URL = self::API_BASE_URL . '/api/v1';
 
     /** Default SDK identifier */
-    const SDK_IDENTIFIER = 'PHP';
+    public const SDK_IDENTIFIER = 'PHP';
 
     /** Default SDK version */
-    const SDK_VERSION = '3.0.0';
+    public const SDK_VERSION = '3.0.0';
 
     /** Base url for connect page (user will be redirected to this page eg. baseurl/app-id) */
-    const CONNECT_BASE_URL = 'https://www.yoti.com/connect';
+    public const CONNECT_BASE_URL = 'https://www.yoti.com/connect';
 
     /** Yoti Hub login */
-    const DASHBOARD_URL = 'https://hub.yoti.com';
+    public const DASHBOARD_URL = 'https://hub.yoti.com';
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -11,11 +11,11 @@ use Psr\Http\Message\ResponseInterface;
 class Request
 {
     /** HTTP methods */
-    const METHOD_GET = 'GET';
-    const METHOD_POST = 'POST';
-    const METHOD_PUT = 'PUT';
-    const METHOD_PATCH = 'PATCH';
-    const METHOD_DELETE = 'DELETE';
+    public const METHOD_GET = 'GET';
+    public const METHOD_POST = 'POST';
+    public const METHOD_PUT = 'PUT';
+    public const METHOD_PATCH = 'PATCH';
+    public const METHOD_DELETE = 'DELETE';
 
     /**
      * @var \Psr\Http\Message\RequestInterface

--- a/src/Http/RequestBuilder.php
+++ b/src/Http/RequestBuilder.php
@@ -14,13 +14,13 @@ use function GuzzleHttp\Psr7\uri_for;
 class RequestBuilder
 {
     /** Digest HTTP header key. */
-    const YOTI_DIGEST_HEADER_KEY = 'X-Yoti-Auth-Digest';
+    private const YOTI_DIGEST_HEADER_KEY = 'X-Yoti-Auth-Digest';
 
     /** SDK Identifier HTTP header key. */
-    const YOTI_SDK_IDENTIFIER_HEADER_KEY = 'X-Yoti-SDK';
+    private const YOTI_SDK_IDENTIFIER_HEADER_KEY = 'X-Yoti-SDK';
 
     /** SDK Version HTTP header key. */
-    const YOTI_SDK_VERSION_HEADER_KEY = 'X-Yoti-SDK-Version';
+    private const YOTI_SDK_VERSION_HEADER_KEY = 'X-Yoti-SDK-Version';
 
     /**
      * @var string

--- a/src/Profile/ActivityDetails.php
+++ b/src/Profile/ActivityDetails.php
@@ -98,10 +98,8 @@ class ActivityDetails
 
     private function setProfile(): void
     {
-        $protobufAttrList = $this->receipt->parseAttribute(
-            Receipt::ATTR_OTHER_PARTY_PROFILE_CONTENT,
-            $this->pemFile
-        );
+        $protobufAttrList = $this->receipt->parseOtherPartyProfileContent($this->pemFile);
+
         $this->userProfile = new UserProfile(
             AttributeListConverter::convertToYotiAttributesList($protobufAttrList)
         );
@@ -109,10 +107,8 @@ class ActivityDetails
 
     private function setApplicationProfile(): void
     {
-        $protobufAttrList = $this->receipt->parseAttribute(
-            Receipt::ATTR_PROFILE_CONTENT,
-            $this->pemFile
-        );
+        $protobufAttrList = $this->receipt->parseProfileContent($this->pemFile);
+
         $this->applicationProfile = new ApplicationProfile(
             AttributeListConverter::convertToYotiAttributesList($protobufAttrList)
         );

--- a/src/Profile/ApplicationProfile.php
+++ b/src/Profile/ApplicationProfile.php
@@ -9,10 +9,10 @@ namespace Yoti\Profile;
  */
 class ApplicationProfile extends BaseProfile
 {
-    const ATTR_APPLICATION_LOGO = 'application_logo';
-    const ATTR_APPLICATION_NAME = 'application_name';
-    const ATTR_APPLICATION_URL = 'application_url';
-    const ATTR_APPLICATION_RECEIPT_BG_COLOR = 'application_receipt_bgcolor';
+    public const ATTR_APPLICATION_LOGO = 'application_logo';
+    public const ATTR_APPLICATION_NAME = 'application_name';
+    public const ATTR_APPLICATION_URL = 'application_url';
+    public const ATTR_APPLICATION_RECEIPT_BG_COLOR = 'application_receipt_bgcolor';
 
     /**
      * The name of the application.

--- a/src/Profile/Attribute/Anchor.php
+++ b/src/Profile/Attribute/Anchor.php
@@ -15,11 +15,11 @@ namespace Yoti\Profile\Attribute;
  */
 class Anchor
 {
-    const TYPE_SOURCE_NAME = 'SOURCE';
-    const TYPE_VERIFIER_NAME = 'VERIFIER';
-    const TYPE_UNKNOWN_NAME = 'UNKNOWN';
-    const TYPE_SOURCE_OID = '1.3.6.1.4.1.47127.1.1.1';
-    const TYPE_VERIFIER_OID = '1.3.6.1.4.1.47127.1.1.2';
+    public const TYPE_SOURCE_NAME = 'SOURCE';
+    public const TYPE_VERIFIER_NAME = 'VERIFIER';
+    public const TYPE_UNKNOWN_NAME = 'UNKNOWN';
+    public const TYPE_SOURCE_OID = '1.3.6.1.4.1.47127.1.1.1';
+    public const TYPE_VERIFIER_OID = '1.3.6.1.4.1.47127.1.1.2';
 
     /**
      * @var string

--- a/src/Profile/Attribute/DocumentDetails.php
+++ b/src/Profile/Attribute/DocumentDetails.php
@@ -14,12 +14,12 @@ class DocumentDetails
      * The values of the Document Details are in the format and order as defined in this pattern
      * e.g PASS_CARD GBR 22719564893 - CITIZENCARD, the last two are optionals
      */
-    const VALIDATION_PATTERN = '/^([A-Za-z_]*) ([A-Za-z]{3}) ([A-Za-z0-9]{1}).*$/';
-    const TYPE_INDEX = 0;
-    const COUNTRY_INDEX = 1;
-    const NUMBER_INDEX = 2;
-    const EXPIRATION_INDEX = 3;
-    const AUTHORITY_INDEX = 4;
+    private const VALIDATION_PATTERN = '/^([A-Za-z_]*) ([A-Za-z]{3}) ([A-Za-z0-9]{1}).*$/';
+    private const TYPE_INDEX = 0;
+    private const COUNTRY_INDEX = 1;
+    private const NUMBER_INDEX = 2;
+    private const EXPIRATION_INDEX = 3;
+    private const AUTHORITY_INDEX = 4;
 
     /**
      * @var string

--- a/src/Profile/Receipt.php
+++ b/src/Profile/Receipt.php
@@ -12,15 +12,15 @@ use Yoti\Util\PemFile;
 
 class Receipt
 {
-    const ATTR_TIMESTAMP = 'timestamp';
-    const ATTR_RECEIPT_ID = 'receipt_id';
-    const ATTR_REMEMBER_ME_ID = 'remember_me_id';
-    const ATTR_PARENT_REMEMBER_ME_ID = 'parent_remember_me_id';
-    const ATTR_PROFILE_CONTENT = 'profile_content';
-    const ATTR_SHARING_OUT_COME = 'sharing_outcome';
-    const ATTR_WRAPPED_RECEIPT_KEY = 'wrapped_receipt_key';
-    const ATTR_OTHER_PARTY_PROFILE_CONTENT = 'other_party_profile_content';
-    const ATTR_EXTRA_DATA_CONTENT = 'extra_data_content';
+    private const ATTR_TIMESTAMP = 'timestamp';
+    private const ATTR_RECEIPT_ID = 'receipt_id';
+    private const ATTR_REMEMBER_ME_ID = 'remember_me_id';
+    private const ATTR_PARENT_REMEMBER_ME_ID = 'parent_remember_me_id';
+    private const ATTR_PROFILE_CONTENT = 'profile_content';
+    private const ATTR_SHARING_OUT_COME = 'sharing_outcome';
+    private const ATTR_WRAPPED_RECEIPT_KEY = 'wrapped_receipt_key';
+    private const ATTR_OTHER_PARTY_PROFILE_CONTENT = 'other_party_profile_content';
+    private const ATTR_EXTRA_DATA_CONTENT = 'extra_data_content';
 
     /**
      * @var array<string, mixed>
@@ -81,9 +81,28 @@ class Receipt
         return $this->receiptData[$attributeName] ?? null;
     }
 
+
     /**
-     * Return Protobuf Attributes List.
+     * @param \Yoti\Util\PemFile $pemFile
      *
+     * @return \Yoti\Protobuf\Attrpubapi\AttributeList
+     */
+    public function parseProfileContent(PemFile $pemFile): AttributeList
+    {
+        return $this->parseAttribute(self::ATTR_PROFILE_CONTENT, $pemFile);
+    }
+
+    /**
+     * @param \Yoti\Util\PemFile $pemFile
+     *
+     * @return \Yoti\Protobuf\Attrpubapi\AttributeList
+     */
+    public function parseOtherPartyProfileContent(PemFile $pemFile): AttributeList
+    {
+        return $this->parseAttribute(self::ATTR_OTHER_PARTY_PROFILE_CONTENT, $pemFile);
+    }
+
+    /**
      * @param string $attributeName
      * @param \Yoti\Util\PemFile $pemFile
      *

--- a/src/Profile/Service.php
+++ b/src/Profile/Service.php
@@ -14,10 +14,10 @@ use Yoti\Util\PemFile;
 class Service
 {
     /** Request successful outcome */
-    const OUTCOME_SUCCESS = 'SUCCESS';
+    private const OUTCOME_SUCCESS = 'SUCCESS';
 
     /** Auth HTTP header key */
-    const YOTI_AUTH_HEADER_KEY = 'X-Yoti-Auth-Key';
+    private const YOTI_AUTH_HEADER_KEY = 'X-Yoti-Auth-Key';
 
     /**
      * @var string

--- a/src/Profile/UserProfile.php
+++ b/src/Profile/UserProfile.php
@@ -11,22 +11,22 @@ use Yoti\Profile\Attribute\AgeVerification;
  */
 class UserProfile extends BaseProfile
 {
-    const AGE_OVER = 'age_over:';
-    const AGE_UNDER = 'age_under:';
+    public const AGE_OVER = 'age_over:';
+    public const AGE_UNDER = 'age_under:';
 
-    const ATTR_FAMILY_NAME = 'family_name';
-    const ATTR_GIVEN_NAMES = 'given_names';
-    const ATTR_FULL_NAME = 'full_name';
-    const ATTR_DATE_OF_BIRTH = 'date_of_birth';
-    const ATTR_GENDER = 'gender';
-    const ATTR_NATIONALITY = 'nationality';
-    const ATTR_PHONE_NUMBER = 'phone_number';
-    const ATTR_SELFIE = 'selfie';
-    const ATTR_EMAIL_ADDRESS = 'email_address';
-    const ATTR_POSTAL_ADDRESS = 'postal_address';
-    const ATTR_DOCUMENT_DETAILS = "document_details";
-    const ATTR_DOCUMENT_IMAGES = 'document_images';
-    const ATTR_STRUCTURED_POSTAL_ADDRESS = 'structured_postal_address';
+    public const ATTR_FAMILY_NAME = 'family_name';
+    public const ATTR_GIVEN_NAMES = 'given_names';
+    public const ATTR_FULL_NAME = 'full_name';
+    public const ATTR_DATE_OF_BIRTH = 'date_of_birth';
+    public const ATTR_GENDER = 'gender';
+    public const ATTR_NATIONALITY = 'nationality';
+    public const ATTR_PHONE_NUMBER = 'phone_number';
+    public const ATTR_SELFIE = 'selfie';
+    public const ATTR_EMAIL_ADDRESS = 'email_address';
+    public const ATTR_POSTAL_ADDRESS = 'postal_address';
+    public const ATTR_DOCUMENT_DETAILS = "document_details";
+    public const ATTR_DOCUMENT_IMAGES = 'document_images';
+    public const ATTR_STRUCTURED_POSTAL_ADDRESS = 'structured_postal_address';
 
     /** @var \Yoti\Profile\Attribute\AgeVerification[] */
     private $ageVerifications;

--- a/src/Profile/Util/Attribute/AttributeConverter.php
+++ b/src/Profile/Util/Attribute/AttributeConverter.php
@@ -17,14 +17,14 @@ use Yoti\Util\Json;
 
 class AttributeConverter
 {
-    const CONTENT_TYPE_UNDEFINED = 0;
-    const CONTENT_TYPE_STRING = 1;
-    const CONTENT_TYPE_JPEG = 2;
-    const CONTENT_TYPE_DATE = 3;
-    const CONTENT_TYPE_PNG = 4;
-    const CONTENT_TYPE_JSON = 5;
-    const CONTENT_TYPE_MULTI_VALUE = 6;
-    const CONTENT_TYPE_INT = 7;
+    private const CONTENT_TYPE_UNDEFINED = 0;
+    private const CONTENT_TYPE_STRING = 1;
+    private const CONTENT_TYPE_JPEG = 2;
+    private const CONTENT_TYPE_DATE = 3;
+    private const CONTENT_TYPE_PNG = 4;
+    private const CONTENT_TYPE_JSON = 5;
+    private const CONTENT_TYPE_MULTI_VALUE = 6;
+    private const CONTENT_TYPE_INT = 7;
 
     /**
      * @param mixed $value

--- a/src/ShareUrl/Extension/LocationConstraintExtensionBuilder.php
+++ b/src/ShareUrl/Extension/LocationConstraintExtensionBuilder.php
@@ -12,7 +12,7 @@ class LocationConstraintExtensionBuilder
     /**
      * Location constraint extension type.
      */
-    const LOCATION_CONSTRAINT = 'LOCATION_CONSTRAINT';
+    private const LOCATION_CONSTRAINT = 'LOCATION_CONSTRAINT';
 
     /**
      * @var float

--- a/src/ShareUrl/Extension/ThirdPartyAttributeExtensionBuilder.php
+++ b/src/ShareUrl/Extension/ThirdPartyAttributeExtensionBuilder.php
@@ -15,7 +15,7 @@ class ThirdPartyAttributeExtensionBuilder
     /**
      * Third Party Attribute Extension Type.
      */
-    const THIRD_PARTY_ATTRIBUTE = 'THIRD_PARTY_ATTRIBUTE';
+    private const THIRD_PARTY_ATTRIBUTE = 'THIRD_PARTY_ATTRIBUTE';
 
     /**
      * @var \Yoti\Profile\ExtraData\AttributeDefinition[]

--- a/src/ShareUrl/Extension/TransactionalFlowExtensionBuilder.php
+++ b/src/ShareUrl/Extension/TransactionalFlowExtensionBuilder.php
@@ -19,7 +19,7 @@ class TransactionalFlowExtensionBuilder
     /**
      * Transactional flow extension type.
      */
-    const TRANSACTIONAL_FLOW = 'TRANSACTIONAL_FLOW';
+    private const TRANSACTIONAL_FLOW = 'TRANSACTIONAL_FLOW';
 
     /**
      * Allows you to provide a non-null object representing the content to be submitted

--- a/src/ShareUrl/Policy/DynamicPolicyBuilder.php
+++ b/src/ShareUrl/Policy/DynamicPolicyBuilder.php
@@ -14,12 +14,12 @@ class DynamicPolicyBuilder
     /**
      * Selfie auth type.
      */
-    const SELFIE_AUTH_TYPE = 1;
+    private const SELFIE_AUTH_TYPE = 1;
 
     /**
      * PIN auth type.
      */
-    const PIN_AUTH_TYPE = 2;
+    private const PIN_AUTH_TYPE = 2;
 
     /**
      * @var \Yoti\ShareUrl\Policy\WantedAttribute[]

--- a/src/ShareUrl/Policy/SourceConstraint.php
+++ b/src/ShareUrl/Policy/SourceConstraint.php
@@ -15,7 +15,7 @@ class SourceConstraint implements \JsonSerializable
     /**
      * Constraint Type.
      */
-    const TYPE = 'SOURCE';
+    private const TYPE = 'SOURCE';
 
     /**
      * @var \Yoti\ShareUrl\Policy\WantedAnchor[]

--- a/src/ShareUrl/Policy/WantedAnchor.php
+++ b/src/ShareUrl/Policy/WantedAnchor.php
@@ -14,22 +14,22 @@ class WantedAnchor implements \JsonSerializable
     /**
      * Passport value.
      */
-    const VALUE_PASSPORT = 'PASSPORT';
+    public const VALUE_PASSPORT = 'PASSPORT';
 
     /**
      * Driving Licence value.
      */
-    const VALUE_DRIVING_LICENSE = 'DRIVING_LICENCE';
+    public const VALUE_DRIVING_LICENSE = 'DRIVING_LICENCE';
 
     /**
      * National ID value.
      */
-    const VALUE_NATIONAL_ID = 'NATIONAL_ID';
+    public const VALUE_NATIONAL_ID = 'NATIONAL_ID';
 
     /**
      * Passcard value.
      */
-    const VALUE_PASSCARD = 'PASS_CARD';
+    public const VALUE_PASSCARD = 'PASS_CARD';
 
     /**
      * @var string

--- a/src/Util/Config.php
+++ b/src/Util/Config.php
@@ -13,16 +13,16 @@ use Yoti\Constants;
 class Config
 {
     /** API URL key */
-    const API_URL = 'api.url';
+    public const API_URL = 'api.url';
 
     /** SDK identifier key */
-    const SDK_IDENTIFIER = 'sdk.identifier';
+    public const SDK_IDENTIFIER = 'sdk.identifier';
 
     /** SDK version key */
-    const SDK_VERSION = 'sdk.version';
+    public const SDK_VERSION = 'sdk.version';
 
     /** HTTP client key */
-    const HTTP_CLIENT = 'http.client';
+    public const HTTP_CLIENT = 'http.client';
 
     /**
      * @var array<string, mixed>

--- a/src/Util/DateTime.php
+++ b/src/Util/DateTime.php
@@ -11,7 +11,7 @@ class DateTime
     /**
      * RFC3339 format with microseconds.
      */
-    const RFC3339 = 'Y-m-d\TH:i:s.uP';
+    public const RFC3339 = 'Y-m-d\TH:i:s.uP';
 
     /**
      * @param string $value

--- a/tests/Aml/AddressTest.php
+++ b/tests/Aml/AddressTest.php
@@ -13,8 +13,8 @@ use Yoti\Test\TestCase;
  */
 class AddressTest extends TestCase
 {
-    const SOME_POSTCODE = 'BN2 1TW';
-    const SOME_COUNTRY_CODE = 'GBR';
+    private const SOME_POSTCODE = 'BN2 1TW';
+    private const SOME_COUNTRY_CODE = 'GBR';
 
     /**
      * @covers ::__construct

--- a/tests/Aml/CountryTest.php
+++ b/tests/Aml/CountryTest.php
@@ -12,7 +12,7 @@ use Yoti\Test\TestCase;
  */
 class CountryTest extends TestCase
 {
-    const SOME_COUNTRY_CODE = 'GBR';
+    private const SOME_COUNTRY_CODE = 'GBR';
 
     /**
      * @covers ::__construct

--- a/tests/Aml/ProfileTest.php
+++ b/tests/Aml/ProfileTest.php
@@ -14,11 +14,11 @@ use Yoti\Test\TestCase;
  */
 class ProfileTest extends TestCase
 {
-    const SOME_COUNTRY_CODE = 'GBR';
-    const SOME_POSTCODE = 'BN2 1TW';
-    const SOME_GIVEN_NAMES = 'Edward Richard George';
-    const SOME_FAMILY_NAME = 'Heath';
-    const SOME_SSN = '1234';
+    private const SOME_COUNTRY_CODE = 'GBR';
+    private const SOME_POSTCODE = 'BN2 1TW';
+    private const SOME_GIVEN_NAMES = 'Edward Richard George';
+    private const SOME_FAMILY_NAME = 'Heath';
+    private const SOME_SSN = '1234';
 
     /**
      * @var Yoti\Aml\Profile

--- a/tests/Http/PayloadTest.php
+++ b/tests/Http/PayloadTest.php
@@ -15,7 +15,7 @@ use function GuzzleHttp\Psr7\stream_for;
  */
 class PayloadTest extends TestCase
 {
-    const SOME_STRING = 'some string';
+    private const SOME_STRING = 'some string';
 
     /**
      * Test getting Payload data as a stream.

--- a/tests/Http/RequestBuilderTest.php
+++ b/tests/Http/RequestBuilderTest.php
@@ -20,12 +20,12 @@ class RequestBuilderTest extends TestCase
     /**
      * Test Base URL.
      */
-    const SOME_BASE_URL = 'http://www.example.com/api/v1';
+    private const SOME_BASE_URL = 'http://www.example.com/api/v1';
 
     /**
      * Test endpoint.
      */
-    const SOME_ENDPOINT = '/some-endpoint';
+    private const SOME_ENDPOINT = '/some-endpoint';
 
     /**
      * @covers ::build

--- a/tests/Http/RequestSignerTest.php
+++ b/tests/Http/RequestSignerTest.php
@@ -18,9 +18,9 @@ use Yoti\Util\PemFile;
  */
 class RequestSignerTest extends TestCase
 {
-    const SOME_PATH = '/some-path';
+    private const SOME_PATH = '/some-path';
 
-    const SOME_METHOD = 'POST';
+    private const SOME_METHOD = 'POST';
 
     /**
      * @var \Yoti\Http\Payload

--- a/tests/Media/ImageTest.php
+++ b/tests/Media/ImageTest.php
@@ -12,7 +12,7 @@ use Yoti\Test\TestCase;
  */
 class ImageTest extends TestCase
 {
-    const SOME_IMAGE_DATA = 'dummyImageData';
+    private const SOME_IMAGE_DATA = 'dummyImageData';
 
     /**
      * @var \Yoti\Media\Image

--- a/tests/Profile/Attribute/SignedTimestampTest.php
+++ b/tests/Profile/Attribute/SignedTimestampTest.php
@@ -12,7 +12,7 @@ use Yoti\Test\TestCase;
  */
 class SignedTimeStampTest extends TestCase
 {
-    const SOME_VERSION = 123;
+    private const SOME_VERSION = 123;
 
     /**
      * @var Yoti\Profile\Attribute\SignedTimestamp

--- a/tests/Profile/AttributeTest.php
+++ b/tests/Profile/AttributeTest.php
@@ -16,7 +16,7 @@ use Yoti\Test\TestCase;
  */
 class AttributeTest extends TestCase
 {
-    const ATTR_VALUE = 'Test FullName';
+    private const ATTR_VALUE = 'Test FullName';
 
     /**
      * @var \Yoti\Profile\Attribute

--- a/tests/Profile/BaseProfileTest.php
+++ b/tests/Profile/BaseProfileTest.php
@@ -13,10 +13,10 @@ use Yoti\Test\TestCase;
  */
 class BaseProfileTest extends TestCase
 {
-    const SOME_ATTRIBUTE = 'some_attribute';
-    const SOME_OTHER_ATTRIBUTE = 'some_other_attribute';
-    const SOME_INVALID_ATTRIBUTE = 'some_invalid_attribute';
-    const SOME_MISSING_ATTRIBUTE = 'some_missing_attribute';
+    private const SOME_ATTRIBUTE = 'some_attribute';
+    private const SOME_OTHER_ATTRIBUTE = 'some_other_attribute';
+    private const SOME_INVALID_ATTRIBUTE = 'some_invalid_attribute';
+    private const SOME_MISSING_ATTRIBUTE = 'some_missing_attribute';
 
     /**
      * @var \Yoti\Profile\BaseProfile

--- a/tests/Profile/ExtraData/AttributeDefinitionTest.php
+++ b/tests/Profile/ExtraData/AttributeDefinitionTest.php
@@ -12,7 +12,7 @@ use Yoti\Test\TestCase;
  */
 class AttributeDefinitionTest extends TestCase
 {
-    const SOME_NAME = 'some name';
+    private const SOME_NAME = 'some name';
 
     /**
      * @var \Yoti\Profile\ExtraData\AttributeDefinition

--- a/tests/Profile/ExtraData/AttributeIssuanceDetailsTest.php
+++ b/tests/Profile/ExtraData/AttributeIssuanceDetailsTest.php
@@ -13,9 +13,9 @@ use Yoti\Test\TestCase;
  */
 class AttributeIssuanceDetailsTest extends TestCase
 {
-    const SOME_ISSUANCE_TOKEN = 'some issuance token';
-    const SOME_ISSUING_ATTRIBUTE_NAME = 'com.thirdparty.id';
-    const SOME_EXPIRY_DATE = '2019-12-02T12:00:00.000Z';
+    private const SOME_ISSUANCE_TOKEN = 'some issuance token';
+    private const SOME_ISSUING_ATTRIBUTE_NAME = 'com.thirdparty.id';
+    private const SOME_EXPIRY_DATE = '2019-12-02T12:00:00.000Z';
 
     /**
      * @var \Yoti\Profile\ExtraData\AttributeIssuanceDetails

--- a/tests/Profile/ReceiptTest.php
+++ b/tests/Profile/ReceiptTest.php
@@ -148,16 +148,15 @@ class ReceiptTest extends TestCase
     }
 
     /**
+     * @covers ::parseOtherPartyProfileContent
      * @covers ::parseAttribute
      * @covers ::getWrappedReceiptKey
      * @covers ::decryptAttribute
      */
     public function testShouldParseOtherPartyProfileContent()
     {
-        $protobufAttributesList = $this->receipt->parseAttribute(
-            Receipt::ATTR_OTHER_PARTY_PROFILE_CONTENT,
-            $this->pemFile
-        );
+        $protobufAttributesList = $this->receipt->parseOtherPartyProfileContent($this->pemFile);
+
         $yotiAttributesList = AttributeListConverter::convertToYotiAttributesList(
             $protobufAttributesList
         );
@@ -166,15 +165,14 @@ class ReceiptTest extends TestCase
     }
 
     /**
+     * @covers ::parseProfileContent
      * @covers ::parseAttribute
      * @covers ::decryptAttribute
      */
     public function testShouldParseProfileContent()
     {
-        $protobufAttributesList = $this->receipt->parseAttribute(
-            Receipt::ATTR_PROFILE_CONTENT,
-            $this->pemFile
-        );
+        $protobufAttributesList = $this->receipt->parseProfileContent($this->pemFile);
+
         $yotiAttributesList = AttributeListConverter::convertToYotiAttributesList(
             $protobufAttributesList
         );

--- a/tests/Profile/Util/Attribute/AttributeConverterTest.php
+++ b/tests/Profile/Util/Attribute/AttributeConverterTest.php
@@ -22,14 +22,14 @@ class AttributeConverterTest extends TestCase
     /**
      * Content Types.
      */
-    const CONTENT_TYPE_UNDEFINED = 0;
-    const CONTENT_TYPE_STRING = 1;
-    const CONTENT_TYPE_JPEG = 2;
-    const CONTENT_TYPE_DATE = 3;
-    const CONTENT_TYPE_PNG = 4;
-    const CONTENT_TYPE_JSON = 5;
-    const CONTENT_TYPE_MULTI_VALUE = 6;
-    const CONTENT_TYPE_INT = 7;
+    private const CONTENT_TYPE_UNDEFINED = 0;
+    private const CONTENT_TYPE_STRING = 1;
+    private const CONTENT_TYPE_JPEG = 2;
+    private const CONTENT_TYPE_DATE = 3;
+    private const CONTENT_TYPE_PNG = 4;
+    private const CONTENT_TYPE_JSON = 5;
+    private const CONTENT_TYPE_MULTI_VALUE = 6;
+    private const CONTENT_TYPE_INT = 7;
 
     /**
      * Mocks \Yoti\Protobuf\Attrpubapi\Attribute with provided name and value.

--- a/tests/Profile/Util/Attribute/AttributeListConverterTest.php
+++ b/tests/Profile/Util/Attribute/AttributeListConverterTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yoti\Test\Profile\Util\Attribute;
 
 use Yoti\Profile\Attribute;
-use Yoti\Profile\Util\Attribute\AttributeConverter;
 use Yoti\Profile\Util\Attribute\AttributeListConverter;
 use Yoti\Protobuf\Attrpubapi\Attribute as AttributeProto;
 use Yoti\Protobuf\Attrpubapi\AttributeList;
@@ -16,6 +15,8 @@ use Yoti\Test\TestCase;
  */
 class AttributeListConverterTest extends TestCase
 {
+    private const CONTENT_TYPE_STRING = 1;
+
     /**
      * @covers ::convertToYotiAttributesList
      */
@@ -35,7 +36,7 @@ class AttributeListConverterTest extends TestCase
             ->willReturn($someValue);
         $someAttribute
             ->method('getContentType')
-            ->willReturn(AttributeConverter::CONTENT_TYPE_STRING);
+            ->willReturn(self::CONTENT_TYPE_STRING);
         $someAttribute
             ->method('getAnchors')
             ->willReturn($this->createMock(\Traversable::class));

--- a/tests/Profile/Util/Attribute/TestAnchors.php
+++ b/tests/Profile/Util/Attribute/TestAnchors.php
@@ -6,7 +6,7 @@ namespace Yoti\Test\Profile\Util\Attribute;
 
 class TestAnchors
 {
-    const SOURCE_PP_ANCHOR = "CjdBTkMtRE9D5oQ/YdIfjbvf1HL/HT7s/Xgse6TlNthXYyfF9knv02vq6Vxd5R"
+    public const SOURCE_PP_ANCHOR = "CjdBTkMtRE9D5oQ/YdIfjbvf1HL/HT7s/Xgse6TlNthXYyfF9knv02vq6Vxd5R"
                         . "afiJbR9xVVl+knEowIMIIECDCCAnCgAwIBAgIRANEL6idR0hcevQr4tmIIcoowDQYJKo"
                         . "ZIhvcNAQELBQAwJzElMCMGA1UEAxMccGFzc3BvcnQtcmVnaXN0cmF0aW9uLXNlcnZlcj"
                         . "AeFw0xODA0MDUxNDM1MDFaFw0xODA0MTIxNDM1MDFaMCcxJTAjBgNVBAMTHHBhc3Nwb3"
@@ -46,7 +46,7 @@ class TestAnchors
                         . "/2LTJHCAEQ0bvEyui02gIaHFIc8RKJ4U36MiJqXMjQlWXbhVu/URDuYOFXITEiHNs5Ua"
                         . "Z0Q8FPlpgca5LurwwVkP/EqVsqzc1tuK06AA==";
 
-    const SOURCE_DL_ANCHOR = "CjdBTkMtRE9Dz8qdV2DSwFJicqASUbdSRfmYOsJzswHQ4hDnfOUXtYeRlVOeQnVr3an"
+    public const SOURCE_DL_ANCHOR = "CjdBTkMtRE9Dz8qdV2DSwFJicqASUbdSRfmYOsJzswHQ4hDnfOUXtYeRlVOeQnVr3an"
                         . "ESmMH7e2HEqAIMIIEHDCCAoSgAwIBAgIQIrSqBBTTXWxgGf6OvVm5XDANBgkqhkiG9w0"
                         . "BAQsFADAuMSwwKgYDVQQDEyNkcml2aW5nLWxpY2VuY2UtcmVnaXN0cmF0aW9uLXNlcnZ"
                         . "lcjAeFw0xODA0MDUxNDI3MzZaFw0xODA0MTIxNDI3MzZaMC4xLDAqBgNVBAMTI2RyaXZ"
@@ -86,7 +86,7 @@ class TestAnchors
                         . "ASx2zgOkeIJVm5UnTC2ywMkcIARDR0uX8mLLaAhocZv/4kdenjmzEE1nkHW7ks7qh+II"
                         . "J0YbSPwVkGiIc7BbgXGE8cSGwKuul83Yy/z1InbhBl2B1drEuOjoA";
 
-    const VERIFIER_YOTI_ADMIN_ANCHOR = "CjdBTkMtRE9DJrhhgGLoPILLZozIid4Aoiw/hLolQRF95pGqqsok3x"
+    public const VERIFIER_YOTI_ADMIN_ANCHOR = "CjdBTkMtRE9DJrhhgGLoPILLZozIid4Aoiw/hLolQRF95pGqqsok3x"
                         . "facAZQ9bJQD6JVzYPutOAIEpwIMIIEGDCCAoCgAwIBAgIRAMEOn91ajjMKgwOfw//2iI"
                         . "0wDQYJKoZIhvcNAQELBQAwLjEsMCoGA1UEAxMjZHJpdmluZy1saWNlbmNlLXJlZ2lzdH"
                         . "JhdGlvbi1zZXJ2ZXIwHhcNMTgwNDA1MTQyNzM2WhcNMTgwNDEyMTQyNzM2WjAuMSwwKg"
@@ -127,7 +127,7 @@ class TestAnchors
                         . "igUHdLW56nhnGLovTMIhz+RsUWrtszSjWSim2/4vJAE8QjXJ98ou4AVzKUOg9EUklWSU"
                         . "5HX0xJQ0VOQ0U=";
 
-    const UNKNOWN_ANCHOR = "CjdBTkMtRE9DwOf29QYtr1yKzW7X/JhQ6qaukET/+bjH0ePCW6UYVccf30sZ5eZPsXY"
+    public const UNKNOWN_ANCHOR = "CjdBTkMtRE9DwOf29QYtr1yKzW7X/JhQ6qaukET/+bjH0ePCW6UYVccf30sZ5eZPsXY"
                         . "+FdUeiudqEosIMIIEBzCCAm+gAwIBAgIRAKum3TTYTSaWFxxuhW6VLIEwDQYJKoZIhvc"
                         . "NAQELBQAwJzElMCMGA1UEAxMcZG9jdW1lbnQtcmVnaXN0cmF0aW9uLXNlcnZlcjAeFw0"
                         . "xOTAzMDUxMDQ1MTBaFw0xOTAzMTIxMDQ1MTBaMCcxJTAjBgNVBAMTHGRvY3VtZW50LXJ"
@@ -167,7 +167,7 @@ class TestAnchors
                         . "6F7sB6t+JNElaEZTw6q7XMkcIARClmruK6ergAhoc+oUj7TElFOKSTLtKhZnW9xYagvq"
                         . "yFC5/yGnbPSIcsyIF51RhoBzyvJ+gsm2e6apVy8WWoW7TZ8Y5CjoA";
 
-    const ANCHOR_NO_VALUE = "CjdBTkMtRE9Dz8qdV2DSwFJicqASUbdSRfmYOsJzswHQ4hDnfOUXtYeRlVOeQnVr3a"
+    public const ANCHOR_NO_VALUE = "CjdBTkMtRE9Dz8qdV2DSwFJicqASUbdSRfmYOsJzswHQ4hDnfOUXtYeRlVOeQnVr3a"
                         . "nESmMH7e2HEpEIMIIEDTCCAnWgAwIBAgIQIrSqBBTTXWxgGf6OvVm5XDANBgkqhkiG9w"
                         . "0BAQsFADAuMSwwKgYDVQQDEyNkcml2aW5nLWxpY2VuY2UtcmVnaXN0cmF0aW9uLXNlcn"
                         . "ZlcjAeFw0xODA0MDUxNDI3MzZaFw0xODA0MTIxNDI3MzZaMC4xLDAqBgNVBAMTI2RyaX"

--- a/tests/Profile/Util/EncryptedDataTest.php
+++ b/tests/Profile/Util/EncryptedDataTest.php
@@ -16,7 +16,7 @@ use Yoti\Util\PemFile;
  */
 class EncrypedDataTest extends TestCase
 {
-    const SOME_DATA = 'some data';
+    private const SOME_DATA = 'some data';
 
     /**
      * @var \Yoti\Util\PemFile

--- a/tests/Profile/Util/ExtraData/DataEntryConverterTest.php
+++ b/tests/Profile/Util/ExtraData/DataEntryConverterTest.php
@@ -14,7 +14,7 @@ use Yoti\Test\TestCase;
  */
 class DataEntryConverterTest extends TestCase
 {
-    const TYPE_THIRD_PARTY_ATTRIBUTE = 6;
+    private const TYPE_THIRD_PARTY_ATTRIBUTE = 6;
 
     /**
      * @covers ::convertValue

--- a/tests/Profile/Util/ExtraData/ExtraDataConverterTest.php
+++ b/tests/Profile/Util/ExtraData/ExtraDataConverterTest.php
@@ -19,7 +19,7 @@ use Yoti\Test\TestData;
  */
 class ExtraDataConverterTest extends TestCase
 {
-    const TYPE_THIRD_PARTY_ATTRIBUTE = 6;
+    private const TYPE_THIRD_PARTY_ATTRIBUTE = 6;
 
     /**
      * @covers ::convertValue

--- a/tests/Profile/Util/ExtraData/ThirdPartyAttributeConverterTest.php
+++ b/tests/Profile/Util/ExtraData/ThirdPartyAttributeConverterTest.php
@@ -15,10 +15,10 @@ use Yoti\Test\TestCase;
  */
 class ThirdPartyAttributeConverterTest extends TestCase
 {
-    const SOME_ISSUANCE_TOKEN = 'some issuance token';
-    const SOME_OTHER_ISSUING_ATTRIBUTE_NAME = 'com.thirdparty.other_id';
-    const SOME_ISSUING_ATTRIBUTE_NAME = 'com.thirdparty.id';
-    const SOME_EXPIRY_DATE = '2019-12-02T12:00:00.123Z';
+    private const SOME_ISSUANCE_TOKEN = 'some issuance token';
+    private const SOME_OTHER_ISSUING_ATTRIBUTE_NAME = 'com.thirdparty.other_id';
+    private const SOME_ISSUING_ATTRIBUTE_NAME = 'com.thirdparty.id';
+    private const SOME_EXPIRY_DATE = '2019-12-02T12:00:00.123Z';
 
     /**
      * @covers ::convertValue

--- a/tests/ShareUrl/DynamicScenarioBuilderTest.php
+++ b/tests/ShareUrl/DynamicScenarioBuilderTest.php
@@ -15,7 +15,7 @@ use Yoti\Test\TestCase;
  */
 class DynamicScenarioBuilderTest extends TestCase
 {
-    const SOME_ENDPOINT = '/test-callback';
+    private const SOME_ENDPOINT = '/test-callback';
 
     /**
      * @covers ::build

--- a/tests/ShareUrl/Extension/LocationConstraintContentTest.php
+++ b/tests/ShareUrl/Extension/LocationConstraintContentTest.php
@@ -12,9 +12,9 @@ use Yoti\Test\TestCase;
  */
 class LocationConstraintContentTest extends TestCase
 {
-    const TYPE_LOCATION_CONSTRAINT = 'LOCATION_CONSTRAINT';
-    const SOME_LATITUDE = 50.8169;
-    const SOME_LONGITUDE = -0.1367;
+    private const TYPE_LOCATION_CONSTRAINT = 'LOCATION_CONSTRAINT';
+    private const SOME_LATITUDE = 50.8169;
+    private const SOME_LONGITUDE = -0.1367;
 
     /**
      * @covers ::__construct

--- a/tests/ShareUrl/Extension/LocationConstraintExtensionBuilderTest.php
+++ b/tests/ShareUrl/Extension/LocationConstraintExtensionBuilderTest.php
@@ -12,9 +12,9 @@ use Yoti\Test\TestCase;
  */
 class LocationConstraintExtensionBuilderTest extends TestCase
 {
-    const TYPE_LOCATION_CONSTRAINT = 'LOCATION_CONSTRAINT';
-    const SOME_LATITUDE = 50.8169;
-    const SOME_LONGITUDE = -0.1367;
+    private const TYPE_LOCATION_CONSTRAINT = 'LOCATION_CONSTRAINT';
+    private const SOME_LATITUDE = 50.8169;
+    private const SOME_LONGITUDE = -0.1367;
 
     /**
      * @covers ::withLatitude

--- a/tests/ShareUrl/Extension/ThirdPartyAttributeExtensionBuilderTest.php
+++ b/tests/ShareUrl/Extension/ThirdPartyAttributeExtensionBuilderTest.php
@@ -12,9 +12,9 @@ use Yoti\Test\TestCase;
  */
 class ThirdPartyAttributeExtensionBuilderTest extends TestCase
 {
-    const THIRD_PARTY_ATTRIBUTE_TYPE = 'THIRD_PARTY_ATTRIBUTE';
-    const SOME_DEFINITION = 'some definition';
-    const SOME_OTHER_DEFINITION = 'some other definition';
+    private const THIRD_PARTY_ATTRIBUTE_TYPE = 'THIRD_PARTY_ATTRIBUTE';
+    private const SOME_DEFINITION = 'some definition';
+    private const SOME_OTHER_DEFINITION = 'some other definition';
 
     /**
      * @covers ::withExpiryDate

--- a/tests/ShareUrl/Extension/TransactionalFlowExtensionBuilderTest.php
+++ b/tests/ShareUrl/Extension/TransactionalFlowExtensionBuilderTest.php
@@ -12,7 +12,7 @@ use Yoti\Test\TestCase;
  */
 class TransactionalFlowExtensionBuilderTest extends TestCase
 {
-    const TYPE_TRANSACTIONAL_FLOW = 'TRANSACTIONAL_FLOW';
+    private const TYPE_TRANSACTIONAL_FLOW = 'TRANSACTIONAL_FLOW';
 
     /**
      * @covers ::build

--- a/tests/ShareUrl/Policy/DynamicPolicyBuilderTest.php
+++ b/tests/ShareUrl/Policy/DynamicPolicyBuilderTest.php
@@ -16,8 +16,8 @@ use Yoti\Test\TestCase;
  */
 class DynamicPolicyBuilderTest extends TestCase
 {
-    const SELFIE_AUTH_TYPE = 1;
-    const PIN_AUTH_TYPE = 2;
+    private const SELFIE_AUTH_TYPE = 1;
+    private const PIN_AUTH_TYPE = 2;
 
     /**
      * @covers ::build

--- a/tests/ShareUrl/Policy/SourceConstraintBuilderTest.php
+++ b/tests/ShareUrl/Policy/SourceConstraintBuilderTest.php
@@ -13,15 +13,15 @@ use Yoti\Test\TestCase;
  */
 class SourceConstraintBuilderTest extends TestCase
 {
-    const ANCHOR_TYPE_SOURCE = 'SOURCE';
-    const ANCHOR_VALUE_PASSPORT = 'PASSPORT';
-    const ANCHOR_VALUE_DRIVING_LICENSE = 'DRIVING_LICENCE';
-    const ANCHOR_VALUE_NATIONAL_ID = 'NATIONAL_ID';
-    const ANCHOR_VALUE_PASSCARD = 'PASS_CARD';
-    const ANCHOR_SUB_TYPE_NATIONAL_ID = 'NATIONAL_ID_SUB_TYPE';
-    const ANCHOR_SUB_TYPE_PASSCARD = 'PASSCARD_SUB_TYPE';
-    const SOME_VALUE = 'test value';
-    const SOME_SUB_TYPE = 'test sub type';
+    private const ANCHOR_TYPE_SOURCE = 'SOURCE';
+    private const ANCHOR_VALUE_PASSPORT = 'PASSPORT';
+    private const ANCHOR_VALUE_DRIVING_LICENSE = 'DRIVING_LICENCE';
+    private const ANCHOR_VALUE_NATIONAL_ID = 'NATIONAL_ID';
+    private const ANCHOR_VALUE_PASSCARD = 'PASS_CARD';
+    private const ANCHOR_SUB_TYPE_NATIONAL_ID = 'NATIONAL_ID_SUB_TYPE';
+    private const ANCHOR_SUB_TYPE_PASSCARD = 'PASSCARD_SUB_TYPE';
+    private const SOME_VALUE = 'test value';
+    private const SOME_SUB_TYPE = 'test sub type';
 
     /**
      * @covers ::build

--- a/tests/ShareUrl/ResultTest.php
+++ b/tests/ShareUrl/ResultTest.php
@@ -12,8 +12,8 @@ use Yoti\Test\TestCase;
  */
 class ResultTest extends TestCase
 {
-    const SOME_SHARE_URL = 'https://api.example.com/qr-code';
-    const SOME_REF_ID = 'some-ref-id';
+    private const SOME_SHARE_URL = 'https://api.example.com/qr-code';
+    private const SOME_REF_ID = 'some-ref-id';
 
     /**
      * @covers ::__construct

--- a/tests/TestData.php
+++ b/tests/TestData.php
@@ -6,21 +6,21 @@ namespace Yoti\Test;
 
 class TestData
 {
-    const SDK_ID = '990a3996-5762-4e8a-aa64-cb406fdb0e68';
-    const RECEIPT_JSON = __DIR__ . '/sample-data/receipt.json';
-    const INVALID_YOTI_CONNECT_TOKEN = 'sdfsdfsdasdajsopifajsd=';
-    const PEM_FILE = __DIR__ . '/sample-data/yw-access-security.pem';
-    const INVALID_PEM_FILE = __DIR__ . '/sample-data/invalid.pem';
-    const DUMMY_SELFIE_FILE = __DIR__ . '/sample-data/dummy-avatar.png';
-    const AML_PRIVATE_KEY = __DIR__ . '/sample-data/aml-check-private-key.pem';
-    const AML_PUBLIC_KEY = __DIR__ . '/sample-data/aml-check-public-key.pem';
-    const AML_CHECK_RESULT_JSON = __DIR__ . '/sample-data/aml-check-result.json';
-    const YOTI_CONNECT_TOKEN = __DIR__ . '/sample-data/connect-token.txt';
-    const YOTI_CONNECT_TOKEN_DECRYPTED = 'i79CctmY-22ad195c-d166-49a2-af16-8f356788c9dd' .
+    public const SDK_ID = '990a3996-5762-4e8a-aa64-cb406fdb0e68';
+    public const RECEIPT_JSON = __DIR__ . '/sample-data/receipt.json';
+    public const INVALID_YOTI_CONNECT_TOKEN = 'sdfsdfsdasdajsopifajsd=';
+    public const PEM_FILE = __DIR__ . '/sample-data/yw-access-security.pem';
+    public const INVALID_PEM_FILE = __DIR__ . '/sample-data/invalid.pem';
+    public const DUMMY_SELFIE_FILE = __DIR__ . '/sample-data/dummy-avatar.png';
+    public const AML_PRIVATE_KEY = __DIR__ . '/sample-data/aml-check-private-key.pem';
+    public const AML_PUBLIC_KEY = __DIR__ . '/sample-data/aml-check-public-key.pem';
+    public const AML_CHECK_RESULT_JSON = __DIR__ . '/sample-data/aml-check-result.json';
+    public const YOTI_CONNECT_TOKEN = __DIR__ . '/sample-data/connect-token.txt';
+    public const YOTI_CONNECT_TOKEN_DECRYPTED = 'i79CctmY-22ad195c-d166-49a2-af16-8f356788c9dd' .
         '-be094d26-19b5-450d-afce-070101760f0b';
-    const MULTI_VALUE_ATTRIBUTE = __DIR__ . '/sample-data/attributes/multi-value.txt';
-    const EXTRA_DATA_CONTENT = __DIR__ . '/sample-data/extra-data-content.txt';
-    const THIRD_PARTY_ATTRIBUTE = __DIR__ . '/sample-data/attributes/third-party-attribute.txt';
-    const PEM_AUTH_KEY = __DIR__ . '/sample-data/pem-auth-key.txt';
-    const CONNECT_BASE_URL = 'https://api.yoti.com/api/v1';
+    public const MULTI_VALUE_ATTRIBUTE = __DIR__ . '/sample-data/attributes/multi-value.txt';
+    public const EXTRA_DATA_CONTENT = __DIR__ . '/sample-data/extra-data-content.txt';
+    public const THIRD_PARTY_ATTRIBUTE = __DIR__ . '/sample-data/attributes/third-party-attribute.txt';
+    public const PEM_AUTH_KEY = __DIR__ . '/sample-data/pem-auth-key.txt';
+    public const CONNECT_BASE_URL = 'https://api.yoti.com/api/v1';
 }

--- a/tests/Util/ConfigTest.php
+++ b/tests/Util/ConfigTest.php
@@ -14,14 +14,14 @@ use Yoti\Util\Config;
  */
 class ConfigTest extends TestCase
 {
-    const SDK_IDENTIFIER_KEY = 'sdk.identifier';
-    const SDK_VERSION_KEY = 'sdk.version';
-    const API_URL_KEY = 'api.url';
-    const HTTP_CLIENT_KEY = 'http.client';
+    private const SDK_IDENTIFIER_KEY = 'sdk.identifier';
+    private const SDK_VERSION_KEY = 'sdk.version';
+    private const API_URL_KEY = 'api.url';
+    private const HTTP_CLIENT_KEY = 'http.client';
 
-    const SOME_SDK_IDENTIFIER = 'some identifier';
-    const SOME_SDK_VERSION = 'some version';
-    const SOME_API_URL = 'http://example.com/api';
+    private const SOME_SDK_IDENTIFIER = 'some identifier';
+    private const SOME_SDK_VERSION = 'some version';
+    private const SOME_API_URL = 'http://example.com/api';
 
     /**
      * @covers ::getSdkIdentifier

--- a/tests/Util/JsonTest.php
+++ b/tests/Util/JsonTest.php
@@ -12,7 +12,7 @@ use Yoti\Util\Json;
  */
 class JsonTest extends TestCase
 {
-    const SOME_JSON_DATA = ['some' => 'json'];
+    private const SOME_JSON_DATA = ['some' => 'json'];
 
     /**
      * @covers ::decode

--- a/tests/Util/ValidationTest.php
+++ b/tests/Util/ValidationTest.php
@@ -12,8 +12,8 @@ use Yoti\Util\Validation;
  */
 class ValidationTest extends TestCase
 {
-    const SOME_NAME = 'some_name';
-    const SOME_STRING = 'some string';
+    private const SOME_NAME = 'some_name';
+    private const SOME_STRING = 'some string';
 
     /**
      * @covers ::isString


### PR DESCRIPTION
### Changed
- Made class constants private by default and public where necessary
- Now running `PSR12.Properties.ConstantVisibility` sniff

### Added
- `Receipt` property/attribute keys don't need to be public as we have public getters - I've introduced 2 new getters in order to make all of these constants private:
  - `::parseProfileContent()`
  - `::parseOtherPartyProfileContent()`
