### PR TITLE
SDK-1361: Remove PHPStan exclusion

### DIFF
--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -5,7 +5,6 @@ parameters:
         - sandbox/src
     excludes_analyse:
         - src/Protobuf/*
-        - src/Profile/Util/Age/*
 
 includes:
     - phpstan-ignore.neon


### PR DESCRIPTION
### Fixed
- Removed PHPStan exclusion of `src/Profile/Util/Age/*`, which no longer exists