### PR TITLE
SDK-1430: Remove unused exception

### DIFF
--- a/src/Media/Exception/InvalidImageTypeException.php
+++ b/src/Media/Exception/InvalidImageTypeException.php
@@ -1,9 +1,0 @@
-<?php
-
-declare(strict_types=1);
-
-namespace Yoti\Media\Exception;
-
-class InvalidImageTypeException extends \InvalidArgumentException
-{
-}


### PR DESCRIPTION
> Amendment to #139 

### Removed
- `Yoti\Media\Exception\InvalidImageTypeException` (this was added when moving the `Image` object into the `Yoti\Media` namespace, but is no longer used)