### PR TITLE
SDK-1446: Document Details Validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,5 @@ coverage
 .scannerwork
 
 .DS_Store
+
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "yoti/yoti-php-sdk",
   "description": "Yoti SDK for quickly integrating your PHP backend with Yoti",
-  "version": "2.5.0",
+  "version": "2.5.1",
   "keywords": [
     "yoti",
     "sdk"

--- a/config.ini
+++ b/config.ini
@@ -1,1 +1,1 @@
-version = 2.5.0
+version = 2.5.1

--- a/examples/composer.lock
+++ b/examples/composer.lock
@@ -65,11 +65,11 @@
         },
         {
             "name": "yoti/yoti-php-sdk",
-            "version": "2.5.0",
+            "version": "2.5.1",
             "dist": {
                 "type": "path",
                 "url": "./sdk",
-                "reference": "828e896870bbfb4ec77739494cf5414e471142e3"
+                "reference": "197f63b703100e70c0a514fb57becf7671853df3"
             },
             "require": {
                 "php": ">=5.5.19"
@@ -79,7 +79,7 @@
                 "friendsofphp/php-cs-fixer": "^2.15",
                 "php": ">=5.6.0",
                 "php-coveralls/php-coveralls": "^2.1",
-                "phpunit/phpunit": "^5.7",
+                "phpunit/phpunit": "^5.7 || ^7.5",
                 "squizlabs/php_codesniffer": "^3.4"
             },
             "type": "library",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey = yoti-web-sdk:php
 sonar.projectName = php-sdk
-sonar.projectVersion = 2.5.0
+sonar.projectVersion = 2.5.1
 sonar.sources=src/Yoti
 sonar.php.coverage.reportPaths=coverage/coverage.xml
 sonar.verbose = true

--- a/src/Yoti/Entity/DocumentDetails.php
+++ b/src/Yoti/Entity/DocumentDetails.php
@@ -9,8 +9,11 @@ class DocumentDetails
     /**
      * The values of the Document Details are in the format and order as defined in this pattern
      * e.g PASS_CARD GBR 22719564893 - CITIZENCARD, the last two are optionals
+     *
+     * @deprecated 3.0.0 This validation pattern is no longer used.
      */
     const VALIDATION_PATTERN = '/^([A-Za-z_]*) ([A-Za-z]{3}) ([A-Za-z0-9]{1}).*$/';
+
     const TYPE_INDEX = 0;
     const COUNTRY_INDEX = 1;
     const NUMBER_INDEX = 2;
@@ -51,7 +54,6 @@ class DocumentDetails
      */
     public function __construct($value)
     {
-        $this->validateValue($value);
         $this->parseFromValue($value);
     }
 
@@ -112,6 +114,11 @@ class DocumentDetails
     private function parseFromValue($value)
     {
         $parsedValues = explode(' ', $value);
+
+        if (count($parsedValues) < 3 || in_array('', $parsedValues, true)) {
+            throw new AttributeException('Invalid value for DocumentDetails');
+        }
+
         $this->setType($parsedValues);
         $this->setIssuingCountry($parsedValues);
         $this->setDocumentNumber($parsedValues);
@@ -163,17 +170,5 @@ class DocumentDetails
     {
         $value = isset($parsedValues[self::AUTHORITY_INDEX]) ? $parsedValues[self::AUTHORITY_INDEX] : null;
         $this->issuingAuthority = $value;
-    }
-
-    /**
-     * @param $value
-     *
-     * @throws AttributeException
-     */
-    private function validateValue($value)
-    {
-        if (!preg_match(self::VALIDATION_PATTERN, $value)) {
-            throw new AttributeException('Invalid value for DocumentDetails');
-        }
     }
 }

--- a/tests/Entity/DocumentDetailsTest.php
+++ b/tests/Entity/DocumentDetailsTest.php
@@ -62,32 +62,69 @@ class DocumentDetailsTest extends TestCase
 
     /**
      * @covers ::__construct
-     * @covers ::validateValue
+     * @covers ::parseFromValue
      */
     public function testShouldThrowExceptionWhenValueIsEmpty()
     {
-        $this->expectException('Yoti\Exception\AttributeException');
-        $document = new DocumentDetails('');
+        $this->expectException(\Yoti\Exception\AttributeException::class);
+        $this->expectExceptionMessage('Invalid value for DocumentDetails');
+
+        new DocumentDetails('');
     }
 
     /**
      * @covers ::__construct
-     * @covers ::validateValue
+     * @covers ::parseFromValue
+     *
+     * @dataProvider valueWithExtraSpacesDataProvider
      */
-    public function testShouldThrowExceptionForInvalidCountry()
+    public function testShouldNotAllowExtraSpaces($value)
     {
-        $this->expectException('Yoti\Exception\AttributeException');
-        $document = new DocumentDetails('PASSPORT 13 1234abc 2016-05-01');
+        $this->expectException(\Yoti\Exception\AttributeException::class);
+        $this->expectExceptionMessage('Invalid value for DocumentDetails');
+
+        new DocumentDetails($value);
+    }
+
+    /**
+     * Value with extra spaces data provider.
+     */
+    public function valueWithExtraSpacesDataProvider()
+    {
+        return [
+            [ 'some-type   some-country some-doc-number - some-authority' ],
+            [ 'some-type some-country  some-doc-number - some-authority' ],
+            [ 'some-type some-country some-doc-number  - some-authority' ],
+            [ 'some-type some-country some-doc-number -  some-authority' ],
+        ];
     }
 
     /**
      * @covers ::__construct
-     * @covers ::validateValue
+     * @covers ::getDocumentNumber
+     *
+     * @dataProvider validValueDataProvider
      */
-    public function testShouldThrowExceptionForInvalidNumber()
+    public function testShouldAllowValidDocumentNumbers($validDocumentNumber)
     {
-        $this->expectException('Yoti\Exception\AttributeException');
-        new DocumentDetails("PASSPORT GBR $%^$%^£ 2016-05-01");
+        $document = new DocumentDetails("some-type some-country $validDocumentNumber - some-authority");
+        $this->assertEquals($validDocumentNumber, $document->getDocumentNumber());
+    }
+
+    /**
+     * Valid value data provider.
+     */
+    public function validValueDataProvider()
+    {
+        return [
+            [ '****' ],
+            [ '~!@#$%^&*()-_=+[]{}|;\':,./<>?' ],
+            [ '""' ],
+            [ '\\' ],
+            [ '"' ],
+            [ '\'\'' ],
+            [ '\'' ],
+        ];
     }
 
     /**


### PR DESCRIPTION
> Release `2.5.1`
> Back-port of #144 

### Fixed
- Allow any character in DocumentDetails value

> Note: This release will also include non-breaking changes that were deferred to `3.0.0`
> https://github.com/getyoti/yoti-php-sdk/compare/2.5.0..2.x

### Fixed
- Added missing properties to _ExtraData_ classes #128 
- `ThirdPartyAttributeConverter::convertValue()` now uses `Yoti\Util\DateTime::stringToDateTime()`, which supports all `RFC3339` date formats #116 

### Added
- `Yoti\Util\DateTime` used for converting strings to `\DateTime` objects
- `Yoti\Exception\DateTimeException`

### Deprecated
- `Yoti\Util\Constants::DATE_FORMAT_RFC3339` - replaced by `Yoti\Util\DateTime::RFC3339`

