### PR TITLE
SDK-1473: Sandbox Optional Attribute

### DIFF
--- a/sandbox/src/Profile/Request/Attribute/SandboxAgeVerification.php
+++ b/sandbox/src/Profile/Request/Attribute/SandboxAgeVerification.php
@@ -22,7 +22,7 @@ class SandboxAgeVerification extends SandboxAttribute
             UserProfile::ATTR_DATE_OF_BIRTH,
             $dateObj->format('Y-m-d'),
             $derivation,
-            'true',
+            true,
             $anchors
         );
     }

--- a/sandbox/src/Profile/Request/Attribute/SandboxAnchor.php
+++ b/sandbox/src/Profile/Request/Attribute/SandboxAnchor.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yoti\Sandbox\Profile\Request\Attribute;
 
-class SandboxAnchor
+class SandboxAnchor implements \JsonSerializable
 {
     /**
      * @var string
@@ -34,23 +34,16 @@ class SandboxAnchor
         $this->timestamp = $timestamp;
     }
 
-    public function getType(): string
+    /**
+     * @return array<string, mixed>
+     */
+    public function jsonSerialize(): array
     {
-        return $this->type;
-    }
-
-    public function getValue(): string
-    {
-        return $this->value;
-    }
-
-    public function getSubtype(): string
-    {
-        return $this->subtype;
-    }
-
-    public function getTimestamp(): int
-    {
-        return $this->timestamp;
+        return [
+            'type' => $this->type,
+            'value' => $this->value,
+            'sub_type' => $this->subtype,
+            'timestamp' => $this->timestamp * 1000000,
+        ];
     }
 }

--- a/sandbox/src/Profile/Request/Attribute/SandboxAttribute.php
+++ b/sandbox/src/Profile/Request/Attribute/SandboxAttribute.php
@@ -6,7 +6,7 @@ namespace Yoti\Sandbox\Profile\Request\Attribute;
 
 use Yoti\Util\Validation;
 
-class SandboxAttribute
+class SandboxAttribute implements \JsonSerializable
 {
     /** @var string */
     protected $name;
@@ -17,7 +17,7 @@ class SandboxAttribute
     /** @var string */
     protected $derivation;
 
-    /** @var string */
+    /** @var bool */
     protected $optional;
 
     /** @var \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] */
@@ -27,14 +27,14 @@ class SandboxAttribute
      * @param string $name
      * @param string $value
      * @param string $derivation
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      */
     public function __construct(
         string $name,
         string $value,
         string $derivation = '',
-        string $optional = 'false',
+        bool $optional = false,
         array $anchors = []
     ) {
         $this->name = $name;
@@ -46,31 +46,17 @@ class SandboxAttribute
         $this->anchors = $anchors;
     }
 
-    public function getName(): string
-    {
-        return $this->name;
-    }
-
-    public function getValue(): string
-    {
-        return $this->value;
-    }
-
-    public function getDerivation(): string
-    {
-        return $this->derivation;
-    }
-
-    public function getOptional(): string
-    {
-        return $this->optional;
-    }
-
     /**
-     * @return \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[]
+     * @return array<string, mixed>
      */
-    public function getAnchors(): array
+    public function jsonSerialize(): array
     {
-        return $this->anchors;
+        return [
+            'name' => $this->name,
+            'value' => $this->value,
+            'derivation' => $this->derivation,
+            'optional' => $this->optional,
+            'anchors' => $this->anchors,
+        ];
     }
 }

--- a/sandbox/src/Profile/Request/TokenRequest.php
+++ b/sandbox/src/Profile/Request/TokenRequest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Yoti\Sandbox\Profile\Request;
 
 use Yoti\Http\Payload;
+use Yoti\Sandbox\Profile\Request\Attribute\SandboxAttribute;
+use Yoti\Util\Validation;
 
-class TokenRequest
+class TokenRequest implements \JsonSerializable
 {
     /**
      * @var string|null
@@ -14,38 +16,38 @@ class TokenRequest
     private $rememberMeId;
 
     /**
-     * @var array[]
+     * @var SandboxAttribute[]
      */
     private $sandboxAttributes;
 
     /**
      * @param string|null $rememberMeId
-     * @param array[] $sandboxAttrs
+     * @param SandboxAttribute[] $sandboxAttributes
      */
-    public function __construct(?string $rememberMeId, array $sandboxAttrs)
+    public function __construct(?string $rememberMeId, array $sandboxAttributes)
     {
         $this->rememberMeId = $rememberMeId;
-        $this->sandboxAttributes = $sandboxAttrs;
-    }
 
-    public function getRememberMeId(): ?string
-    {
-        return $this->rememberMeId;
+        Validation::isArrayOfType($sandboxAttributes, [ SandboxAttribute::class ], 'sandboxAttributes');
+        $this->sandboxAttributes = $sandboxAttributes;
     }
 
     /**
-     * @return array[]
+     * @return array<string, mixed>
      */
-    public function getSandboxAttributes(): array
+    public function jsonSerialize(): array
     {
-        return $this->sandboxAttributes;
-    }
-
-    public function getPayload(): Payload
-    {
-        return Payload::fromJsonData([
+        return [
             'remember_me_id' => $this->rememberMeId,
             'profile_attributes' => $this->sandboxAttributes,
-        ]);
+        ];
+    }
+
+    /**
+     * @return Payload
+     */
+    public function getPayload(): Payload
+    {
+        return Payload::fromJsonData($this);
     }
 }

--- a/sandbox/src/Profile/Request/TokenRequestBuilder.php
+++ b/sandbox/src/Profile/Request/TokenRequestBuilder.php
@@ -17,7 +17,7 @@ class TokenRequestBuilder
     private $rememberMeId;
 
     /**
-     * @var array[]
+     * @var SandboxAttribute[]
      */
     private $sandboxAttributes = [];
 
@@ -32,12 +32,12 @@ class TokenRequestBuilder
 
     /**
      * @param string $value
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setFullName(string $value, string $optional = 'false', array $anchors = []): self
+    public function setFullName(string $value, bool $optional = false, array $anchors = []): self
     {
         $this->addAttribute($this->createAttribute(
             UserProfile::ATTR_FULL_NAME,
@@ -51,12 +51,12 @@ class TokenRequestBuilder
 
     /**
      * @param string $value
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setFamilyName(string $value, string $optional = 'false', array $anchors = []): self
+    public function setFamilyName(string $value, bool $optional = false, array $anchors = []): self
     {
         $this->addAttribute($this->createAttribute(
             UserProfile::ATTR_FAMILY_NAME,
@@ -70,12 +70,12 @@ class TokenRequestBuilder
 
     /**
      * @param string $value
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setGivenNames(string $value, string $optional = 'false', array $anchors = []): self
+    public function setGivenNames(string $value, bool $optional = false, array $anchors = []): self
     {
         $this->addAttribute($this->createAttribute(
             UserProfile::ATTR_GIVEN_NAMES,
@@ -89,12 +89,12 @@ class TokenRequestBuilder
 
     /**
      * @param \DateTime $dateTime
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setDateOfBirth(\DateTime $dateTime, string $optional = 'false', array $anchors = []): self
+    public function setDateOfBirth(\DateTime $dateTime, bool $optional = false, array $anchors = []): self
     {
         $this->addAttribute($this->createAttribute(
             UserProfile::ATTR_DATE_OF_BIRTH,
@@ -108,12 +108,12 @@ class TokenRequestBuilder
 
     /**
      * @param string $value
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setGender(string $value, string $optional = 'false', array $anchors = []): self
+    public function setGender(string $value, bool $optional = false, array $anchors = []): self
     {
         $this->addAttribute($this->createAttribute(
             UserProfile::ATTR_GENDER,
@@ -127,12 +127,12 @@ class TokenRequestBuilder
 
     /**
      * @param string $value
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setNationality(string $value, string $optional = 'false', array $anchors = []): self
+    public function setNationality(string $value, bool $optional = false, array $anchors = []): self
     {
         $this->addAttribute($this->createAttribute(
             UserProfile::ATTR_NATIONALITY,
@@ -146,12 +146,12 @@ class TokenRequestBuilder
 
     /**
      * @param string $value
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setPhoneNumber(string $value, string $optional = 'false', array $anchors = []): self
+    public function setPhoneNumber(string $value, bool $optional = false, array $anchors = []): self
     {
         $this->addAttribute($this->createAttribute(
             UserProfile::ATTR_PHONE_NUMBER,
@@ -165,12 +165,12 @@ class TokenRequestBuilder
 
     /**
      * @param string $value
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setSelfie(string $value, string $optional = 'false', array $anchors = []): self
+    public function setSelfie(string $value, bool $optional = false, array $anchors = []): self
     {
         $base64Selfie = base64_encode($value);
         return $this->setBase64Selfie($base64Selfie, $optional, $anchors);
@@ -178,12 +178,12 @@ class TokenRequestBuilder
 
     /**
      * @param string $value
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setBase64Selfie(string $value, string $optional = 'true', array $anchors = []): self
+    public function setBase64Selfie(string $value, bool $optional = false, array $anchors = []): self
     {
         $this->addAttribute($this->createAttribute(
             UserProfile::ATTR_SELFIE,
@@ -197,12 +197,12 @@ class TokenRequestBuilder
 
     /**
      * @param string $value
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setEmailAddress(string $value, string $optional = 'false', array $anchors = []): self
+    public function setEmailAddress(string $value, bool $optional = false, array $anchors = []): self
     {
         $this->addAttribute($this->createAttribute(
             UserProfile::ATTR_EMAIL_ADDRESS,
@@ -216,12 +216,12 @@ class TokenRequestBuilder
 
     /**
      * @param string $value
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setPostalAddress(string $value, string $optional = 'false', array $anchors = []): self
+    public function setPostalAddress(string $value, bool $optional = false, array $anchors = []): self
     {
         $this->addAttribute($this->createAttribute(
             UserProfile::ATTR_POSTAL_ADDRESS,
@@ -235,12 +235,12 @@ class TokenRequestBuilder
 
     /**
      * @param string $value
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setStructuredPostalAddress(string $value, string $optional = 'false', array $anchors = []): self
+    public function setStructuredPostalAddress(string $value, bool $optional = false, array $anchors = []): self
     {
         $this->addAttribute($this->createAttribute(
             UserProfile::ATTR_STRUCTURED_POSTAL_ADDRESS,
@@ -254,14 +254,14 @@ class TokenRequestBuilder
 
     /**
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxDocumentDetails $documentDetails
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
     public function setDocumentDetails(
         SandboxDocumentDetails $documentDetails,
-        string $optional = 'true',
+        bool $optional = true,
         array $anchors = []
     ): self {
         $this->addAttribute($this->createAttribute(
@@ -276,12 +276,12 @@ class TokenRequestBuilder
 
     /**
      * @param string $value
-     * @param string $optional
+     * @param bool $optional
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return $this
      */
-    public function setDocumentDetailsWithString(string $value, string $optional = 'true', array $anchors = []): self
+    public function setDocumentDetailsWithString(string $value, bool $optional = true, array $anchors = []): self
     {
         $this->addAttribute($this->createAttribute(
             UserProfile::ATTR_DOCUMENT_DETAILS,
@@ -301,34 +301,8 @@ class TokenRequestBuilder
 
     public function addAttribute(SandboxAttribute $attribute): self
     {
-        $this->sandboxAttributes[] = [
-            'name' => $attribute->getName(),
-            'value' => $attribute->getValue(),
-            'derivation' => $attribute->getDerivation(),
-            'optional' => $attribute->getOptional(),
-            'anchors' => $this->formatAnchors($attribute->getAnchors())
-        ];
+        $this->sandboxAttributes[] = $attribute;
         return $this;
-    }
-
-    /**
-     * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
-     *
-     * @return array[]
-     */
-    private function formatAnchors(array $anchors): array
-    {
-        $anchorsList = [];
-        $tsMultiplier = 1000000;
-        foreach ($anchors as $anchor) {
-            $anchorsList[] = [
-                'type' => strtoupper($anchor->getType()),
-                'value' => $anchor->getValue(),
-                'sub_type' => $anchor->getSubtype(),
-                'timestamp' => $anchor->getTimestamp() * $tsMultiplier
-            ];
-        }
-        return $anchorsList;
     }
 
     /**
@@ -336,8 +310,8 @@ class TokenRequestBuilder
      * @param string $value
      * @param string $derivation
      *  Empty value means there is no derivation for this attribute
-     * @param string $optional
-     *  'false' value means this attribute is required
+     * @param bool $optional
+     *  false value means this attribute is required
      * @param \Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor[] $anchors
      *
      * @return SandboxAttribute
@@ -346,7 +320,7 @@ class TokenRequestBuilder
         string $name,
         string $value,
         string $derivation,
-        string $optional,
+        bool $optional,
         array $anchors
     ): SandboxAttribute {
         return new SandboxAttribute($name, $value, $derivation, $optional, $anchors);

--- a/sandbox/tests/Profile/Request/Attribute/SandboxAgeVerificationTest.php
+++ b/sandbox/tests/Profile/Request/Attribute/SandboxAgeVerificationTest.php
@@ -13,7 +13,8 @@ use Yoti\Test\TestCase;
  */
 class SandboxAgeVerificationTest extends TestCase
 {
-    private const SOME_VALUE = '2007-02-15';
+    private const SOME_TIMESTAMP = 1171502725;
+    private const SOME_TIMESTAMP_DATE_STRING = '2007-02-15';
     private const SOME_DERIVATION = 'age_under:18';
 
     /**
@@ -23,10 +24,9 @@ class SandboxAgeVerificationTest extends TestCase
 
     public function setup(): void
     {
-        $dateTime = (new \DateTime())->setTimestamp(1171502725);
         $this->ageVerification = new SandboxAgeVerification(
-            $dateTime,
-            'age_under:18'
+            (new \DateTime())->setTimestamp(self::SOME_TIMESTAMP),
+            self::SOME_DERIVATION
         );
     }
 
@@ -39,7 +39,7 @@ class SandboxAgeVerificationTest extends TestCase
         $this->assertJsonStringEqualsJsonString(
             json_encode([
                 'name' => UserProfile::ATTR_DATE_OF_BIRTH,
-                'value' => self::SOME_VALUE,
+                'value' => self::SOME_TIMESTAMP_DATE_STRING,
                 'derivation' => self::SOME_DERIVATION,
                 'optional' => true,
                 'anchors' => [],
@@ -59,7 +59,7 @@ class SandboxAgeVerificationTest extends TestCase
         $this->assertJsonStringEqualsJsonString(
             json_encode([
                 'name' => UserProfile::ATTR_DATE_OF_BIRTH,
-                'value' => self::SOME_VALUE,
+                'value' => self::SOME_TIMESTAMP_DATE_STRING,
                 'derivation' => 'age_over:20',
                 'optional' => true,
                 'anchors' => [],
@@ -79,7 +79,7 @@ class SandboxAgeVerificationTest extends TestCase
         $this->assertJsonStringEqualsJsonString(
             json_encode([
                 'name' => UserProfile::ATTR_DATE_OF_BIRTH,
-                'value' => self::SOME_VALUE,
+                'value' => self::SOME_TIMESTAMP_DATE_STRING,
                 'derivation' => 'age_under:30',
                 'optional' => true,
                 'anchors' => [],

--- a/sandbox/tests/Profile/Request/Attribute/SandboxAgeVerificationTest.php
+++ b/sandbox/tests/Profile/Request/Attribute/SandboxAgeVerificationTest.php
@@ -13,10 +13,13 @@ use Yoti\Test\TestCase;
  */
 class SandboxAgeVerificationTest extends TestCase
 {
+    private const SOME_VALUE = '2007-02-15';
+    private const SOME_DERIVATION = 'age_under:18';
+
     /**
      * @var SandboxAgeVerification
      */
-    public $ageVerification;
+    private $ageVerification;
 
     public function setup(): void
     {
@@ -28,77 +31,60 @@ class SandboxAgeVerificationTest extends TestCase
     }
 
     /**
-     * @covers ::getName
+     * @covers ::jsonSerialize
      * @covers ::__construct
      */
-    public function testGetName()
+    public function testJsonSerialize()
     {
-        $this->assertEquals(
-            UserProfile::ATTR_DATE_OF_BIRTH,
-            $this->ageVerification->getName()
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'name' => UserProfile::ATTR_DATE_OF_BIRTH,
+                'value' => self::SOME_VALUE,
+                'derivation' => self::SOME_DERIVATION,
+                'optional' => true,
+                'anchors' => [],
+            ]),
+            json_encode($this->ageVerification)
         );
     }
 
     /**
-     * @covers ::getValue
-     * @covers ::__construct
-     */
-    public function testGetValue()
-    {
-        $this->assertEquals('2007-02-15', $this->ageVerification->getValue());
-    }
-
-    /**
-     * @covers ::getDerivation
-     * @covers ::__construct
-     */
-    public function testGetDerivation()
-    {
-        $this->assertEquals('age_under:18', $this->ageVerification->getDerivation());
-    }
-
-    /**
-     * @covers ::getOptional
-     * @covers ::__construct
-     */
-    public function testGetOptional()
-    {
-        $this->assertEquals('true', $this->ageVerification->getOptional());
-    }
-
-    /**
-     * @covers ::getAnchors
-     * @covers ::__construct
-     */
-    public function testGetAnchors()
-    {
-        $this->assertEquals(
-            json_encode([]),
-            json_encode($this->ageVerification->getAnchors())
-        );
-    }
-
-    /**
-     * @covers ::getDerivation
      * @covers ::setAgeOver
      * @covers ::__construct
      */
     public function testGetAgeOver()
     {
-        $ageVerification = clone $this->ageVerification;
-        $ageVerification->setAgeOver(20);
-        $this->assertEquals('age_over:20', $ageVerification->getDerivation());
+        $this->ageVerification->setAgeOver(20);
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'name' => UserProfile::ATTR_DATE_OF_BIRTH,
+                'value' => self::SOME_VALUE,
+                'derivation' => 'age_over:20',
+                'optional' => true,
+                'anchors' => [],
+            ]),
+            json_encode($this->ageVerification)
+        );
     }
 
     /**
-     * @covers ::getDerivation
      * @covers ::setAgeUnder
      * @covers ::__construct
      */
     public function testAgeUnder()
     {
-        $ageVerification = clone $this->ageVerification;
-        $ageVerification->setAgeUnder(18);
-        $this->assertEquals('age_under:18', $ageVerification->getDerivation());
+        $this->ageVerification->setAgeUnder(30);
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'name' => UserProfile::ATTR_DATE_OF_BIRTH,
+                'value' => self::SOME_VALUE,
+                'derivation' => 'age_under:30',
+                'optional' => true,
+                'anchors' => [],
+            ]),
+            json_encode($this->ageVerification)
+        );
     }
 }

--- a/sandbox/tests/Profile/Request/Attribute/SandboxAnchorTest.php
+++ b/sandbox/tests/Profile/Request/Attribute/SandboxAnchorTest.php
@@ -43,7 +43,7 @@ class SandboxAnchorTest extends TestCase
                 'type' => self::SOME_TYPE,
                 'value' => self::SOME_VALUE,
                 'sub_type' => self::SOME_SUB_TYPE,
-                'timestamp' => 1544624701 * 1000000
+                'timestamp' => self::SOME_TIMESTAMP * 1000000,
             ]),
             json_encode($this->anchor)
         );

--- a/sandbox/tests/Profile/Request/Attribute/SandboxAnchorTest.php
+++ b/sandbox/tests/Profile/Request/Attribute/SandboxAnchorTest.php
@@ -12,54 +12,40 @@ use Yoti\Test\TestCase;
  */
 class SandboxAnchorTest extends TestCase
 {
+    private const SOME_TYPE = 'SOURCE';
+    private const SOME_VALUE = 'PASSPORT';
+    private const SOME_SUB_TYPE = 'OCR';
+    private const SOME_TIMESTAMP = 1544624701;
+
     /**
      * @var SandboxAnchor
      */
-    public $anchor;
+    private $anchor;
 
     public function setup(): void
     {
         $this->anchor = new SandboxAnchor(
-            'Source',
-            'PASSPORT',
-            'OCR',
-            1544624701 // 12-12-2018 14:25:01
+            self::SOME_TYPE,
+            self::SOME_VALUE,
+            self::SOME_SUB_TYPE,
+            self::SOME_TIMESTAMP
         );
     }
 
     /**
-     * @covers ::getType
+     * @covers ::jsonSerialize
      * @covers ::__construct
      */
-    public function testGetType()
+    public function testJsonSerialize()
     {
-        $this->assertEquals('Source', $this->anchor->getType());
-    }
-
-    /**
-     * @covers ::getValue
-     * @covers ::__construct
-     */
-    public function testGetValue()
-    {
-        $this->assertEquals('PASSPORT', $this->anchor->getValue());
-    }
-
-    /**
-     * @covers ::getSubtype
-     * @covers ::__construct
-     */
-    public function testGetSubtype()
-    {
-        $this->assertEquals('OCR', $this->anchor->getSubtype());
-    }
-
-    /**
-     * @covers ::getTimestamp
-     * @covers ::__construct
-     */
-    public function testGetTimestamp()
-    {
-        $this->assertEquals(1544624701, $this->anchor->getTimestamp());
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'type' => self::SOME_TYPE,
+                'value' => self::SOME_VALUE,
+                'sub_type' => self::SOME_SUB_TYPE,
+                'timestamp' => 1544624701 * 1000000
+            ]),
+            json_encode($this->anchor)
+        );
     }
 }

--- a/sandbox/tests/Profile/Request/Attribute/SandboxAttributeTest.php
+++ b/sandbox/tests/Profile/Request/Attribute/SandboxAttributeTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yoti\Sandbox\Test\Profile\Request\Attribute;
 
-use Yoti\Profile\UserProfile;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxAttribute;
 use Yoti\Test\TestCase;
 
@@ -13,6 +12,7 @@ use Yoti\Test\TestCase;
  */
 class SandboxAttributeTest extends TestCase
 {
+    private const SOME_NAME = 'some-name';
     private const SOME_VALUE = 'some-value';
 
     /**
@@ -23,7 +23,7 @@ class SandboxAttributeTest extends TestCase
     public function setup(): void
     {
         $this->attribute = new SandboxAttribute(
-            UserProfile::ATTR_FAMILY_NAME,
+            self::SOME_NAME,
             self::SOME_VALUE,
             ''
         );
@@ -37,7 +37,7 @@ class SandboxAttributeTest extends TestCase
     {
         $this->assertJsonStringEqualsJsonString(
             json_encode([
-                'name' => UserProfile::ATTR_FAMILY_NAME,
+                'name' => self::SOME_NAME,
                 'value' => self::SOME_VALUE,
                 'derivation' => '',
                 'optional' => false,

--- a/sandbox/tests/Profile/Request/Attribute/SandboxAttributeTest.php
+++ b/sandbox/tests/Profile/Request/Attribute/SandboxAttributeTest.php
@@ -13,6 +13,8 @@ use Yoti\Test\TestCase;
  */
 class SandboxAttributeTest extends TestCase
 {
+    private const SOME_VALUE = 'some-value';
+
     /**
      * @var SandboxAttribute
      */
@@ -22,61 +24,26 @@ class SandboxAttributeTest extends TestCase
     {
         $this->attribute = new SandboxAttribute(
             UserProfile::ATTR_FAMILY_NAME,
-            'Fake_Family_Name',
+            self::SOME_VALUE,
             ''
         );
     }
 
     /**
-     * @covers ::getName
+     * @covers ::jsonSerialize
      * @covers ::__construct
      */
-    public function testGetName()
+    public function testJsonSerialize()
     {
-        $this->assertEquals(UserProfile::ATTR_FAMILY_NAME, $this->attribute->getName());
-    }
-
-    /**
-     * @covers ::getValue
-     * @covers ::__construct
-     */
-    public function testGetValue()
-    {
-        $this->assertEquals('Fake_Family_Name', $this->attribute->getValue());
-    }
-
-    /**
-     * @covers ::getDerivation
-     * @covers ::__construct
-     */
-    public function testGetDerivation()
-    {
-        $this->assertEmpty($this->attribute->getDerivation());
-    }
-
-    /**
-     * @covers ::getOptional
-     * @covers ::__construct
-     */
-    public function testGetOptional()
-    {
-        $this->assertEquals(
-            'false',
-            $this->attribute->getOptional(),
-            'Should return false as a string'
-        );
-    }
-
-    /**
-     * @covers ::getAnchors
-     * @covers ::__construct
-     */
-    public function testGetAnchors()
-    {
-        $this->assertEquals(
-            json_encode([]),
-            json_encode($this->attribute->getAnchors()),
-            'Should be an empty array'
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'name' => UserProfile::ATTR_FAMILY_NAME,
+                'value' => self::SOME_VALUE,
+                'derivation' => '',
+                'optional' => false,
+                'anchors' => [],
+            ]),
+            json_encode($this->attribute)
         );
     }
 }

--- a/sandbox/tests/Profile/Request/TokenRequestBuilderTest.php
+++ b/sandbox/tests/Profile/Request/TokenRequestBuilderTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yoti\Sandbox\Test\Profile\Request;
 
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxAgeVerification;
+use Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxDocumentDetails;
 use Yoti\Sandbox\Profile\Request\TokenRequest;
 use Yoti\Sandbox\Profile\Request\TokenRequestBuilder;
@@ -18,6 +19,12 @@ class TokenRequestBuilderTest extends TestCase
     private const SOME_REMEMBER_ME_ID = 'some_remember_me_id';
     private const SOME_NAME = 'some name';
     private const SOME_STRING_VALUE = 'some string';
+    private const SOME_ANCHOR_JSON_DATA = [
+        'type' => 'some type',
+        'sub_type' => 'some sub type',
+        'value' => 'some anchor value',
+        'timestamp' => 1575998454,
+    ];
 
     /**
      * @var \Yoti\Sandbox\Profile\RequestBuilders
@@ -42,7 +49,7 @@ class TokenRequestBuilderTest extends TestCase
     /**
      * @covers ::setRememberMeId
      */
-    public function testGetRememberMeId()
+    public function testSetRememberMeId()
     {
         $this->requestBuilder->setRememberMeId(self::SOME_REMEMBER_ME_ID);
         $tokenRequest = $this->requestBuilder->build();
@@ -87,6 +94,47 @@ class TokenRequestBuilderTest extends TestCase
                         'derivation' => '',
                         'optional' => false,
                         'anchors' => [],
+                    ]
+                ]
+            ]),
+            json_encode($tokenRequest)
+        );
+    }
+
+    /**
+     * @covers ::setFullName
+     * @covers ::setFamilyName
+     * @covers ::setGivenNames
+     * @covers ::setGender
+     * @covers ::setNationality
+     * @covers ::setPhoneNumber
+     * @covers ::setBase64Selfie
+     * @covers ::setEmailAddress
+     * @covers ::setPostalAddress
+     * @covers ::setStructuredPostalAddress
+     * @covers ::createAttribute
+     * @covers ::addAttribute
+     *
+     * @dataProvider stringAttributeSettersDataProvider
+     */
+    public function testStringAttributeSettersWithAnchor($setterMethod, $name)
+    {
+        $someAnchor = $this->createMock(SandboxAnchor::class);
+        $someAnchor->method('jsonSerialize')->willReturn(self::SOME_ANCHOR_JSON_DATA);
+
+        $this->requestBuilder->{$setterMethod}(self::SOME_STRING_VALUE, true, [ $someAnchor ]);
+        $tokenRequest = $this->requestBuilder->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'remember_me_id' => null,
+                'profile_attributes' => [
+                    [
+                        'name' => $name,
+                        'value' => self::SOME_STRING_VALUE,
+                        'derivation' => '',
+                        'optional' => true,
+                        'anchors' => [ self::SOME_ANCHOR_JSON_DATA ],
                     ]
                 ]
             ]),

--- a/sandbox/tests/Profile/Request/TokenRequestBuilderTest.php
+++ b/sandbox/tests/Profile/Request/TokenRequestBuilderTest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Yoti\Sandbox\Test\Profile\Request;
 
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxAgeVerification;
-use Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor;
-use Yoti\Sandbox\Profile\Request\Attribute\SandboxAttribute;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxDocumentDetails;
 use Yoti\Sandbox\Profile\Request\TokenRequest;
 use Yoti\Sandbox\Profile\Request\TokenRequestBuilder;
@@ -20,9 +18,6 @@ class TokenRequestBuilderTest extends TestCase
     private const SOME_REMEMBER_ME_ID = 'some_remember_me_id';
     private const SOME_NAME = 'some name';
     private const SOME_STRING_VALUE = 'some string';
-    private const SOME_TYPE = 'some type';
-    private const SOME_SUB_TYPE = 'some sub type';
-    private const SOME_TIMESTAMP = 1575998454;
 
     /**
      * @var \Yoti\Sandbox\Profile\RequestBuilders
@@ -52,7 +47,13 @@ class TokenRequestBuilderTest extends TestCase
         $this->requestBuilder->setRememberMeId(self::SOME_REMEMBER_ME_ID);
         $tokenRequest = $this->requestBuilder->build();
 
-        $this->assertEquals(self::SOME_REMEMBER_ME_ID, $tokenRequest->getRememberMeId());
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'remember_me_id' => self::SOME_REMEMBER_ME_ID,
+                'profile_attributes' => []
+            ]),
+            json_encode($tokenRequest)
+        );
     }
 
     /**
@@ -66,10 +67,8 @@ class TokenRequestBuilderTest extends TestCase
      * @covers ::setEmailAddress
      * @covers ::setPostalAddress
      * @covers ::setStructuredPostalAddress
-     * @covers ::setDocumentDetailsWithString
      * @covers ::createAttribute
      * @covers ::addAttribute
-     * @covers ::formatAnchors
      *
      * @dataProvider stringAttributeSettersDataProvider
      */
@@ -77,11 +76,22 @@ class TokenRequestBuilderTest extends TestCase
     {
         $this->requestBuilder->{$setterMethod}(self::SOME_STRING_VALUE);
         $tokenRequest = $this->requestBuilder->build();
-        $sandboxAttribute = $tokenRequest->getSandboxAttributes()[0];
 
-        $this->assertEquals($sandboxAttribute['name'], $name);
-        $this->assertEquals($sandboxAttribute['value'], self::SOME_STRING_VALUE);
-        $this->assertEquals($sandboxAttribute['anchors'], []);
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'remember_me_id' => null,
+                'profile_attributes' => [
+                    [
+                        'name' => $name,
+                        'value' => self::SOME_STRING_VALUE,
+                        'derivation' => '',
+                        'optional' => false,
+                        'anchors' => [],
+                    ]
+                ]
+            ]),
+            json_encode($tokenRequest)
+        );
     }
 
     /**
@@ -102,7 +112,6 @@ class TokenRequestBuilderTest extends TestCase
             ['setEmailAddress', 'email_address'],
             ['setPostalAddress', 'postal_address'],
             ['setStructuredPostalAddress', 'structured_postal_address'],
-            ['setDocumentDetailsWithString', 'document_details'],
         ];
     }
 
@@ -114,10 +123,22 @@ class TokenRequestBuilderTest extends TestCase
         $someDOB = new \DateTime();
         $this->requestBuilder->setDateOfBirth($someDOB);
         $tokenRequest = $this->requestBuilder->build();
-        $sandboxAttribute = $tokenRequest->getSandboxAttributes()[0];
 
-        $this->assertEquals($sandboxAttribute['name'], 'date_of_birth');
-        $this->assertEquals($sandboxAttribute['value'], $someDOB->format('Y-m-d'));
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'remember_me_id' => null,
+                'profile_attributes' => [
+                    [
+                        'name' => 'date_of_birth',
+                        'value' => $someDOB->format('Y-m-d'),
+                        'derivation' => '',
+                        'optional' => false,
+                        'anchors' => [],
+                    ]
+                ]
+            ]),
+            json_encode($tokenRequest)
+        );
     }
 
     /**
@@ -127,10 +148,22 @@ class TokenRequestBuilderTest extends TestCase
     {
         $this->requestBuilder->setSelfie(self::SOME_STRING_VALUE);
         $tokenRequest = $this->requestBuilder->build();
-        $sandboxAttribute = $tokenRequest->getSandboxAttributes()[0];
 
-        $this->assertEquals($sandboxAttribute['name'], 'selfie');
-        $this->assertEquals($sandboxAttribute['value'], base64_encode(self::SOME_STRING_VALUE));
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'remember_me_id' => null,
+                'profile_attributes' => [
+                    [
+                        'name' => 'selfie',
+                        'value' => base64_encode(self::SOME_STRING_VALUE),
+                        'derivation' => '',
+                        'optional' => false,
+                        'anchors' => [],
+                    ]
+                ]
+            ]),
+            json_encode($tokenRequest)
+        );
     }
 
     /**
@@ -143,10 +176,48 @@ class TokenRequestBuilderTest extends TestCase
 
         $this->requestBuilder->setDocumentDetails($someDocumentDetails);
         $tokenRequest = $this->requestBuilder->build();
-        $sandboxAttribute = $tokenRequest->getSandboxAttributes()[0];
 
-        $this->assertEquals($sandboxAttribute['name'], 'document_details');
-        $this->assertEquals($sandboxAttribute['value'], self::SOME_STRING_VALUE);
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'remember_me_id' => null,
+                'profile_attributes' => [
+                    [
+                        'name' => 'document_details',
+                        'value' => self::SOME_STRING_VALUE,
+                        'derivation' => '',
+                        'optional' => true,
+                        'anchors' => [],
+                    ]
+                ]
+            ]),
+            json_encode($tokenRequest)
+        );
+    }
+
+
+    /**
+     * @covers ::setDocumentDetailsWithString
+     */
+    public function testSetDocumentDetailsWithString()
+    {
+        $this->requestBuilder->setDocumentDetailsWithString(self::SOME_STRING_VALUE);
+        $tokenRequest = $this->requestBuilder->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'remember_me_id' => null,
+                'profile_attributes' => [
+                    [
+                        'name' => 'document_details',
+                        'value' => self::SOME_STRING_VALUE,
+                        'derivation' => '',
+                        'optional' => true,
+                        'anchors' => [],
+                    ]
+                ]
+            ]),
+            json_encode($tokenRequest)
+        );
     }
 
     /**
@@ -155,43 +226,25 @@ class TokenRequestBuilderTest extends TestCase
     public function testSetAgeVerification()
     {
         $someAgeVerification  = $this->createMock(SandboxAgeVerification::class);
-        $someAgeVerification->method('getName')->willReturn(self::SOME_NAME);
-        $someAgeVerification->method('getValue')->willReturn(self::SOME_STRING_VALUE);
-        $someAgeVerification->method('getAnchors')->willReturn([]);
+        $someAgeVerification->method('jsonSerialize')->willReturn([
+            'name' => self::SOME_NAME,
+            'value' => self::SOME_STRING_VALUE,
+        ]);
 
         $this->requestBuilder->setAgeVerification($someAgeVerification);
         $tokenRequest = $this->requestBuilder->build();
-        $sandboxAttribute = $tokenRequest->getSandboxAttributes()[0];
 
-        $this->assertEquals($sandboxAttribute['name'], self::SOME_NAME);
-        $this->assertEquals($sandboxAttribute['value'], self::SOME_STRING_VALUE);
-    }
-
-    /**
-     * @covers ::formatAnchors
-     */
-    public function testFormatAnchors()
-    {
-        $someAnchor = $this->createMock(SandboxAnchor::class);
-        $someAnchor->method('getType')->willReturn(self::SOME_TYPE);
-        $someAnchor->method('getSubType')->willReturn(self::SOME_SUB_TYPE);
-        $someAnchor->method('getValue')->willReturn(self::SOME_STRING_VALUE);
-        $someAnchor->method('getTimestamp')->willReturn(self::SOME_TIMESTAMP);
-
-        $someAttribute = $this->createMock(SandboxAttribute::class);
-        $someAttribute->method('getAnchors')->willReturn([$someAnchor]);
-
-        $this->requestBuilder->addAttribute($someAttribute);
-        $tokenRequest = $this->requestBuilder->build();
-        $sandboxAttribute = $tokenRequest->getSandboxAttributes()[0];
-
-        $this->assertEquals($sandboxAttribute['anchors'], [
-            [
-                'type' => strtoupper(self::SOME_TYPE),
-                'value' => self::SOME_STRING_VALUE,
-                'sub_type' => self::SOME_SUB_TYPE,
-                'timestamp' => self::SOME_TIMESTAMP * 1000000,
-            ],
-        ]);
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'remember_me_id' => null,
+                'profile_attributes' => [
+                    [
+                        'name' => self::SOME_NAME,
+                        'value' => self::SOME_STRING_VALUE,
+                    ]
+                ]
+            ]),
+            json_encode($tokenRequest)
+        );
     }
 }

--- a/sandbox/tests/Profile/Request/TokenRequestTest.php
+++ b/sandbox/tests/Profile/Request/TokenRequestTest.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace Yoti\Sandbox\Test\Profile\Request;
 
 use Yoti\Http\Payload;
-use Yoti\Profile\UserProfile;
-use Yoti\Sandbox\Profile\Request\Attribute\SandboxAnchor;
 use Yoti\Sandbox\Profile\Request\Attribute\SandboxAttribute;
 use Yoti\Sandbox\Profile\Request\TokenRequest;
 use Yoti\Test\TestCase;
@@ -17,12 +15,12 @@ use Yoti\Test\TestCase;
 class TokenRequestTest extends TestCase
 {
     private const SOME_REMEMBER_ME_ID = 'some_remember_me_id';
-    private const SOME_VALUE = 'some-value';
-    private const SOME_ANCHOR_JSON_DATA = [
-        'type' => 'some type',
-        'sub_type' => 'some sub type',
-        'value' => 'some anchor value',
-        'timestamp' => 1575998454,
+    private const SOME_ATTRIBUTE_JSON_DATA = [
+        'name' => 'some-name',
+        'value' => 'some-value',
+        'derivation' => '',
+        'optional' => false,
+        'anchors' => [],
     ];
 
     /**
@@ -35,40 +33,15 @@ class TokenRequestTest extends TestCase
      */
     public function setup(): void
     {
-        $someAnchor = $this->createMock(SandboxAnchor::class);
-        $someAnchor->method('jsonSerialize')->willReturn(self::SOME_ANCHOR_JSON_DATA);
+        $someAttribute = $this->createMock(SandboxAttribute::class);
+        $someAttribute
+            ->method('jsonSerialize')
+            ->willReturn(self::SOME_ATTRIBUTE_JSON_DATA);
 
         $this->tokenRequest = new TokenRequest(
             self::SOME_REMEMBER_ME_ID,
-            [
-                new SandboxAttribute(
-                    UserProfile::ATTR_FAMILY_NAME,
-                    self::SOME_VALUE,
-                    '',
-                    false,
-                    [ $someAnchor ]
-                )
-            ]
+            [ $someAttribute ]
         );
-    }
-
-    /**
-     * The expected JSON data.
-     */
-    private function expectedJsonData()
-    {
-        return [
-            'remember_me_id' => self::SOME_REMEMBER_ME_ID,
-            'profile_attributes' => [
-                [
-                    'name' => UserProfile::ATTR_FAMILY_NAME,
-                    'value' => self::SOME_VALUE,
-                    'derivation' => '',
-                    'optional' => false,
-                    'anchors' => [ self::SOME_ANCHOR_JSON_DATA ],
-                ]
-            ]
-        ];
     }
 
     /**
@@ -78,7 +51,10 @@ class TokenRequestTest extends TestCase
     public function testJsonSerialize()
     {
         $this->assertJsonStringEqualsJsonString(
-            json_encode($this->expectedJsonData()),
+            json_encode([
+                'remember_me_id' => self::SOME_REMEMBER_ME_ID,
+                'profile_attributes' => [ self::SOME_ATTRIBUTE_JSON_DATA ],
+            ]),
             json_encode($this->tokenRequest)
         );
     }
@@ -90,7 +66,10 @@ class TokenRequestTest extends TestCase
     public function testGetPayload()
     {
         $this->assertEquals(
-            (string) Payload::fromJsonData($this->expectedJsonData()),
+            (string) Payload::fromJsonData([
+                'remember_me_id' => self::SOME_REMEMBER_ME_ID,
+                'profile_attributes' => [ self::SOME_ATTRIBUTE_JSON_DATA ],
+            ]),
             (string) $this->tokenRequest->getPayload()
         );
     }


### PR DESCRIPTION
### Changed
- Implemented `JsonSerializable` to replace custom building of JSON data
- Optional flag is now `boolean` throughout instead of `string`

### Removed
- Removed redundant public getters for JSON serialisable objects _(there is no need to use getters on JSON payload objects)_
