### PR TITLE
SDK-1475: Use DateTime for sandbox anchor timestamps

### DIFF
--- a/sandbox/src/Profile/Request/Attribute/SandboxAnchor.php
+++ b/sandbox/src/Profile/Request/Attribute/SandboxAnchor.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Yoti\Sandbox\Profile\Request\Attribute;
 
+use Yoti\Util\DateTime;
+
 class SandboxAnchor implements \JsonSerializable
 {
     /**
@@ -22,11 +24,11 @@ class SandboxAnchor implements \JsonSerializable
     private $subtype;
 
     /**
-     * @var int
+     * @var \DateTime
      */
     private $timestamp;
 
-    public function __construct(string $type, string $value, string $subType, int $timestamp)
+    public function __construct(string $type, string $value, string $subType, \DateTime $timestamp)
     {
         $this->type = $type;
         $this->value = $value;
@@ -43,7 +45,7 @@ class SandboxAnchor implements \JsonSerializable
             'type' => $this->type,
             'value' => $this->value,
             'sub_type' => $this->subtype,
-            'timestamp' => $this->timestamp * 1000000,
+            'timestamp' => DateTime::dateTimeToTimestamp($this->timestamp),
         ];
     }
 }

--- a/sandbox/tests/Profile/Request/Attribute/SandboxAnchorTest.php
+++ b/sandbox/tests/Profile/Request/Attribute/SandboxAnchorTest.php
@@ -15,37 +15,46 @@ class SandboxAnchorTest extends TestCase
     private const SOME_TYPE = 'SOURCE';
     private const SOME_VALUE = 'PASSPORT';
     private const SOME_SUB_TYPE = 'OCR';
-    private const SOME_TIMESTAMP = 1544624701;
-
-    /**
-     * @var SandboxAnchor
-     */
-    private $anchor;
-
-    public function setup(): void
-    {
-        $this->anchor = new SandboxAnchor(
-            self::SOME_TYPE,
-            self::SOME_VALUE,
-            self::SOME_SUB_TYPE,
-            self::SOME_TIMESTAMP
-        );
-    }
 
     /**
      * @covers ::jsonSerialize
      * @covers ::__construct
+     *
+     * @dataProvider validTimestampProvider
      */
-    public function testJsonSerialize()
+    public function testJsonSerialize($timestamp, $dateString)
     {
+        $anchor = new SandboxAnchor(
+            self::SOME_TYPE,
+            self::SOME_VALUE,
+            self::SOME_SUB_TYPE,
+            new \DateTime($dateString)
+        );
+
         $this->assertJsonStringEqualsJsonString(
             json_encode([
                 'type' => self::SOME_TYPE,
                 'value' => self::SOME_VALUE,
                 'sub_type' => self::SOME_SUB_TYPE,
-                'timestamp' => self::SOME_TIMESTAMP * 1000000,
+                'timestamp' => $timestamp,
             ]),
-            json_encode($this->anchor)
+            json_encode($anchor)
         );
+    }
+
+    /**
+     * Provides valid microsecond timestamps and their expected RFC3339 representation with microseconds.
+     */
+    public function validTimestampProvider()
+    {
+        return [
+            [ 1523538872835537, '2018-04-12T13:14:32.835537+00:00' ],
+            [ -1571630945999999, '1920-03-13T19:50:54.000001+00:00' ],
+            [ 1571630945999999, '2019-10-21T04:09:05.999999+00:00' ],
+            [ 1571630945000000, '2019-10-21T04:09:05+00:00' ],
+            [ 1571630945000000, '2019-10-21T04:09:05' ],
+            [ 1571616000000000, '2019-10-21' ],
+            [ -1571702400000000, '1920-03-13' ],
+        ];
     }
 }

--- a/src/Util/DateTime.php
+++ b/src/Util/DateTime.php
@@ -35,15 +35,49 @@ class DateTime
     }
 
     /**
+     * Extract the microseconds from provided timestamp.
+     *
+     * @param int $timestamp
+     *
+     * @return int
+     */
+    private static function extractMicrosecondsFromTimestamp(int $timestamp): int
+    {
+        $microseconds = $timestamp % 1000000;
+        if ($microseconds < 0) {
+            return $microseconds + 1000000;
+        }
+        return $microseconds;
+    }
+
+    /**
      * @param int $timestamp
      *
      * @return \DateTime
      */
     public static function timestampToDateTime(int $timestamp): \DateTime
     {
-        // Format DateTime to include microseconds and timezone
-        $timeIncMicroSeconds = number_format($timestamp / 1000000, 6, '.', '');
-        return static::createFromFormat('U.u', $timeIncMicroSeconds);
+        $seconds = floor($timestamp / 1000000);
+        $microSeconds = self::extractMicrosecondsFromTimestamp($timestamp);
+        $zeroPaddedMicroSeconds = str_pad((string) $microSeconds, 6, '0', STR_PAD_LEFT);
+
+        $formattedTimestamp = sprintf(
+            '%d.%s',
+            $seconds,
+            $zeroPaddedMicroSeconds
+        );
+
+        return static::createFromFormat('U.u', $formattedTimestamp);
+    }
+
+    /**
+     * @param \DateTime $dateTime
+     *
+     * @return int
+     */
+    public static function dateTimeToTimestamp(\DateTime $dateTime): int
+    {
+        return ($dateTime->getTimestamp() * 1000000) + (int) $dateTime->format('u');
     }
 
     /**

--- a/tests/Util/DateTimeTest.php
+++ b/tests/Util/DateTimeTest.php
@@ -15,13 +15,43 @@ class DateTimeTest extends TestCase
     /**
      * @covers ::timestampToDateTime
      * @covers ::createFromFormat
+     * @covers ::extractMicrosecondsFromTimestamp
+     *
+     * @dataProvider validTimestampProvider
      */
-    public function testTimestampToDateTime()
+    public function testTimestampToDateTime($timestamp, $expectedDateString)
     {
         $this->assertEquals(
-            '2018-04-12T13:14:32.835537+00:00',
-            DateTime::timestampToDateTime(1523538872835537)->format(DateTime::RFC3339)
+            $expectedDateString,
+            DateTime::timestampToDateTime($timestamp)->format(DateTime::RFC3339)
         );
+    }
+
+    /**
+     * @covers ::dateTimeToTimestamp
+     *
+     * @dataProvider validTimestampProvider
+     */
+    public function testDateTimeToTimestamp($timestamp, $expectedDateString)
+    {
+        $dateTime = new \DateTime($expectedDateString);
+
+        $this->assertEquals(
+            $timestamp,
+            DateTime::dateTimeToTimestamp($dateTime)
+        );
+    }
+
+    /**
+     * Provides valid microsecond timestamps and their expected RFC3339 representation with microseconds.
+     */
+    public function validTimestampProvider()
+    {
+        return [
+            [ 1523538872835537, '2018-04-12T13:14:32.835537+00:00' ],
+            [ -1571630945999999, '1920-03-13T19:50:54.000001+00:00' ],
+            [ 1571630945999999, '2019-10-21T04:09:05.999999+00:00' ],
+        ];
     }
 
     /**
@@ -66,10 +96,10 @@ class DateTimeTest extends TestCase
             [ '2006-01-02T22:04:05.123456Z', '2006-01-02T22:04:05.123456+00:00' ],
             [ '2002-10-02T10:00:00-05:00', '2002-10-02T10:00:00.000000-05:00' ],
             [ '2002-10-02T10:00:00+11:00', '2002-10-02T10:00:00.000000+11:00' ],
-            ['1920-03-13T19:50:53.000001Z', '1920-03-13T19:50:53.000001+00:00'],
-            ['1920-03-13T19:50:53.999999Z', '1920-03-13T19:50:53.999999+00:00'],
-            ['1920-03-13T19:50:53.000100Z', '1920-03-13T19:50:53.000100+00:00'],
-            ['1920-03-13T19:50:53.999999+04:00', '1920-03-13T19:50:53.999999+04:00'],
+            [ '1920-03-13T19:50:53.000001Z', '1920-03-13T19:50:53.000001+00:00' ],
+            [ '1920-03-13T19:50:53.999999Z', '1920-03-13T19:50:53.999999+00:00' ],
+            [ '1920-03-13T19:50:53.000100Z', '1920-03-13T19:50:53.000100+00:00'  ],
+            [ '1920-03-13T19:50:53.999999+04:00', '1920-03-13T19:50:53.999999+04:00' ],
         ];
     }
 


### PR DESCRIPTION
### Fixed
- Sandbox anchor timestamps are now set using `\DateTime` object
- `Yoti\Util\DateTime::timestampToDateTime()` now supports negative microsecond timestamps
