### PR TITLE
SDK-1501: API URL environment variable

### DIFF
--- a/examples/doc-scan/app/Providers/YotiDocScanServiceProvider.php
+++ b/examples/doc-scan/app/Providers/YotiDocScanServiceProvider.php
@@ -16,9 +16,7 @@ class YotiDocScanServiceProvider extends ServiceProvider implements DeferrablePr
         $this->app->singleton(DocScanClient::class, function ($app) {
             $config = $app['config']['yoti'];
 
-            return new DocScanClient($config['client.sdk.id'], $config['pem.file.path'], [
-                'api.url' => $config['doc.scan.api.url'],
-            ]);
+            return new DocScanClient($config['client.sdk.id'], $config['pem.file.path']);
         });
     }
 

--- a/examples/doc-scan/config/yoti.php
+++ b/examples/doc-scan/config/yoti.php
@@ -3,7 +3,6 @@
 return [
     'client.sdk.id' => env('YOTI_SDK_ID'),
     'doc.scan.iframe.url' => env('YOTI_DOC_SCAN_IFRAME_URL') ?: 'https://api.yoti.com/idverify/v1/web/index.html',
-    'doc.scan.api.url' => env('YOTI_DOC_SCAN_API_URL') ?: null,
     'pem.file.path' => (function($filePath) {
         return strpos($filePath, '/') === 0 ? $filePath : base_path($filePath);
     })(env('YOTI_KEY_FILE_PATH')),

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -12,8 +12,14 @@ class Constants
     /** Default API URL */
     public const API_URL = self::API_BASE_URL . '/api/v1';
 
+    /** Environment variable to override the default API URL */
+    public const ENV_API_URL = 'YOTI_API_URL';
+
     /** Default Doc Scan API URL */
     public const DOC_SCAN_API_URL = self::API_BASE_URL . '/idverify/v1';
+
+    /** Environment variable to override the default Doc Scan API URL */
+    public const ENV_DOC_SCAN_API_URL = 'YOTI_DOC_SCAN_API_URL';
 
     /** Default SDK identifier */
     public const SDK_IDENTIFIER = 'PHP';

--- a/src/DocScan/DocScanClient.php
+++ b/src/DocScan/DocScanClient.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yoti\DocScan;
 
+use Yoti\Constants;
 use Yoti\DocScan\Session\Create\CreateSessionResult;
 use Yoti\DocScan\Session\Create\SessionSpecification;
 use Yoti\DocScan\Session\Retrieve\GetSessionResult;
@@ -48,7 +49,13 @@ class DocScanClient
         array $options = []
     ) {
         Validation::notEmptyString($sdkId, 'SDK ID');
-        $pemFile = Pemfile::resolveFromString($pem);
+        $pemFile = PemFile::resolveFromString($pem);
+
+        // Set API URL from environment variable.
+        if (getenv(Constants::ENV_DOC_SCAN_API_URL) !== false && !isset($options[Config::API_URL])) {
+            $options[Config::API_URL] = getenv(Constants::ENV_DOC_SCAN_API_URL);
+        }
+
         $config = new Config($options);
 
         $this->docScanService = new Service($sdkId, $pemFile, $config);

--- a/src/YotiClient.php
+++ b/src/YotiClient.php
@@ -57,7 +57,13 @@ class YotiClient
         array $options = []
     ) {
         Validation::notEmptyString($sdkId, 'SDK ID');
-        $pemFile = Pemfile::resolveFromString($pem);
+        $pemFile = PemFile::resolveFromString($pem);
+
+        // Set API URL from environment variable.
+        if (getenv(Constants::ENV_API_URL) !== false && !isset($options[Config::API_URL])) {
+            $options[Config::API_URL] = getenv(Constants::ENV_API_URL);
+        }
+
         $config = new Config($options);
 
         $this->profileService = new ProfileService($sdkId, $pemFile, $config);

--- a/tests/DocScan/DocScanClientTest.php
+++ b/tests/DocScan/DocScanClientTest.php
@@ -36,6 +36,107 @@ class DocScanClientTest extends TestCase
     /**
      * @test
      * @covers ::__construct
+     */
+    public function testDefaultApiUrl()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn(file_get_contents(TestData::DOC_SCAN_SESSION_CREATION_RESPONSE));
+        $response->method('getStatusCode')->willReturn(200);
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->exactly(1))
+            ->method('sendRequest')
+            ->with($this->callback(function ($requestMessage) {
+                $this->assertStringStartsWith(
+                    TestData::DOC_SCAN_BASE_URL,
+                    (string) $requestMessage->getUri()
+                );
+                return true;
+            }))
+            ->willReturn($response);
+
+        $docScanClient = new DocScanClient(TestData::SDK_ID, TestData::PEM_FILE, [
+            Config::HTTP_CLIENT => $httpClient,
+        ]);
+
+        $sessionSpecificationMock = $this->createMock(SessionSpecification::class);
+        $sessionSpecificationMock->method('jsonSerialize')->willReturn([]);
+
+        $docScanClient->createSession($sessionSpecificationMock);
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function testApiUrlOptionOverridesEnvironmentVariable()
+    {
+        putenv('YOTI_DOC_SCAN_API_URL=https://example.com/env/api');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn(file_get_contents(TestData::DOC_SCAN_SESSION_CREATION_RESPONSE));
+        $response->method('getStatusCode')->willReturn(200);
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->exactly(1))
+            ->method('sendRequest')
+            ->with($this->callback(function ($requestMessage) {
+                $this->assertStringStartsWith(
+                    'https://example.com/option/api',
+                    (string) $requestMessage->getUri()
+                );
+                return true;
+            }))
+            ->willReturn($response);
+
+        $docScanClient = new DocScanClient(TestData::SDK_ID, TestData::PEM_FILE, [
+            Config::HTTP_CLIENT => $httpClient,
+            Config::API_URL => 'https://example.com/option/api'
+        ]);
+
+        $sessionSpecificationMock = $this->createMock(SessionSpecification::class);
+        $sessionSpecificationMock->method('jsonSerialize')->willReturn([]);
+
+        $docScanClient->createSession($sessionSpecificationMock);
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function testApiUrlEnvironmentVariable()
+    {
+        putenv('YOTI_DOC_SCAN_API_URL=https://example.com/env/api');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn(file_get_contents(TestData::DOC_SCAN_SESSION_CREATION_RESPONSE));
+        $response->method('getStatusCode')->willReturn(200);
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->exactly(1))
+            ->method('sendRequest')
+            ->with($this->callback(function ($requestMessage) {
+                $this->assertStringStartsWith(
+                    'https://example.com/env/api',
+                    (string) $requestMessage->getUri()
+                );
+                return true;
+            }))
+            ->willReturn($response);
+
+        $docScanClient = new DocScanClient(TestData::SDK_ID, TestData::PEM_FILE, [
+            Config::HTTP_CLIENT => $httpClient,
+        ]);
+
+        $sessionSpecificationMock = $this->createMock(SessionSpecification::class);
+        $sessionSpecificationMock->method('jsonSerialize')->willReturn([]);
+
+        $docScanClient->createSession($sessionSpecificationMock);
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
      * @covers ::createSession
      * @throws \Yoti\Exception\PemFileException
      * @throws \Yoti\DocScan\Exception\DocScanException

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yoti\Test;
 
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
+use Yoti\Constants;
 
 class TestCase extends PHPUnitTestCase
 {
@@ -37,6 +38,10 @@ class TestCase extends PHPUnitTestCase
         // Restores ini settings.
         ini_restore('error_log');
         ini_restore('display_errors');
+
+        // Remove environment variables.
+        putenv(Constants::ENV_API_URL);
+        putenv(Constants::ENV_DOC_SCAN_API_URL);
 
         self::$mockFunctions = [];
     }

--- a/tests/YotiClientTest.php
+++ b/tests/YotiClientTest.php
@@ -38,6 +38,98 @@ class YotiClientTest extends TestCase
     }
 
     /**
+     * @test
+     * @covers ::__construct
+     */
+    public function testDefaultApiUrl()
+    {
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn(stream_for(file_get_contents(TestData::AML_CHECK_RESULT_JSON)));
+        $response->method('getStatusCode')->willReturn(200);
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->exactly(1))
+            ->method('sendRequest')
+            ->with($this->callback(function ($requestMessage) {
+                $this->assertStringStartsWith(
+                    TestData::CONNECT_BASE_URL,
+                    (string) $requestMessage->getUri()
+                );
+                return true;
+            }))
+            ->willReturn($response);
+
+        $yotiClient = new YotiClient(TestData::SDK_ID, TestData::PEM_FILE, [
+            Config::HTTP_CLIENT => $httpClient
+        ]);
+
+        $yotiClient->performAmlCheck($this->createMock(AmlProfile::class));
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function testApiUrlOptionOverridesEnvironmentVariable()
+    {
+        putenv('YOTI_API_URL=https://example.com/env/api');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn(stream_for(file_get_contents(TestData::AML_CHECK_RESULT_JSON)));
+        $response->method('getStatusCode')->willReturn(200);
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->exactly(1))
+            ->method('sendRequest')
+            ->with($this->callback(function ($requestMessage) {
+                $this->assertStringStartsWith(
+                    'https://example.com/option/api',
+                    (string) $requestMessage->getUri()
+                );
+                return true;
+            }))
+            ->willReturn($response);
+
+        $yotiClient = new YotiClient(TestData::SDK_ID, TestData::PEM_FILE, [
+            Config::HTTP_CLIENT => $httpClient,
+            Config::API_URL => 'https://example.com/option/api',
+        ]);
+
+        $yotiClient->performAmlCheck($this->createMock(AmlProfile::class));
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function testApiUrlEnvironmentVariable()
+    {
+        putenv('YOTI_API_URL=https://example.com/env/api');
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('getBody')->willReturn(stream_for(file_get_contents(TestData::AML_CHECK_RESULT_JSON)));
+        $response->method('getStatusCode')->willReturn(200);
+
+        $httpClient = $this->createMock(ClientInterface::class);
+        $httpClient->expects($this->exactly(1))
+            ->method('sendRequest')
+            ->with($this->callback(function ($requestMessage) {
+                $this->assertStringStartsWith(
+                    'https://example.com/env/api',
+                    (string) $requestMessage->getUri()
+                );
+                return true;
+            }))
+            ->willReturn($response);
+
+        $yotiClient = new YotiClient(TestData::SDK_ID, TestData::PEM_FILE, [
+            Config::HTTP_CLIENT => $httpClient,
+        ]);
+
+        $yotiClient->performAmlCheck($this->createMock(AmlProfile::class));
+    }
+
+    /**
      * @covers ::getActivityDetails
      * @covers ::__construct
      */


### PR DESCRIPTION
### Added
- Default API URLs can now be overridden using environment variables:
  - `YOTI_API_URL` to override the default API URL
  - `YOTI_DOC_SCAN_API_URL` to override the default Doc Scan API URL