### PR TITLE
SDK-1550: Add type to responses

### DIFF
--- a/src/DocScan/Session/Retrieve/CheckResponse.php
+++ b/src/DocScan/Session/Retrieve/CheckResponse.php
@@ -9,6 +9,10 @@ use Yoti\Util\DateTime;
 
 class CheckResponse
 {
+    /**
+     * @var string|null
+     */
+    private $type;
 
     /**
      * @var string|null
@@ -52,6 +56,7 @@ class CheckResponse
      */
     public function __construct(array $checkData)
     {
+        $this->type = $checkData['type'] ?? null;
         $this->id = $checkData['id'] ?? null;
         $this->state = $checkData['state'] ?? null;
         $this->resourcesUsed = $checkData['resources_used'] ?? [];
@@ -71,6 +76,14 @@ class CheckResponse
 
         $this->lastUpdated = isset($checkData['last_updated']) ?
             DateTime::stringToDateTime($checkData['last_updated']) : null;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getType(): ?string
+    {
+        return $this->type;
     }
 
     /**

--- a/src/DocScan/Session/Retrieve/GeneratedCheckResponse.php
+++ b/src/DocScan/Session/Retrieve/GeneratedCheckResponse.php
@@ -6,6 +6,10 @@ namespace Yoti\DocScan\Session\Retrieve;
 
 class GeneratedCheckResponse
 {
+    /**
+     * @var string|null
+     */
+    private $type;
 
     /**
      * @var string|null
@@ -18,7 +22,16 @@ class GeneratedCheckResponse
      */
     public function __construct(array $generatedCheck)
     {
+        $this->type = $generatedCheck['type'] ?? null;
         $this->id = $generatedCheck['id'] ?? null;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getType(): ?string
+    {
+        return $this->type;
     }
 
     /**

--- a/src/DocScan/Session/Retrieve/LivenessResourceResponse.php
+++ b/src/DocScan/Session/Retrieve/LivenessResourceResponse.php
@@ -4,5 +4,26 @@ namespace Yoti\DocScan\Session\Retrieve;
 
 class LivenessResourceResponse extends ResourceResponse
 {
+    /**
+     * @var string|null
+     */
+    private $livenessType;
 
+    /**
+     * @param array<string, mixed> $resource
+     */
+    public function __construct(array $resource)
+    {
+        parent::__construct($resource);
+
+        $this->livenessType = $resource['liveness_type'] ?? null;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getLivenessType(): ?string
+    {
+        return $this->livenessType;
+    }
 }

--- a/src/DocScan/Session/Retrieve/ResourceResponse.php
+++ b/src/DocScan/Session/Retrieve/ResourceResponse.php
@@ -6,7 +6,6 @@ use Yoti\DocScan\Constants;
 
 class ResourceResponse
 {
-
     /**
      * @var string|null
      */

--- a/src/DocScan/Session/Retrieve/TaskResponse.php
+++ b/src/DocScan/Session/Retrieve/TaskResponse.php
@@ -9,6 +9,10 @@ use Yoti\Util\DateTime;
 
 class TaskResponse
 {
+    /**
+     * @var string|null
+     */
+    private $type;
 
     /**
      * @var string|null
@@ -46,6 +50,7 @@ class TaskResponse
      */
     public function __construct(array $task)
     {
+        $this->type = $task['type'] ?? null;
         $this->id = $task['id'] ?? null;
         $this->state = $task['state'] ?? null;
 
@@ -95,6 +100,14 @@ class TaskResponse
             $parsedGeneratedMedia[] = new GeneratedMedia($generatedMedia);
         }
         return $parsedGeneratedMedia;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getType(): ?string
+    {
+        return $this->type;
     }
 
     /**

--- a/tests/DocScan/Session/Retrieve/CheckResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/CheckResponseTest.php
@@ -15,7 +15,7 @@ use Yoti\Util\DateTime;
  */
 class CheckResponseTest extends TestCase
 {
-
+    private const SOME_TYPE = 'someType';
     private const SOME_ID = 'someId';
     private const SOME_STATE = 'someState';
     private const SOME_CREATED = '2019-12-02T12:00:00.123Z';
@@ -29,6 +29,7 @@ class CheckResponseTest extends TestCase
     /**
      * @test
      * @covers ::__construct
+     * @covers ::getType
      * @covers ::getId
      * @covers ::getState
      * @covers ::getCreated
@@ -47,11 +48,12 @@ class CheckResponseTest extends TestCase
             'resources_used' => self::SOME_RESOURCES_USED,
             'generated_media' => self::SOME_GENERATED_MEDIA,
             'report' => [],
-            'type' => 'ID_DOCUMENT_AUTHENTICITY',
+            'type' => self::SOME_TYPE,
         ];
 
         $result = new CheckResponse($input);
 
+        $this->assertEquals(self::SOME_TYPE, $result->getType());
         $this->assertEquals(self::SOME_ID, $result->getId());
         $this->assertEquals(self::SOME_STATE, $result->getState());
         $this->assertEquals(DateTime::stringToDateTime(self::SOME_CREATED), $result->getCreated());
@@ -70,7 +72,7 @@ class CheckResponseTest extends TestCase
     public function shouldParseReport()
     {
         $input = [
-            'type' => 'ID_DOCUMENT_AUTHENTICITY',
+            'type' => self::SOME_TYPE,
             'report' => [ ] // Key just needs to exist for test
         ];
 
@@ -89,7 +91,7 @@ class CheckResponseTest extends TestCase
     public function resourcesUsedAndGeneratedMediaShouldDefaultToEmptyList()
     {
         $input = [
-            'type' => 'ID_DOCUMENT_AUTHENTICITY',
+            'type' => self::SOME_TYPE,
         ];
 
         $result = new CheckResponse($input);

--- a/tests/DocScan/Session/Retrieve/GetSessionResultTest.php
+++ b/tests/DocScan/Session/Retrieve/GetSessionResultTest.php
@@ -4,7 +4,6 @@ declare(strict_types=1);
 
 namespace Yoti\Test\DocScan\Session\Retrieve;
 
-use Yoti\DocScan\Constants;
 use Yoti\DocScan\Session\Retrieve\AuthenticityCheckResponse;
 use Yoti\DocScan\Session\Retrieve\CheckResponse;
 use Yoti\DocScan\Session\Retrieve\GetSessionResult;
@@ -15,7 +14,11 @@ use Yoti\Test\TestCase;
  */
 class GetSessionResultTest extends TestCase
 {
-
+    private const ID_DOCUMENT_AUTHENTICITY = 'ID_DOCUMENT_AUTHENTICITY';
+    private const ID_DOCUMENT_FACE_MATCH = 'ID_DOCUMENT_FACE_MATCH';
+    private const ID_DOCUMENT_TEXT_DATA_CHECK = 'ID_DOCUMENT_TEXT_DATA_CHECK';
+    private const LIVENESS = 'LIVENESS';
+    private const SOME_UNKNOWN_TYPE = 'someUnknownType';
     private const SOME_STATE = 'someState';
     private const SOME_SESSION_ID = 'someSessionId';
     private const SOME_USER_TRACKING_ID = 'someUserTrackingId';
@@ -69,14 +72,16 @@ class GetSessionResultTest extends TestCase
     {
         $input = [
             'checks' => [
-                [ 'type' => 'someUnknownType' ],
+                [ 'type' => self::SOME_UNKNOWN_TYPE ],
             ],
         ];
 
         $result = new GetSessionResult($input);
 
         $this->assertCount(1, $result->getChecks());
+
         $this->assertInstanceOf(CheckResponse::class, $result->getChecks()[0]);
+        $this->assertEquals(self::SOME_UNKNOWN_TYPE, $result->getChecks()[0]->getType());
     }
 
     /**
@@ -92,10 +97,10 @@ class GetSessionResultTest extends TestCase
     {
         $input = [
             'checks' => [
-                [ 'type' => Constants::ID_DOCUMENT_AUTHENTICITY ],
-                [ 'type' => Constants::ID_DOCUMENT_FACE_MATCH ],
-                [ 'type' => Constants::ID_DOCUMENT_TEXT_DATA_CHECK ],
-                [ 'type' => Constants::LIVENESS ],
+                [ 'type' => self::ID_DOCUMENT_AUTHENTICITY ],
+                [ 'type' => self::ID_DOCUMENT_FACE_MATCH ],
+                [ 'type' => self::ID_DOCUMENT_TEXT_DATA_CHECK ],
+                [ 'type' => self::LIVENESS ],
             ],
         ];
 
@@ -106,5 +111,10 @@ class GetSessionResultTest extends TestCase
         $this->assertCount(1, $result->getFaceMatchChecks());
         $this->assertCount(1, $result->getTextDataChecks());
         $this->assertCount(1, $result->getLivenessChecks());
+
+        $this->assertEquals(self::ID_DOCUMENT_AUTHENTICITY, $result->getAuthenticityChecks()[0]->getType());
+        $this->assertEquals(self::ID_DOCUMENT_FACE_MATCH, $result->getFaceMatchChecks()[0]->getType());
+        $this->assertEquals(self::ID_DOCUMENT_TEXT_DATA_CHECK, $result->getTextDataChecks()[0]->getType());
+        $this->assertEquals(self::LIVENESS, $result->getLivenessChecks()[0]->getType());
     }
 }

--- a/tests/DocScan/Session/Retrieve/LivenessResourceResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/LivenessResourceResponseTest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Yoti\Test\DocScan\Session\Retrieve;
+
+use Yoti\DocScan\Session\Retrieve\LivenessResourceResponse;
+use Yoti\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\DocScan\Session\Retrieve\LivenessResourceResponse
+ */
+class LivenessResourceResponseTest extends TestCase
+{
+    private const SOME_LIVENESS_TYPE = 'someLivenessType';
+
+    /**
+     * @test
+     * @covers ::__construct
+     * @covers ::getLivenessType
+     */
+    public function shouldBuildCorrectly()
+    {
+        $input = [
+            'liveness_type' => self::SOME_LIVENESS_TYPE,
+        ];
+
+        $result = new LivenessResourceResponse($input);
+
+        $this->assertEquals(self::SOME_LIVENESS_TYPE, $result->getLivenessType());
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     * @covers ::getLivenessType
+     */
+    public function shouldNotThrowExceptionIfMissingValues()
+    {
+        $result = new LivenessResourceResponse([]);
+
+        $this->assertNull($result->getLivenessType());
+    }
+}

--- a/tests/DocScan/Session/Retrieve/ResourceResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/ResourceResponseTest.php
@@ -14,7 +14,8 @@ use Yoti\Test\TestCase;
  */
 class ResourceResponseTest extends TestCase
 {
-
+    private const ID_DOCUMENT_TEXT_DATA_EXTRACTION = 'ID_DOCUMENT_TEXT_DATA_EXTRACTION';
+    private const SOME_UNKNOWN_TASK = 'someUnknownTask';
     private const SOME_ID = 'someId';
 
     /**
@@ -28,7 +29,7 @@ class ResourceResponseTest extends TestCase
         $input = [
             'id' => self::SOME_ID,
             'tasks' => [
-                ['type' => 'ID_DOCUMENT_TEXT_DATA_EXTRACTION'],
+                ['type' => self::ID_DOCUMENT_TEXT_DATA_EXTRACTION],
             ],
         ];
 
@@ -47,7 +48,7 @@ class ResourceResponseTest extends TestCase
     {
         $input = [
             'tasks' => [
-                ['type' => 'ID_DOCUMENT_TEXT_DATA_EXTRACTION'],
+                ['type' => self::ID_DOCUMENT_TEXT_DATA_EXTRACTION],
             ],
         ];
 
@@ -55,6 +56,7 @@ class ResourceResponseTest extends TestCase
 
         $this->assertCount(1, $result->getTasks());
         $this->assertInstanceOf(TextExtractionTaskResponse::class, $result->getTasks()[0]);
+        $this->assertEquals(self::ID_DOCUMENT_TEXT_DATA_EXTRACTION, $result->getTasks()[0]->getType());
     }
 
     /**
@@ -66,8 +68,8 @@ class ResourceResponseTest extends TestCase
     {
         $input = [
             'tasks' => [
-                ['type' => 'ID_DOCUMENT_TEXT_DATA_EXTRACTION'],
-                ['type' => 'someUnknownType'],
+                ['type' => self::ID_DOCUMENT_TEXT_DATA_EXTRACTION],
+                ['type' => self::SOME_UNKNOWN_TASK],
             ],
         ];
 
@@ -82,11 +84,11 @@ class ResourceResponseTest extends TestCase
      * @covers ::__construct
      * @covers ::createTaskFromArray
      */
-    public function shouldIgnoreUnknownTypeOfTask()
+    public function shouldCreateUnknownTypeOfTask()
     {
         $input = [
             'tasks' => [
-                ['type' => 'someUnknownType'],
+                ['type' => self::SOME_UNKNOWN_TASK],
             ],
         ];
 
@@ -94,6 +96,7 @@ class ResourceResponseTest extends TestCase
 
         $this->assertCount(1, $result->getTasks());
         $this->assertInstanceOf(TaskResponse::class, $result->getTasks()[0]);
+        $this->assertEquals(self::SOME_UNKNOWN_TASK, $result->getTasks()[0]->getType());
     }
 
     /**

--- a/tests/DocScan/Session/Retrieve/TaskResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/TaskResponseTest.php
@@ -16,7 +16,7 @@ use Yoti\Util\DateTime;
  */
 class TaskResponseTest extends TestCase
 {
-
+    private const SOME_TYPE = 'someType';
     private const SOME_ID = 'someId';
     private const SOME_STATE = 'someState';
     private const SOME_CREATED = '2019-03-24T03:55:12Z';
@@ -34,6 +34,7 @@ class TaskResponseTest extends TestCase
      * @covers ::__construct
      * @covers ::parseGeneratedChecks
      * @covers ::parseGeneratedMedia
+     * @covers ::getType
      * @covers ::getId
      * @covers ::getState
      * @covers ::getCreated
@@ -50,11 +51,12 @@ class TaskResponseTest extends TestCase
             'last_updated' => self::SOME_LAST_UPDATED,
             'generated_checks' => self::SOME_GENERATED_CHECKS,
             'generated_media' => self::SOME_GENERATED_MEDIA,
-            'type' => 'ID_DOCUMENT_TEXT_DATA_EXTRACTION',
+            'type' => self::SOME_TYPE,
         ];
 
         $result = new TextExtractionTaskResponse($input);
 
+        $this->assertEquals(self::SOME_TYPE, $result->getType());
         $this->assertEquals(self::SOME_ID, $result->getId());
         $this->assertEquals(self::SOME_STATE, $result->getState());
         $this->assertEquals(DateTime::stringToDateTime(self::SOME_CREATED), $result->getCreated());
@@ -85,11 +87,12 @@ class TaskResponseTest extends TestCase
                 ],
             ],
             'generated_media' => self::SOME_GENERATED_MEDIA,
-            'type' => 'ID_DOCUMENT_TEXT_DATA_EXTRACTION',
+            'type' => self::SOME_TYPE,
         ];
 
         $result = new TextExtractionTaskResponse($input);
 
+        $this->assertEquals(self::SOME_TYPE, $result->getType());
         $this->assertEquals(self::SOME_ID, $result->getId());
         $this->assertEquals(self::SOME_STATE, $result->getState());
         $this->assertEquals(DateTime::stringToDateTime(self::SOME_CREATED), $result->getCreated());
@@ -123,7 +126,7 @@ class TaskResponseTest extends TestCase
                 ]
             ],
             'generated_media' => self::SOME_GENERATED_MEDIA,
-            'type' => 'ID_DOCUMENT_TEXT_DATA_EXTRACTION',
+            'type' => self::SOME_TYPE,
         ];
 
         $result = new TaskResponse($input);
@@ -138,8 +141,9 @@ class TaskResponseTest extends TestCase
      */
     public function shouldNotThrowExceptionWhenAllMissingValuesExceptType()
     {
-        $result = new TextExtractionTaskResponse([ 'type' => 'ID_DOCUMENT_TEXT_DATA_EXTRACTION' ]);
+        $result = new TextExtractionTaskResponse([]);
 
+        $this->assertNull($result->getType());
         $this->assertNull($result->getId());
         $this->assertNull($result->getState());
         $this->assertNull($result->getCreated());

--- a/tests/DocScan/Session/Retrieve/TaskResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/TaskResponseTest.php
@@ -6,7 +6,6 @@ namespace Yoti\Test\DocScan\Session\Retrieve;
 
 use Yoti\DocScan\Session\Retrieve\GeneratedCheckResponse;
 use Yoti\DocScan\Session\Retrieve\GeneratedTextDataCheckResponse;
-use Yoti\DocScan\Session\Retrieve\TaskResponse;
 use Yoti\DocScan\Session\Retrieve\TextExtractionTaskResponse;
 use Yoti\Test\TestCase;
 use Yoti\Util\DateTime;
@@ -18,16 +17,42 @@ class TaskResponseTest extends TestCase
 {
     private const SOME_TYPE = 'someType';
     private const SOME_ID = 'someId';
+    private const SOME_OTHER_ID = 'someOtherId';
     private const SOME_STATE = 'someState';
     private const SOME_CREATED = '2019-03-24T03:55:12Z';
     private const SOME_LAST_UPDATED = '2019-03-24T03:55:12Z';
-    private const SOME_GENERATED_CHECKS = [
-        [ 'type' => 'ID_DOCUMENT_TEXT_DATA_CHECK' ],
-    ];
-    private const SOME_GENERATED_MEDIA = [
-        [ 'someKey' => 'someValue' ],
-        [ 'someOtherKey' => 'someOtherValue' ],
-    ];
+    private const SOME_UNKNOWN_TYPE = 'someUnknownType';
+    private const ID_DOCUMENT_TEXT_DATA_CHECK = 'ID_DOCUMENT_TEXT_DATA_CHECK';
+
+    /**
+     * @var TextExtractionTaskResponse
+     */
+    private $taskResponse;
+
+    public function setup(): void
+    {
+         $this->taskResponse = new TextExtractionTaskResponse([
+            'id' => self::SOME_ID,
+            'type' => self::SOME_TYPE,
+            'state' => self::SOME_STATE,
+            'created' => self::SOME_CREATED,
+            'last_updated' => self::SOME_LAST_UPDATED,
+            'generated_checks' => [
+                [
+                    'id' => self::SOME_ID,
+                    'type' => self::ID_DOCUMENT_TEXT_DATA_CHECK,
+                ],
+                [
+                    'id' => self::SOME_OTHER_ID,
+                    'type' => self::SOME_UNKNOWN_TYPE,
+                ],
+            ],
+            'generated_media' => [
+                [],
+                [],
+            ],
+         ]);
+    }
 
     /**
      * @test
@@ -42,67 +67,50 @@ class TaskResponseTest extends TestCase
      * @covers ::getGeneratedMedia
      * @covers ::getGeneratedChecks
      */
-    public function shouldBuildCorrectly()
+    public function shouldMapPropertiesCorrectly()
     {
-        $input = [
-            'id' => self::SOME_ID,
-            'state' => self::SOME_STATE,
-            'created' => self::SOME_CREATED,
-            'last_updated' => self::SOME_LAST_UPDATED,
-            'generated_checks' => self::SOME_GENERATED_CHECKS,
-            'generated_media' => self::SOME_GENERATED_MEDIA,
-            'type' => self::SOME_TYPE,
-        ];
-
-        $result = new TextExtractionTaskResponse($input);
-
-        $this->assertEquals(self::SOME_TYPE, $result->getType());
-        $this->assertEquals(self::SOME_ID, $result->getId());
-        $this->assertEquals(self::SOME_STATE, $result->getState());
-        $this->assertEquals(DateTime::stringToDateTime(self::SOME_CREATED), $result->getCreated());
-        $this->assertEquals(DateTime::stringToDateTime(self::SOME_LAST_UPDATED), $result->getLastUpdated());
-
-        $this->assertCount(1, $result->getGeneratedChecks());
-        $this->assertInstanceOf(GeneratedTextDataCheckResponse::class, $result->getGeneratedChecks()[0]);
-        $this->assertCount(2, $result->getGeneratedMedia());
+        $this->assertEquals(self::SOME_TYPE, $this->taskResponse->getType());
+        $this->assertEquals(self::SOME_ID, $this->taskResponse->getId());
+        $this->assertEquals(self::SOME_STATE, $this->taskResponse->getState());
+        $this->assertEquals(DateTime::stringToDateTime(self::SOME_CREATED), $this->taskResponse->getCreated());
+        $this->assertEquals(DateTime::stringToDateTime(self::SOME_LAST_UPDATED), $this->taskResponse->getLastUpdated());
+        $this->assertCount(2, $this->taskResponse->getGeneratedChecks());
+        $this->assertContainsOnlyInstancesOf(GeneratedCheckResponse::class, $this->taskResponse->getGeneratedChecks());
+        $this->assertCount(2, $this->taskResponse->getGeneratedMedia());
     }
 
     /**
      * @test
      * @covers ::parseGeneratedChecks
+     * @covers ::getGeneratedChecks
      * @covers \Yoti\DocScan\Session\Retrieve\GeneratedCheckResponse::__construct
      * @covers \Yoti\DocScan\Session\Retrieve\GeneratedCheckResponse::getId
+     * @covers \Yoti\DocScan\Session\Retrieve\GeneratedCheckResponse::getType
+     */
+    public function shouldReturnGeneratedTextDataChecks()
+    {
+        $generatedCheck = $this->taskResponse->getGeneratedChecks()[0];
+
+        $this->assertInstanceOf(GeneratedTextDataCheckResponse::class, $generatedCheck);
+        $this->assertEquals(self::SOME_ID, $generatedCheck->getId());
+        $this->assertEquals(self::ID_DOCUMENT_TEXT_DATA_CHECK, $generatedCheck->getType());
+    }
+
+    /**
+     * @test
+     * @covers ::parseGeneratedChecks
+     * @covers ::getGeneratedChecks
+     * @covers \Yoti\DocScan\Session\Retrieve\GeneratedCheckResponse::__construct
+     * @covers \Yoti\DocScan\Session\Retrieve\GeneratedCheckResponse::getId
+     * @covers \Yoti\DocScan\Session\Retrieve\GeneratedCheckResponse::getType
      */
     public function shouldReturnGeneratedCheckWithUnknownType()
     {
-        $input = [
-            'id' => self::SOME_ID,
-            'state' => self::SOME_STATE,
-            'created' => self::SOME_CREATED,
-            'last_updated' => self::SOME_LAST_UPDATED,
-            'generated_checks' => [
-                [
-                    'id' => 'someId',
-                    'type' => 'someUnknownType',
-                ],
-            ],
-            'generated_media' => self::SOME_GENERATED_MEDIA,
-            'type' => self::SOME_TYPE,
-        ];
+        $generatedCheck = $this->taskResponse->getGeneratedChecks()[1];
 
-        $result = new TextExtractionTaskResponse($input);
-
-        $this->assertEquals(self::SOME_TYPE, $result->getType());
-        $this->assertEquals(self::SOME_ID, $result->getId());
-        $this->assertEquals(self::SOME_STATE, $result->getState());
-        $this->assertEquals(DateTime::stringToDateTime(self::SOME_CREATED), $result->getCreated());
-        $this->assertEquals(DateTime::stringToDateTime(self::SOME_LAST_UPDATED), $result->getLastUpdated());
-
-        $this->assertCount(2, $result->getGeneratedMedia());
-
-        $this->assertCount(1, $result->getGeneratedChecks());
-        $this->assertEquals('someId', $result->getGeneratedChecks()[0]->getId());
-        $this->assertInstanceOf(GeneratedCheckResponse::class, $result->getGeneratedChecks()[0]);
+        $this->assertInstanceOf(GeneratedCheckResponse::class, $generatedCheck);
+        $this->assertEquals(self::SOME_OTHER_ID, $generatedCheck->getId());
+        $this->assertEquals(self::SOME_UNKNOWN_TYPE, $generatedCheck->getType());
     }
 
     /**
@@ -112,27 +120,8 @@ class TaskResponseTest extends TestCase
      */
     public function shouldFilterGeneratedTextDataChecks(): void
     {
-        $input = [
-            'id' => self::SOME_ID,
-            'state' => self::SOME_STATE,
-            'created' => self::SOME_CREATED,
-            'last_updated' => self::SOME_LAST_UPDATED,
-            'generated_checks' => [
-                [
-                    'type' => 'someUnknownType',
-                ],
-                [
-                    'type' => 'ID_DOCUMENT_TEXT_DATA_CHECK',
-                ]
-            ],
-            'generated_media' => self::SOME_GENERATED_MEDIA,
-            'type' => self::SOME_TYPE,
-        ];
-
-        $result = new TaskResponse($input);
-
-        $this->assertCount(2, $result->getGeneratedChecks());
-        $this->assertCount(1, $result->getGeneratedTextDataChecks());
+        $this->assertCount(2, $this->taskResponse->getGeneratedChecks());
+        $this->assertCount(1, $this->taskResponse->getGeneratedTextDataChecks());
     }
 
     /**

--- a/tests/DocScan/Session/Retrieve/ZoomLivenessResourceResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/ZoomLivenessResourceResponseTest.php
@@ -10,10 +10,12 @@ use Yoti\Test\TestCase;
  */
 class ZoomLivenessResourceResponseTest extends TestCase
 {
+    private const SOME_LIVENESS_TYPE = 'someLivenessType';
 
     /**
      * @test
      * @covers ::__construct
+     * @covers ::getLivenessType
      * @covers ::parseFrames
      * @covers ::getFaceMap
      * @covers ::getFrames
@@ -21,6 +23,7 @@ class ZoomLivenessResourceResponseTest extends TestCase
     public function shouldBuildCorrectly()
     {
         $input = [
+            'liveness_type' => self::SOME_LIVENESS_TYPE,
             'facemap' => [],
             'frames' => [
                 [ 'someFrameKey' => 'someFrameValue' ],
@@ -30,6 +33,7 @@ class ZoomLivenessResourceResponseTest extends TestCase
 
         $result = new ZoomLivenessResourceResponse($input);
 
+        $this->assertEquals(self::SOME_LIVENESS_TYPE, $result->getLivenessType());
         $this->assertNotNull($result->getFaceMap());
         $this->assertCount(2, $result->getFrames());
     }
@@ -42,6 +46,7 @@ class ZoomLivenessResourceResponseTest extends TestCase
     {
         $result = new ZoomLivenessResourceResponse([]);
 
+        $this->assertNull($result->getLivenessType());
         $this->assertNull($result->getFaceMap());
         $this->assertCount(0, $result->getFrames());
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -54,12 +54,10 @@ class TestCase extends PHPUnitTestCase
      *
      * @param string $function
      * @param callable $callback
-     *
-     * @return callable|null
      */
-    protected static function mockFunction($function, $callback)
+    protected static function mockFunction($function, $callback): void
     {
-        return self::$mockFunctions[$function] = $callback;
+        self::$mockFunctions[$function] = $callback;
     }
 
     /**


### PR DESCRIPTION
### Added
- `CheckResponse::getType()`
- `TaskResponse::getType()`
- `LivenessResourceResponse::getLivenessType()`
- `GeneratedCheckResponse::getType()`
