### PR TITLE
SDK-1501: Environment Variables

### DIFF
--- a/src/DocScan/DocScanClient.php
+++ b/src/DocScan/DocScanClient.php
@@ -12,6 +12,7 @@ use Yoti\DocScan\Support\SupportedDocumentsResponse;
 use Yoti\Exception\PemFileException;
 use Yoti\Media\Media;
 use Yoti\Util\Config;
+use Yoti\Util\Env;
 use Yoti\Util\PemFile;
 use Yoti\Util\Validation;
 
@@ -53,8 +54,8 @@ class DocScanClient
         $pemFile = PemFile::resolveFromString($pem);
 
         // Set API URL from environment variable.
-        if (getenv(Constants::ENV_DOC_SCAN_API_URL) !== false && !isset($options[Config::API_URL])) {
-            $options[Config::API_URL] = getenv(Constants::ENV_DOC_SCAN_API_URL);
+        if (($envUrl = Env::get(Constants::ENV_DOC_SCAN_API_URL)) !== null && !isset($options[Config::API_URL])) {
+            $options[Config::API_URL] = $envUrl;
         }
 
         $config = new Config($options);

--- a/src/DocScan/DocScanClient.php
+++ b/src/DocScan/DocScanClient.php
@@ -54,9 +54,7 @@ class DocScanClient
         $pemFile = PemFile::resolveFromString($pem);
 
         // Set API URL from environment variable.
-        if (($envUrl = Env::get(Constants::ENV_DOC_SCAN_API_URL)) !== null && !isset($options[Config::API_URL])) {
-            $options[Config::API_URL] = $envUrl;
-        }
+        $options[Config::API_URL] = $options[Config::API_URL] ?? Env::get(Constants::ENV_DOC_SCAN_API_URL);
 
         $config = new Config($options);
 

--- a/src/Util/Env.php
+++ b/src/Util/Env.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Util;
+
+class Env
+{
+    /**
+     * Get environment variable.
+     *
+     * @param string $name
+     * @return string|null
+     */
+    public static function get(string $name): ?string
+    {
+        if (isset($_SERVER[$name])) {
+            return (string) $_SERVER[$name];
+        }
+
+        return null;
+    }
+}

--- a/src/YotiClient.php
+++ b/src/YotiClient.php
@@ -61,9 +61,7 @@ class YotiClient
         $pemFile = PemFile::resolveFromString($pem);
 
         // Set API URL from environment variable.
-        if (($envUrl = Env::get(Constants::ENV_API_URL)) !== null && !isset($options[Config::API_URL])) {
-            $options[Config::API_URL] = $envUrl;
-        }
+        $options[Config::API_URL] = $options[Config::API_URL] ?? Env::get(Constants::ENV_API_URL);
 
         $config = new Config($options);
 

--- a/src/YotiClient.php
+++ b/src/YotiClient.php
@@ -13,6 +13,7 @@ use Yoti\ShareUrl\DynamicScenario;
 use Yoti\ShareUrl\Result as ShareUrlResult;
 use Yoti\ShareUrl\Service as ShareUrlService;
 use Yoti\Util\Config;
+use Yoti\Util\Env;
 use Yoti\Util\PemFile;
 use Yoti\Util\Validation;
 
@@ -60,8 +61,8 @@ class YotiClient
         $pemFile = PemFile::resolveFromString($pem);
 
         // Set API URL from environment variable.
-        if (getenv(Constants::ENV_API_URL) !== false && !isset($options[Config::API_URL])) {
-            $options[Config::API_URL] = getenv(Constants::ENV_API_URL);
+        if (($envUrl = Env::get(Constants::ENV_API_URL)) !== null && !isset($options[Config::API_URL])) {
+            $options[Config::API_URL] = $envUrl;
         }
 
         $config = new Config($options);

--- a/tests/DocScan/DocScanClientTest.php
+++ b/tests/DocScan/DocScanClientTest.php
@@ -69,10 +69,11 @@ class DocScanClientTest extends TestCase
     /**
      * @test
      * @covers ::__construct
+     * @backupGlobals enabled
      */
     public function testApiUrlOptionOverridesEnvironmentVariable()
     {
-        putenv('YOTI_DOC_SCAN_API_URL=https://example.com/env/api');
+        $_SERVER['YOTI_DOC_SCAN_API_URL'] = 'https://example.com/env/api';
 
         $response = $this->createMock(ResponseInterface::class);
         $response->method('getBody')->willReturn(file_get_contents(TestData::DOC_SCAN_SESSION_CREATION_RESPONSE));
@@ -104,10 +105,11 @@ class DocScanClientTest extends TestCase
     /**
      * @test
      * @covers ::__construct
+     * @backupGlobals enabled
      */
     public function testApiUrlEnvironmentVariable()
     {
-        putenv('YOTI_DOC_SCAN_API_URL=https://example.com/env/api');
+        $_SERVER['YOTI_DOC_SCAN_API_URL'] = 'https://example.com/env/api';
 
         $response = $this->createMock(ResponseInterface::class);
         $response->method('getBody')->willReturn(file_get_contents(TestData::DOC_SCAN_SESSION_CREATION_RESPONSE));

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yoti\Test;
 
 use PHPUnit\Framework\TestCase as PHPUnitTestCase;
-use Yoti\Constants;
 
 class TestCase extends PHPUnitTestCase
 {
@@ -38,10 +37,6 @@ class TestCase extends PHPUnitTestCase
         // Restores ini settings.
         ini_restore('error_log');
         ini_restore('display_errors');
-
-        // Remove environment variables.
-        putenv(Constants::ENV_API_URL);
-        putenv(Constants::ENV_DOC_SCAN_API_URL);
 
         self::$mockFunctions = [];
     }

--- a/tests/Util/EnvTest.php
+++ b/tests/Util/EnvTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Test\Util;
+
+use Yoti\Test\TestCase;
+use Yoti\Util\Env;
+
+/**
+ * @coversDefaultClass \Yoti\Util\Env
+ */
+class EnvTest extends TestCase
+{
+    private const SOME_KEY = 'some-key';
+    private const SOME_STRING = 'some-string';
+
+    /**
+     * @covers ::get
+     * @backupGlobals enabled
+     */
+    public function testGet()
+    {
+        $_SERVER[self::SOME_KEY] = self::SOME_STRING;
+
+        $this->assertEquals(
+            self::SOME_STRING,
+            Env::get(self::SOME_KEY)
+        );
+    }
+
+    /**
+     * @covers ::get
+     * @backupGlobals enabled
+     */
+    public function testGetUnavailable()
+    {
+        $this->assertNull(Env::get(self::SOME_KEY));
+    }
+}

--- a/tests/YotiClientTest.php
+++ b/tests/YotiClientTest.php
@@ -69,10 +69,11 @@ class YotiClientTest extends TestCase
     /**
      * @test
      * @covers ::__construct
+     * @backupGlobals enabled
      */
     public function testApiUrlOptionOverridesEnvironmentVariable()
     {
-        putenv('YOTI_API_URL=https://example.com/env/api');
+        $_SERVER['YOTI_API_URL'] = 'https://example.com/env/api';
 
         $response = $this->createMock(ResponseInterface::class);
         $response->method('getBody')->willReturn(stream_for(file_get_contents(TestData::AML_CHECK_RESULT_JSON)));
@@ -101,10 +102,11 @@ class YotiClientTest extends TestCase
     /**
      * @test
      * @covers ::__construct
+     * @backupGlobals enabled
      */
     public function testApiUrlEnvironmentVariable()
     {
-        putenv('YOTI_API_URL=https://example.com/env/api');
+        $_SERVER['YOTI_API_URL'] = 'https://example.com/env/api';
 
         $response = $this->createMock(ResponseInterface::class);
         $response->method('getBody')->willReturn(stream_for(file_get_contents(TestData::AML_CHECK_RESULT_JSON)));


### PR DESCRIPTION
> Revised #158 

### Changed
- Read environment variables from `$_SERVER` instead of `getenv`