### PR TITLE
SDK-1429: AML JSON serialization

### DIFF
--- a/src/Aml/Address.php
+++ b/src/Aml/Address.php
@@ -52,13 +52,13 @@ class Address implements \JsonSerializable
     /**
      * Get address data.
      *
-     * @return array<string, string|null>
+     * @return array<string, string|Country|null>
      */
     public function jsonSerialize(): array
     {
         return [
-            self::POSTCODE_ATTR => $this->postcode,
-            self::COUNTRY_ATTR => $this->country->getCode(),
+            self::POSTCODE_ATTR => $this->getPostcode(),
+            self::COUNTRY_ATTR => $this->getCountry(),
         ];
     }
 

--- a/src/Aml/Country.php
+++ b/src/Aml/Country.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Yoti\Aml;
 
-class Country
+class Country implements \JsonSerializable
 {
     /**
      * Country code.
@@ -27,5 +27,13 @@ class Country
     public function getCode(): string
     {
         return $this->code;
+    }
+
+    /**
+     * @return string
+     */
+    public function jsonSerialize(): string
+    {
+        return $this->getCode();
     }
 }

--- a/src/Aml/Profile.php
+++ b/src/Aml/Profile.php
@@ -97,10 +97,10 @@ class Profile implements \JsonSerializable
     public function jsonSerialize(): array
     {
         return [
-            self::GIVEN_NAMES_ATTR  => $this->givenNames,
-            self::FAMILY_NAME_ATTR  => $this->familyName,
-            self::SSN_ATTR => $this->ssn,
-            self::ADDRESS_ATTR => $this->amlAddress,
+            self::GIVEN_NAMES_ATTR  => $this->getGivenNames(),
+            self::FAMILY_NAME_ATTR  => $this->getFamilyName(),
+            self::SSN_ATTR => $this->getSsn(),
+            self::ADDRESS_ATTR => $this->getAmlAddress(),
         ];
     }
 

--- a/tests/Aml/AddressTest.php
+++ b/tests/Aml/AddressTest.php
@@ -17,15 +17,27 @@ class AddressTest extends TestCase
     private const SOME_COUNTRY_CODE = 'GBR';
 
     /**
+     * @var Country
+     */
+    private $countryMock;
+
+    public function setup(): void
+    {
+        $this->countryMock = $this->createMock(Country::class);
+        $this->countryMock
+            ->method('jsonSerialize')
+            ->willReturn(self::SOME_COUNTRY_CODE);
+    }
+
+    /**
      * @covers ::__construct
      * @covers ::getCountry
      */
     public function testGetCountry()
     {
-        $someCountry = $this->createMock(Country::class);
-        $amlAddress = new Address($someCountry);
+        $amlAddress = new Address($this->countryMock);
 
-        $this->assertEquals($someCountry, $amlAddress->getCountry());
+        $this->assertEquals($this->countryMock, $amlAddress->getCountry());
     }
 
     /**
@@ -35,7 +47,7 @@ class AddressTest extends TestCase
     public function testGetPostcode()
     {
         $amlAddress = new Address(
-            $this->createMock(Country::class),
+            $this->countryMock,
             self::SOME_POSTCODE
         );
 
@@ -48,7 +60,7 @@ class AddressTest extends TestCase
      */
     public function testGetPostcodeNull()
     {
-        $amlAddress = new Address($this->createMock(Country::class));
+        $amlAddress = new Address($this->countryMock);
 
         $this->assertNull($amlAddress->getPostcode());
     }
@@ -59,20 +71,23 @@ class AddressTest extends TestCase
      */
     public function testJsonSerialize()
     {
-        $someCountry = $this->createMock(Country::class);
-        $someCountry
-            ->method('getCode')
-            ->willreturn(self::SOME_COUNTRY_CODE);
-
-        $amlAddress = new Address($someCountry, self::SOME_POSTCODE);
+        $amlAddress = new Address($this->countryMock, self::SOME_POSTCODE);
 
         $expectedData = [
             'post_code' => self::SOME_POSTCODE,
-            'country' => self::SOME_COUNTRY_CODE,
+            'country' => $this->countryMock,
         ];
 
         $this->assertEquals($expectedData, $amlAddress->jsonSerialize());
-        $this->assertEquals(json_encode($expectedData), json_encode($amlAddress));
-        $this->assertEquals(json_encode($expectedData), (string) $amlAddress);
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode($expectedData),
+            json_encode($amlAddress)
+        );
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode($expectedData),
+            (string) $amlAddress
+        );
     }
 }

--- a/tests/Aml/CountryTest.php
+++ b/tests/Aml/CountryTest.php
@@ -15,13 +15,35 @@ class CountryTest extends TestCase
     private const SOME_COUNTRY_CODE = 'GBR';
 
     /**
+     * @var Country
+     */
+    private $country;
+
+    public function setup(): void
+    {
+        $this->country = new Country(self::SOME_COUNTRY_CODE);
+    }
+
+    /**
      * @covers ::__construct
      * @covers ::getCode
      */
     public function testGetCode()
     {
-        $country = new Country(self::SOME_COUNTRY_CODE);
+        $this->assertEquals(
+            self::SOME_COUNTRY_CODE,
+            $this->country->getCode()
+        );
+    }
 
-        $this->assertEquals(self::SOME_COUNTRY_CODE, $country->getCode());
+    /**
+     * @covers ::jsonSerialize
+     */
+    public function testJsonSerialize()
+    {
+        $this->assertJsonStringEqualsJsonString(
+            json_encode(self::SOME_COUNTRY_CODE),
+            json_encode($this->country)
+        );
     }
 }


### PR DESCRIPTION
### Changed
- Use AML getters for JSON serialisation
- `Country` now implements `\JsonSerializable` and serializes to country code string