### PR TITLE
SDK-1346: PHPStan Baseline

### DIFF
--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,7 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Instanceof between Yoti\\\\Protobuf\\\\Sharepubapi\\\\IssuingAttributes and Yoti\\\\Protobuf\\\\Sharepubapi\\\\IssuingAttributes will always evaluate to true\\.$#"
+			count: 1
+			path: src/Profile/Util/ExtraData/ThirdPartyAttributeConverter.php
+

--- a/phpstan-ignore.neon
+++ b/phpstan-ignore.neon
@@ -1,6 +1,0 @@
-parameters:
-	ignoreErrors:
-		-
-			message: '#Instanceof between Yoti\\Protobuf\\Sharepubapi\\IssuingAttributes and Yoti\\Protobuf\\Sharepubapi\\IssuingAttributes will always evaluate to true#'
-			count: 1
-			path: src/Profile/Util/ExtraData/ThirdPartyAttributeConverter.php

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -6,4 +6,4 @@ parameters:
         - src/Protobuf/*
 
 includes:
-    - phpstan-ignore.neon
+    - phpstan-baseline.neon


### PR DESCRIPTION
### Fixed
- Generate PHPStan baseline with default filename using `phpstan analyse --generate-baseline` - see https://phpstan.org/user-guide/baseline (replaces custom filename)
  > Note: ignore is added as `ThirdPartyAttribute::getIssuingAttributes()` in the generated protobuf code can technically return `null`