### PR TITLE
SDK-1586: Use millisecond date format

### DIFF
--- a/src/ShareUrl/Extension/ThirdPartyAttributeContent.php
+++ b/src/ShareUrl/Extension/ThirdPartyAttributeContent.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Yoti\ShareUrl\Extension;
 
 use Yoti\Profile\ExtraData\AttributeDefinition;
-use Yoti\Util\DateTime;
 use Yoti\Util\Json;
 use Yoti\Util\Validation;
 
@@ -46,7 +45,7 @@ class ThirdPartyAttributeContent implements \JsonSerializable
         return [
             'expiry_date' => $this->expiryDate
                 ->setTimezone(new \DateTimeZone('UTC'))
-                ->format(DateTime::RFC3339),
+                ->format(\DateTime::RFC3339_EXTENDED),
             'definitions' => $this->definitions,
         ];
     }

--- a/tests/ShareUrl/Extension/ThirdPartyAttributeContentTest.php
+++ b/tests/ShareUrl/Extension/ThirdPartyAttributeContentTest.php
@@ -30,7 +30,7 @@ class ThirdPartyAttributeContentTest extends TestCase
         );
 
         $expectedJson = json_encode([
-            'expiry_date' => '2019-12-02T12:00:00.123000+00:00',
+            'expiry_date' => '2019-12-02T12:00:00.123+00:00',
             'definitions' => [
                 [
                     'name' => $someDefinition,


### PR DESCRIPTION
### Fixed
- Use [`\DateTime::RFC3339_EXTENDED`](https://www.php.net/manual/en/class.datetimeinterface.php#datetime.constants.rfc3339_extended) for 3rd party attribute expiry date