### PR TITLE
SDK-1597: Treat empty env variable strings as null

### DIFF
--- a/src/Util/Env.php
+++ b/src/Util/Env.php
@@ -15,7 +15,13 @@ class Env
     public static function get(string $name): ?string
     {
         if (isset($_SERVER[$name])) {
-            return (string) $_SERVER[$name];
+            $value = $_SERVER[$name];
+
+            if (is_string($value) && strlen($value) === 0) {
+                return null;
+            }
+
+            return (string) $value;
         }
 
         return null;

--- a/tests/Util/EnvTest.php
+++ b/tests/Util/EnvTest.php
@@ -18,15 +18,36 @@ class EnvTest extends TestCase
     /**
      * @covers ::get
      * @backupGlobals enabled
+     *
+     * @dataProvider envValueDataProvider
      */
-    public function testGet()
+    public function testGet($setValue, $getValue)
     {
-        $_SERVER[self::SOME_KEY] = self::SOME_STRING;
+        $_SERVER[self::SOME_KEY] = $setValue;
 
-        $this->assertEquals(
-            self::SOME_STRING,
+        $this->assertSame(
+            $getValue,
             Env::get(self::SOME_KEY)
         );
+    }
+
+    /**
+     * Provides environment variable values and their expected return values.
+     */
+    public function envValueDataProvider()
+    {
+        return [
+            [ self::SOME_STRING, self::SOME_STRING ],
+            [ '', null ],
+            [ '0', '0' ],
+            [ '1', '1' ],
+            [ 0, '0' ],
+            [ 1, '1' ],
+            [ 'true', 'true' ],
+            [ 'false', 'false' ],
+            [ true, '1' ],
+            [ false, '' ],
+        ];
     }
 
     /**


### PR DESCRIPTION
### Fixed
- `Yoti\Util\Env::get()` now returns `null` when an environment variable is an empty string

> Note: This is to align with behaviour in other SDKs