### PR TITLE
SDK-1581: Doc Scan exception message

### DIFF
--- a/src/Aml/Service.php
+++ b/src/Aml/Service.php
@@ -84,33 +84,39 @@ class Service
             return;
         }
 
-        $responseArr = Json::decode((string) $response->getBody());
-
-        $errorMessage = $this->getErrorMessage($responseArr);
-        $errorCode = isset($responseArr['code']) ? $responseArr['code'] : 'Error';
-
-        // Throw the error message that's included in the response
-        if (strlen($errorMessage) > 0) {
-            throw new AmlException("$errorCode - {$errorMessage}");
-        }
-
-        // Throw a general error message
-        throw new AmlException("{$errorCode} - Server responded with {$httpCode}");
+        throw new AmlException($this->getErrorMessage($response));
     }
 
     /**
-     * Get error message from the response array.
+     * Get error message from the response.
      *
-     * @param array<string, array> $result
+     * @param \Psr\Http\Message\ResponseInterface $response
      *
      * @return string
      */
-    private function getErrorMessage(array $result): string
+    private function getErrorMessage(ResponseInterface $response): string
     {
-        $errorMessage = '';
-        if (isset($result['errors'][0]['property']) && isset($result['errors'][0]['message'])) {
-            $errorMessage = $result['errors'][0]['property'] . ': ' . $result['errors'][0]['message'];
+        $httpCode = $response->getStatusCode();
+        $statusCodeMessage = "Server responded with {$httpCode}";
+
+        if (
+            $response->hasHeader('Content-Type') &&
+            $response->getHeader('Content-Type')[0] !== 'application/json'
+        ) {
+            return $statusCodeMessage;
         }
-        return $errorMessage;
+
+        $jsonData = Json::decode((string) $response->getBody());
+
+        $errorCode = isset($jsonData['code']) ? $jsonData['code'] : 'Error';
+
+        // Throw the error message that's included in the response.
+        if (isset($jsonData['errors'][0]['property']) && isset($jsonData['errors'][0]['message'])) {
+            $errorMessage = $jsonData['errors'][0]['property'] . ': ' . $jsonData['errors'][0]['message'];
+            return "{$errorCode} - {$errorMessage}";
+        }
+
+        // Throw a general error message.
+        return "{$errorCode} - {$statusCodeMessage}";
     }
 }

--- a/src/DocScan/Exception/DocScanException.php
+++ b/src/DocScan/Exception/DocScanException.php
@@ -95,14 +95,15 @@ class DocScanException extends \Exception
             return [];
         }
 
-        return array_filter(array_map(
-            function ($error): ?string {
+        return array_reduce(
+            $jsonData->errors,
+            function ($carry, $error): array {
                 if (isset($error->property) && isset($error->message)) {
-                    return sprintf('%s "%s"', $error->property, $error->message);
+                    $carry[] = sprintf('%s "%s"', $error->property, $error->message);
                 }
-                return null;
+                return $carry;
             },
-            $jsonData->errors
-        ));
+            []
+        );
     }
 }

--- a/src/DocScan/Exception/DocScanException.php
+++ b/src/DocScan/Exception/DocScanException.php
@@ -7,10 +7,10 @@ namespace Yoti\DocScan\Exception;
 use Exception;
 use Psr\Http\Message\ResponseInterface;
 use Throwable;
+use Yoti\Util\Json;
 
 class DocScanException extends Exception
 {
-
     /**
      * @var ResponseInterface|null
      */
@@ -22,9 +22,10 @@ class DocScanException extends Exception
      * @param ResponseInterface|null $response
      * @param Throwable|null $previous
      */
-    public function __construct($message = "", ResponseInterface $response = null, Throwable $previous = null)
+    public function __construct($message = "", ?ResponseInterface $response = null, Throwable $previous = null)
     {
-        parent::__construct($message, 0, $previous);
+        parent::__construct($this->formatMessage($message, $response), 0, $previous);
+
         $this->response = $response;
     }
 
@@ -37,5 +38,60 @@ class DocScanException extends Exception
     public function getResponse(): ?ResponseInterface
     {
         return $this->response;
+    }
+
+    /**
+     * @param string $message
+     * @param ResponseInterface|null $response
+     *
+     * @return string
+     */
+    private function formatMessage(string $message, ?ResponseInterface $response): string
+    {
+        if (
+            $response === null ||
+            !$response->hasHeader('Content-Type') ||
+            $response->getHeader('Content-Type')[0] !== 'application/json'
+        ) {
+            return $message;
+        }
+
+        $jsonData = Json::decode((string) $response->getBody(), false);
+        $formattedResponse = $this->formatResponse($jsonData);
+        if ($formattedResponse !== null) {
+            return sprintf('%s - %s', $message, $formattedResponse);
+        }
+
+        return $message;
+    }
+
+    /**
+     * @param \stdClass $jsonData
+     *
+     * @return string|null
+     */
+    private function formatResponse(\stdClass $jsonData): ?string
+    {
+        if (!isset($jsonData->message) || !isset($jsonData->code)) {
+            return null;
+        }
+
+        $responseMessage = sprintf('%s - %s', $jsonData->code, $jsonData->message);
+
+        if (!isset($jsonData->errors) || !is_array($jsonData->errors)) {
+            return $responseMessage;
+        }
+
+        $propertyErrors = array_filter(array_map(
+            function ($error): ?string {
+                if (isset($error->property) && isset($error->message)) {
+                    return sprintf('%s "%s"', $error->property, $error->message);
+                }
+                return null;
+            },
+            $jsonData->errors
+        ));
+
+        return sprintf('%s: %s', $responseMessage, implode(', ', $propertyErrors));
     }
 }

--- a/src/DocScan/Exception/DocScanException.php
+++ b/src/DocScan/Exception/DocScanException.php
@@ -76,11 +76,26 @@ class DocScanException extends \Exception
 
         $responseMessage = sprintf('%s - %s', $jsonData->code, $jsonData->message);
 
-        if (!isset($jsonData->errors) || !is_array($jsonData->errors)) {
-            return $responseMessage;
+        $propertyErrors = $this->formatPropertyErrors($jsonData);
+        if (count($propertyErrors) > 0) {
+            return sprintf('%s: %s', $responseMessage, implode(', ', $propertyErrors));
         }
 
-        $propertyErrors = array_filter(array_map(
+        return $responseMessage;
+    }
+
+    /**
+     * @param \stdClass $jsonData
+     *
+     * @return string[]
+     */
+    private function formatPropertyErrors(\stdClass $jsonData): array
+    {
+        if (!isset($jsonData->errors) || !is_array($jsonData->errors)) {
+            return [];
+        }
+
+        return array_filter(array_map(
             function ($error): ?string {
                 if (isset($error->property) && isset($error->message)) {
                     return sprintf('%s "%s"', $error->property, $error->message);
@@ -89,7 +104,5 @@ class DocScanException extends \Exception
             },
             $jsonData->errors
         ));
-
-        return sprintf('%s: %s', $responseMessage, implode(', ', $propertyErrors));
     }
 }

--- a/src/DocScan/Exception/DocScanException.php
+++ b/src/DocScan/Exception/DocScanException.php
@@ -4,12 +4,10 @@ declare(strict_types=1);
 
 namespace Yoti\DocScan\Exception;
 
-use Exception;
 use Psr\Http\Message\ResponseInterface;
-use Throwable;
 use Yoti\Util\Json;
 
-class DocScanException extends Exception
+class DocScanException extends \Exception
 {
     /**
      * @var ResponseInterface|null
@@ -20,9 +18,9 @@ class DocScanException extends Exception
      * DocScanException constructor.
      * @param string $message
      * @param ResponseInterface|null $response
-     * @param Throwable|null $previous
+     * @param \Throwable|null $previous
      */
-    public function __construct($message = "", ?ResponseInterface $response = null, Throwable $previous = null)
+    public function __construct($message = "", ?ResponseInterface $response = null, \Throwable $previous = null)
     {
         parent::__construct($this->formatMessage($message, $response), 0, $previous);
 

--- a/tests/Aml/ServiceTest.php
+++ b/tests/Aml/ServiceTest.php
@@ -117,15 +117,91 @@ class ServiceTest extends TestCase
     }
 
     /**
+     * @covers ::performCheck
+     * @covers ::validateAmlResult
+     * @covers ::getErrorMessage
+     *
+     * @dataProvider httpErrorStatusCodeProvider
+     */
+    public function testPerformAmlCheckFailureWithCode($statusCode)
+    {
+        $this->expectException(\Yoti\Exception\AmlException::class);
+        $this->expectExceptionMessage("SOME_CODE - Server responded with {$statusCode}");
+
+        $amlService = $this->createServiceWithErrorResponse(
+            $statusCode,
+            json_encode([
+                'code' => 'SOME_CODE',
+            ])
+        );
+
+        $amlService->performCheck($this->createMock(Profile::class));
+    }
+
+    /**
+     * @covers ::performCheck
+     * @covers ::validateAmlResult
+     * @covers ::getErrorMessage
+     *
+     * @dataProvider httpErrorStatusCodeProvider
+     */
+    public function testPerformAmlCheckFailureWithCodeAndErrors($statusCode)
+    {
+        $this->expectException(\Yoti\Exception\AmlException::class);
+        $this->expectExceptionMessage("SOME_CODE - some property: some message");
+
+        $amlService = $this->createServiceWithErrorResponse(
+            $statusCode,
+            json_encode([
+                'code' => 'SOME_CODE',
+                'errors' => [
+                    [
+                        'message' => 'some message',
+                        'property' => 'some property',
+                    ]
+                ]
+            ])
+        );
+
+        $amlService->performCheck($this->createMock(Profile::class));
+    }
+
+    /**
+     * @covers ::performCheck
+     * @covers ::validateAmlResult
+     * @covers ::getErrorMessage
+     *
+     * @dataProvider httpErrorStatusCodeProvider
+     */
+    public function testPerformAmlCheckFailureWithoutJsonResponse($statusCode)
+    {
+        $this->expectException(\Yoti\Exception\AmlException::class);
+        $this->expectExceptionMessage("Server responded with {$statusCode}");
+
+        $amlService = $this->createServiceWithErrorResponse(
+            $statusCode,
+            'some response',
+            'text/html'
+        );
+
+        $amlService->performCheck($this->createMock(Profile::class));
+    }
+
+    /**
      * @param int $statusCode
      *
      * @return \Yoti\Aml\Service
      */
-    private function createServiceWithErrorResponse($statusCode, $body = '{}')
+    private function createServiceWithErrorResponse($statusCode, $body = '{}', ?string $contentType = null)
     {
         $response = $this->createMock(ResponseInterface::class);
         $response->method('getBody')->willReturn(stream_for($body));
         $response->method('getStatusCode')->willReturn($statusCode);
+
+        if ($contentType !== null) {
+            $response->method('hasHeader')->willReturn(true);
+            $response->method('getHeader')->willReturn([$contentType]);
+        }
 
         $httpClient = $this->createMock(ClientInterface::class);
         $httpClient

--- a/tests/DocScan/Exception/DocScanExceptionTest.php
+++ b/tests/DocScan/Exception/DocScanExceptionTest.php
@@ -98,7 +98,7 @@ class DocScanExceptionTest extends TestCase
                 ),
             ],
             /**
-             * Message, code and errors with unknown items
+             * Message, code and errors with some unknown items
              */
             [
                 self::SOME_MESSAGE,
@@ -117,7 +117,7 @@ class DocScanExceptionTest extends TestCase
                         [
                             'property' => self::SOME_OTHER_PROPERTY,
                             'message' => self::SOME_OTHER_PROPERTY_MESSAGE,
-                        ]
+                        ],
                     ],
                 ],
                 sprintf(
@@ -127,6 +127,32 @@ class DocScanExceptionTest extends TestCase
                     self::SOME_RESPONSE_MESSAGE,
                     self::SOME_OTHER_PROPERTY,
                     self::SOME_OTHER_PROPERTY_MESSAGE
+                ),
+            ],
+            /**
+             * Message, code and errors with unknown items
+             */
+            [
+                self::SOME_MESSAGE,
+                [
+                    'message' => self::SOME_RESPONSE_MESSAGE,
+                    'code' => self::SOME_RESPONSE_CODE,
+                    'errors' => [
+                        [
+                            'some_unknown_item' => 'some unknown item',
+                            'message' => self::SOME_PROPERTY_MESSAGE,
+                        ],
+                        [
+                            'property' => self::SOME_PROPERTY,
+                            'some_unknown_item' => 'some unknown item',
+                        ],
+                    ],
+                ],
+                sprintf(
+                    '%s - %s - %s',
+                    self::SOME_MESSAGE,
+                    self::SOME_RESPONSE_CODE,
+                    self::SOME_RESPONSE_MESSAGE
                 ),
             ],
             /**
@@ -145,7 +171,7 @@ class DocScanExceptionTest extends TestCase
                         [
                             'property' => self::SOME_OTHER_PROPERTY,
                             'message' => self::SOME_OTHER_PROPERTY_MESSAGE,
-                        ]
+                        ],
                     ],
                 ],
                 sprintf(

--- a/tests/DocScan/Exception/DocScanExceptionTest.php
+++ b/tests/DocScan/Exception/DocScanExceptionTest.php
@@ -6,10 +6,27 @@ use Psr\Http\Message\ResponseInterface;
 use Yoti\DocScan\Exception\DocScanException;
 use Yoti\Test\TestCase;
 
+use function GuzzleHttp\Psr7\stream_for;
+
 class DocScanExceptionTest extends TestCase
 {
 
-    private const SOME_ERROR_MESSAGE = 'Some Error Message';
+    private const SOME_MESSAGE = 'Some message';
+    private const SOME_RESPONSE_CODE = 'SOME_ERROR_CODE';
+    private const SOME_RESPONSE_MESSAGE = 'Some response message';
+    private const SOME_PROPERTY = 'some.property';
+    private const SOME_PROPERTY_MESSAGE = 'Some property message';
+    private const SOME_OTHER_PROPERTY = 'some.other.property';
+    private const SOME_OTHER_PROPERTY_MESSAGE = 'Some other property message';
+
+    /**
+     * @test
+     */
+    public function responseShouldBeOptional()
+    {
+        $docScanException = new DocScanException(self::SOME_MESSAGE);
+        $this->assertEquals(self::SOME_MESSAGE, $docScanException->getMessage());
+    }
 
     /**
      * @test
@@ -18,8 +35,150 @@ class DocScanExceptionTest extends TestCase
     {
         $responseMock = $this->createMock(ResponseInterface::class);
 
-        $docScanException = new DocScanException(self::SOME_ERROR_MESSAGE, $responseMock);
-        $this->assertEquals(self::SOME_ERROR_MESSAGE, $docScanException->getMessage());
+        $docScanException = new DocScanException(self::SOME_MESSAGE, $responseMock);
+        $this->assertEquals(self::SOME_MESSAGE, $docScanException->getMessage());
+        $this->assertSame($responseMock, $docScanException->getResponse());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldExcludeNonJsonResponsesFromMessage()
+    {
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->method('hasHeader')->willReturn(true);
+        $responseMock->method('getHeader')->willReturn(['text/html']);
+
+        $docScanException = new DocScanException(self::SOME_MESSAGE, $responseMock);
+
+        $this->assertEquals(self::SOME_MESSAGE, $docScanException->getMessage());
         $this->assertEquals($responseMock, $docScanException->getResponse());
+    }
+
+    /**
+     * @test
+     *
+     * @dataProvider jsonResponseMessageDataProvider
+     */
+    public function shouldIncludeFormattedResponseInMessage($message, $jsonData, $expectedMessage)
+    {
+        $responseMock = $this->createMock(ResponseInterface::class);
+        $responseMock->method('hasHeader')->willReturn(true);
+        $responseMock->method('getHeader')->willReturn(['application/json']);
+        $responseMock->method('getBody')->willReturn(stream_for(json_encode($jsonData)));
+
+        $docScanException = new DocScanException($message, $responseMock);
+
+        $this->assertEquals($expectedMessage, $docScanException->getMessage());
+        $this->assertEquals($responseMock, $docScanException->getResponse());
+    }
+
+    /**
+     * Provides JSON response data and their expected exception message.
+     *
+     * @return array
+     */
+    public function jsonResponseMessageDataProvider(): array
+    {
+        return [
+            /**
+             * Message and code.
+             */
+            [
+                self::SOME_MESSAGE,
+                [
+                    'message' => self::SOME_RESPONSE_MESSAGE,
+                    'code' => self::SOME_RESPONSE_CODE
+                ],
+                sprintf(
+                    '%s - %s - %s',
+                    self::SOME_MESSAGE,
+                    self::SOME_RESPONSE_CODE,
+                    self::SOME_RESPONSE_MESSAGE
+                ),
+            ],
+            /**
+             * Message, code and errors with unknown items
+             */
+            [
+                self::SOME_MESSAGE,
+                [
+                    'message' => self::SOME_RESPONSE_MESSAGE,
+                    'code' => self::SOME_RESPONSE_CODE,
+                    'errors' => [
+                        [
+                            'some_unknown_item' => 'some unknown item',
+                            'message' => self::SOME_PROPERTY_MESSAGE,
+                        ],
+                        [
+                            'property' => self::SOME_PROPERTY,
+                            'some_unknown_item' => 'some unknown item',
+                        ],
+                        [
+                            'property' => self::SOME_OTHER_PROPERTY,
+                            'message' => self::SOME_OTHER_PROPERTY_MESSAGE,
+                        ]
+                    ],
+                ],
+                sprintf(
+                    '%s - %s - %s: %s "%s"',
+                    self::SOME_MESSAGE,
+                    self::SOME_RESPONSE_CODE,
+                    self::SOME_RESPONSE_MESSAGE,
+                    self::SOME_OTHER_PROPERTY,
+                    self::SOME_OTHER_PROPERTY_MESSAGE
+                ),
+            ],
+            /**
+             * Message, code and errors.
+             */
+            [
+                self::SOME_MESSAGE,
+                [
+                    'message' => self::SOME_RESPONSE_MESSAGE,
+                    'code' => self::SOME_RESPONSE_CODE,
+                    'errors' => [
+                        [
+                            'property' => self::SOME_PROPERTY,
+                            'message' => self::SOME_PROPERTY_MESSAGE,
+                        ],
+                        [
+                            'property' => self::SOME_OTHER_PROPERTY,
+                            'message' => self::SOME_OTHER_PROPERTY_MESSAGE,
+                        ]
+                    ],
+                ],
+                sprintf(
+                    '%s - %s - %s: %s "%s", %s "%s"',
+                    self::SOME_MESSAGE,
+                    self::SOME_RESPONSE_CODE,
+                    self::SOME_RESPONSE_MESSAGE,
+                    self::SOME_PROPERTY,
+                    self::SOME_PROPERTY_MESSAGE,
+                    self::SOME_OTHER_PROPERTY,
+                    self::SOME_OTHER_PROPERTY_MESSAGE
+                ),
+            ],
+            /**
+             * Message without code.
+             */
+            [
+                self::SOME_MESSAGE,
+                [
+                    'message' => self::SOME_RESPONSE_MESSAGE,
+                ],
+                self::SOME_MESSAGE,
+            ],
+            /**
+             * Code without message.
+             */
+            [
+                self::SOME_MESSAGE,
+                [
+                    'code' => self::SOME_RESPONSE_CODE,
+                ],
+                self::SOME_MESSAGE,
+            ],
+        ];
     }
 }


### PR DESCRIPTION
### Changed
- `DocScanException` now includes formatted response error when available

#### Example:
```
Server responded with 400 - PAYLOAD_VALIDATION - There were errors validating the payload: sdk_config.allowed_capture_methods "Value is not valid", sdk_config.font_colour "provided colour must be a valid Hex Code", sdk_config.locale "must not be blank"
```

### Fixed
- `AmlService::performCheck()` will now throw an `AmlException` for non-JSON error responses. Previously, a `JsonException` would be thrown if the SDK was misconfigured with an incorrect API URL that returned non-JSON content.
  > Note: `AmlException` messages remain unchanged