### PR TITLE
SDK-1627: Check for deprecations

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "brainmaestro/composer-git-hooks": "^2.8",
     "phpstan/phpstan-strict-rules": "^0.12.1",
     "phpstan/extension-installer": "^1.0",
-    "symfony/phpunit-bridge": "^5.0"
+    "symfony/phpunit-bridge": "^5.1"
   },
   "autoload-dev": {
     "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,8 @@
     "friendsofphp/php-cs-fixer": "^2.15",
     "brainmaestro/composer-git-hooks": "^2.8",
     "phpstan/phpstan-strict-rules": "^0.12.1",
-    "phpstan/extension-installer": "^1.0"
+    "phpstan/extension-installer": "^1.0",
+    "symfony/phpunit-bridge": "^5.0"
   },
   "autoload-dev": {
     "psr-4": {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -21,4 +21,7 @@
     <logging>
         <log type="coverage-text" target="php://stdout" showUncoveredFiles="true"/>
     </logging>
+    <listeners>
+        <listener class="Symfony\Bridge\PhpUnit\SymfonyTestsListener"/>
+    </listeners>
 </phpunit>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,9 @@
          convertWarningsToExceptions="false"
          bootstrap="tests/bootstrap.php"
          stopOnFailure="false">
+    <php>
+        <env name="SYMFONY_DEPRECATIONS_HELPER" value="max[total]=1"/>
+    </php>
     <testsuites>
         <testsuite name="Yoti Test Suite">
             <directory>tests/</directory>


### PR DESCRIPTION
### Added
- Added `symfony/phpunit-bridge` dev dependency to test deprecation errors.
  - Set maximum deprecations threshold to 1 to allow for known deprecation error - see https://github.com/protocolbuffers/protobuf/pull/7629 (marking the related tests as legacy could fix this, but would be misleading). We can remove this configuration if/when this is fixed.