### PR TITLE
SDK-1628: Protobuf C Extension

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,6 +29,15 @@ jobs:
       script:
         - travis_retry composer require guzzlehttp/guzzle "^6.5"
         - composer test
+    - <<: *compatibility
+      php: "7.4"
+      name: "PHP: 7.4 / Protobuf C Extension"
+      install:
+        - pecl install protobuf-3.12.2
+        - travis_retry composer self-update
+        - travis_retry composer install --no-interaction --prefer-source --dev
+      script:
+        - composer test
     - <<: *test
       stage: Analyze
       name: Sonarcloud

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Please feel free to reach out
 * PHP ^7.1
 * CURL PHP extension (must support TLSv1.2)
 
+### Recommended (optional)
+- [Protobuf C extension](https://github.com/protocolbuffers/protobuf/tree/master/php) (PHP package will be used by default)
+
 ## Enabling the SDK
 
 To import the Yoti SDK inside your project, you can use your favourite dependency management system.

--- a/src/Profile/Util/Attribute/AttributeListConverter.php
+++ b/src/Profile/Util/Attribute/AttributeListConverter.php
@@ -21,7 +21,7 @@ class AttributeListConverter
 
         foreach ($attributeList->getAttributes() as $attr) { /** @var \Yoti\Protobuf\Attrpubapi\Attribute $attr */
             $attrName = $attr->getName();
-            if (null === $attrName) {
+            if (null === $attrName || strlen($attrName) === 0) {
                 continue;
             }
             $yotiAttribute = AttributeConverter::convertToYotiAttribute($attr);

--- a/tests/Profile/Util/Attribute/AttributeConverterTest.php
+++ b/tests/Profile/Util/Attribute/AttributeConverterTest.php
@@ -32,28 +32,19 @@ class AttributeConverterTest extends TestCase
     private const CONTENT_TYPE_INT = 7;
 
     /**
-     * Mocks \Yoti\Protobuf\Attrpubapi\Attribute with provided name and value.
+     * Creates \Yoti\Protobuf\Attrpubapi\Attribute with provided name and value.
      */
-    private function getMockForProtobufAttribute($name, $value, $contentType = self::CONTENT_TYPE_STRING)
+    private function createProtobufAttribute($name, $value, $contentType = self::CONTENT_TYPE_STRING)
     {
-        // Setup protobuf mock.
-        $protobufAttribute = $this->getMockBuilder(\Yoti\Protobuf\Attrpubapi\Attribute::class)
-            ->disableOriginalConstructor()
-            ->getMock();
-        $protobufAttribute
-            ->method('getAnchors')
-            ->willReturn($this->getMockBuilder(\Traversable::class)->getMock());
-        $protobufAttribute
-            ->method('getName')
-            ->willReturn($name);
-        $protobufAttribute
-            ->method('getValue')
-            ->willReturn($value);
-        $protobufAttribute
-            ->method('getContentType')
-            ->willReturn($contentType);
-
-        return $protobufAttribute;
+        return new \Yoti\Protobuf\Attrpubapi\Attribute([
+            'name' => $name,
+            'value' => $value,
+            'content_type' => $contentType,
+            'anchors' => new \Google\Protobuf\Internal\RepeatedField(
+                \Google\Protobuf\Internal\GPBType::MESSAGE,
+                \Yoti\Protobuf\Attrpubapi\Anchor::class
+            ),
+        ]);
     }
 
     /**
@@ -74,7 +65,7 @@ class AttributeConverterTest extends TestCase
      */
     public function testConvertToYotiAttribute()
     {
-        $attr = AttributeConverter::convertToYotiAttribute($this->getMockForProtobufAttribute('test_attr', 'my_value'));
+        $attr = AttributeConverter::convertToYotiAttribute($this->createProtobufAttribute('test_attr', 'my_value'));
         $this->assertEquals('test_attr', $attr->getName());
         $this->assertEquals('my_value', $attr->getValue());
     }
@@ -86,7 +77,7 @@ class AttributeConverterTest extends TestCase
     public function testConvertDate()
     {
         $someTimeStamp = '2016-07-19T08:55:38Z';
-        $attr = AttributeConverter::convertToYotiAttribute($this->getMockForProtobufAttribute(
+        $attr = AttributeConverter::convertToYotiAttribute($this->createProtobufAttribute(
             'test_attr',
             $someTimeStamp,
             self::CONTENT_TYPE_DATE
@@ -102,7 +93,7 @@ class AttributeConverterTest extends TestCase
      */
     public function testEmptyApplicationLogo()
     {
-        $attr = AttributeConverter::convertToYotiAttribute($this->getMockForProtobufAttribute(
+        $attr = AttributeConverter::convertToYotiAttribute($this->createProtobufAttribute(
             'application_logo',
             '',
             self::CONTENT_TYPE_PNG
@@ -117,7 +108,7 @@ class AttributeConverterTest extends TestCase
     public function testConvertDateInvalid()
     {
         $this->captureExpectedLogs();
-        $attr = AttributeConverter::convertToYotiAttribute($this->getMockForProtobufAttribute(
+        $attr = AttributeConverter::convertToYotiAttribute($this->createProtobufAttribute(
             'test_attr',
             'some-invalid-date',
             self::CONTENT_TYPE_DATE
@@ -133,7 +124,7 @@ class AttributeConverterTest extends TestCase
     public function testConvertJson()
     {
         $someJsonData = ['some' => 'json'];
-        $attr = AttributeConverter::convertToYotiAttribute($this->getMockForProtobufAttribute(
+        $attr = AttributeConverter::convertToYotiAttribute($this->createProtobufAttribute(
             'test_attr',
             json_encode($someJsonData),
             self::CONTENT_TYPE_JSON
@@ -146,7 +137,7 @@ class AttributeConverterTest extends TestCase
      */
     public function testConvertDocumentDetails()
     {
-        $attr = AttributeConverter::convertToYotiAttribute($this->getMockForProtobufAttribute(
+        $attr = AttributeConverter::convertToYotiAttribute($this->createProtobufAttribute(
             'document_details',
             'PASSPORT GBR 01234567 2020-01-01',
             self::CONTENT_TYPE_STRING
@@ -167,7 +158,7 @@ class AttributeConverterTest extends TestCase
         $this->captureExpectedLogs();
 
         $attr = AttributeConverter::convertToYotiAttribute(
-            $this->getMockForProtobufAttribute('undefined_attr', 'undefined_value', self::CONTENT_TYPE_UNDEFINED)
+            $this->createProtobufAttribute('undefined_attr', 'undefined_value', self::CONTENT_TYPE_UNDEFINED)
         );
         $this->assertEquals('undefined_attr', $attr->getName());
         $this->assertEquals('undefined_value', $attr->getValue());
@@ -185,7 +176,7 @@ class AttributeConverterTest extends TestCase
         $this->captureExpectedLogs();
 
         $attr = AttributeConverter::convertToYotiAttribute(
-            $this->getMockForProtobufAttribute('unknown_attr', 'unknown_value', 100)
+            $this->createProtobufAttribute('unknown_attr', 'unknown_value', 100)
         );
         $this->assertEquals('unknown_attr', $attr->getName());
         $this->assertEquals('unknown_value', $attr->getValue());
@@ -198,7 +189,7 @@ class AttributeConverterTest extends TestCase
      */
     public function testConvertToYotiAttributeEmptyStringValue()
     {
-        $attr = AttributeConverter::convertToYotiAttribute($this->getMockForProtobufAttribute(
+        $attr = AttributeConverter::convertToYotiAttribute($this->createProtobufAttribute(
             'test_attr',
             '',
             self::CONTENT_TYPE_STRING
@@ -216,7 +207,7 @@ class AttributeConverterTest extends TestCase
     {
         $this->captureExpectedLogs();
 
-        $attr = AttributeConverter::convertToYotiAttribute($this->getMockForProtobufAttribute(
+        $attr = AttributeConverter::convertToYotiAttribute($this->createProtobufAttribute(
             'test_attr',
             '',
             $contentType
@@ -234,7 +225,7 @@ class AttributeConverterTest extends TestCase
      */
     public function testConvertToYotiAttributeIntegerValue($int)
     {
-        $attr = AttributeConverter::convertToYotiAttribute($this->getMockForProtobufAttribute(
+        $attr = AttributeConverter::convertToYotiAttribute($this->createProtobufAttribute(
             'test_attr',
             (string) $int,
             self::CONTENT_TYPE_INT
@@ -300,7 +291,7 @@ class AttributeConverterTest extends TestCase
         $protoMultiValue->setValues($this->createMultiValueValues());
 
         // Create mock Attribute that will return MultiValue as the value.
-        $protobufAttribute = $this->getMockForProtobufAttribute(
+        $protobufAttribute = $this->createProtobufAttribute(
             'document_images',
             $protoMultiValue->serializeToString(),
             self::CONTENT_TYPE_MULTI_VALUE
@@ -332,7 +323,7 @@ class AttributeConverterTest extends TestCase
         $this->captureExpectedLogs();
 
         // Create mock Attribute that will return MultiValue as the value.
-        $protobufAttribute = $this->getMockForProtobufAttribute(
+        $protobufAttribute = $this->createProtobufAttribute(
             'document_images',
             'invalid value',
             self::CONTENT_TYPE_STRING
@@ -362,7 +353,7 @@ class AttributeConverterTest extends TestCase
         $protoMultiValue->setValues($values);
 
         // Create mock Attribute that will return MultiValue as the value.
-        $protobufAttribute = $this->getMockForProtobufAttribute(
+        $protobufAttribute = $this->createProtobufAttribute(
             'test_attr',
             $protoMultiValue->serializeToString(),
             self::CONTENT_TYPE_MULTI_VALUE
@@ -425,7 +416,7 @@ class AttributeConverterTest extends TestCase
         $protoMultiValue->setValues($values);
 
         // Create mock Attribute that will return MultiValue as the value.
-        $protobufAttribute = $this->getMockForProtobufAttribute(
+        $protobufAttribute = $this->createProtobufAttribute(
             'test_attr',
             $protoMultiValue->serializeToString(),
             self::CONTENT_TYPE_MULTI_VALUE
@@ -454,7 +445,7 @@ class AttributeConverterTest extends TestCase
         $protoMultiValue->setValues($values);
 
         // Create mock Attribute that will return MultiValue as the value.
-        $protobufAttribute = $this->getMockForProtobufAttribute(
+        $protobufAttribute = $this->createProtobufAttribute(
             'test_attr',
             $protoMultiValue->serializeToString(),
             self::CONTENT_TYPE_MULTI_VALUE

--- a/tests/Profile/Util/Attribute/AttributeListConverterTest.php
+++ b/tests/Profile/Util/Attribute/AttributeListConverterTest.php
@@ -27,47 +27,29 @@ class AttributeListConverterTest extends TestCase
         $someName = 'some name';
         $someValue = 'some value';
 
-        $someAttribute = $this->createMock(AttributeProto::class);
-        $someAttribute
-            ->method('getName')
-            ->willReturn($someName);
-        $someAttribute
-            ->method('getValue')
-            ->willReturn($someValue);
-        $someAttribute
-            ->method('getContentType')
-            ->willReturn(self::CONTENT_TYPE_STRING);
-        $someAttribute
-            ->method('getAnchors')
-            ->willReturn($this->createMock(\Traversable::class));
+        $someAttribute = new AttributeProto([
+            'name' => $someName,
+            'value' => $someValue,
+            'content_type' => self::CONTENT_TYPE_STRING,
+            'anchors' => [],
+        ]);
 
-        $someNullNameAttribute = $this->createMock(AttributeProto::class);
-        $someNullNameAttribute
-            ->method('getName')
-            ->willReturn(null);
+        $someEmptyNameAttribute = new AttributeProto();
 
-        $someEmptyNonStringAttribute = $this->createMock(AttributeProto::class);
-        $someEmptyNonStringAttribute
-            ->method('getName')
-            ->willReturn('some-attribute');
-        $someEmptyNonStringAttribute
-            ->method('getValue')
-            ->willReturn('');
-        $someEmptyNonStringAttribute
-            ->method('getContentType')
-            ->willReturn(100);
-        $someEmptyNonStringAttribute
-            ->method('getAnchors')
-            ->willReturn($this->createMock(\Traversable::class));
+        $someEmptyNonStringAttribute = new AttributeProto([
+            'name' => 'some-attribute',
+            'value' => '',
+            'content_type' => 100,
+            'anchors' => [],
+        ]);
 
-        $someAttributeList = $this->createMock(AttributeList::class);
-        $someAttributeList
-            ->method('getAttributes')
-            ->willReturn([
+        $someAttributeList = new AttributeList([
+            'attributes' => [
                 $someAttribute,
-                $someNullNameAttribute,
+                $someEmptyNameAttribute,
                 $someEmptyNonStringAttribute,
-            ]);
+            ],
+        ]);
 
         $yotiAttributesList = AttributeListConverter::convertToYotiAttributesList($someAttributeList);
 

--- a/tests/Profile/Util/ExtraData/ExtraDataConverterTest.php
+++ b/tests/Profile/Util/ExtraData/ExtraDataConverterTest.php
@@ -91,7 +91,7 @@ class ExtraDataConverterTest extends TestCase
 
         $this->assertInstanceOf(ExtraData::class, $extraData);
         $this->assertNull($extraData->getAttributeIssuanceDetails());
-        $this->assertLogContains("Failed to parse extra data: Error occurred during parsing: Unexpected wire type");
+        $this->assertLogContains("Failed to parse extra data: Error occurred during parsing");
     }
 
     /**

--- a/tests/Profile/Util/ExtraData/ThirdPartyAttributeConverterTest.php
+++ b/tests/Profile/Util/ExtraData/ThirdPartyAttributeConverterTest.php
@@ -130,17 +130,29 @@ class ThirdPartyAttributeConverterTest extends TestCase
      */
     private function createThirdPartyAttribute($token, $expiryDate, $definitions)
     {
-        return (new ThirdPartyAttribute([
-            'issuance_token' => $token,
-            'issuing_attributes' => new IssuingAttributes([
-                'expiry_date' => $expiryDate,
-                'definitions' => array_map(
-                    function ($definition) {
-                        return new Definition($definition);
-                    },
-                    $definitions
-                )
-            ]),
-        ]))->serializeToString();
+        $thirdPartyAttribute = new ThirdPartyAttribute();
+
+        if (isset($token)) {
+            $thirdPartyAttribute->setIssuanceToken($token);
+        }
+
+        $issuingAttributes = new IssuingAttributes();
+
+        if (isset($expiryDate)) {
+            $issuingAttributes->setExpiryDate($expiryDate);
+        }
+
+        if (isset($definitions)) {
+            $issuingAttributes->setDefinitions(array_map(
+                function ($definition) {
+                    return new Definition($definition);
+                },
+                $definitions
+            ));
+        }
+
+        $thirdPartyAttribute->setIssuingAttributes($issuingAttributes);
+
+        return $thirdPartyAttribute->serializeToString();
     }
 }


### PR DESCRIPTION
- [x] Merge #115 and rebase this PR

### Added
- Travis job to test with [protobuf C extension](https://github.com/protocolbuffers/protobuf/tree/master/php) ([pecl](https://pecl.php.net/package/protobuf)) installed - integrators should install this extension for performance improvements

### Changed
- No longer mocking protobuf classes _(PHPUnit cannot mock protobuf classes with extension enabled)_
- Attribute converter now skips attributes with name that is `null` or empty string `""`
  > Note: it's not possible to create a protobuf attribute with `null` name without mocking, so we could remove this condition. When the name is not set, it will default to an empty string `""`, so skipping when the name is `null` or `""` seemed sensible.
- Exceptions messages are shorter with the extension enabled, so tests have been updated to check for the shorter version.