### PR TITLE
SDK-1673: Correct token decoding

### DIFF
--- a/src/Profile/Service.php
+++ b/src/Profile/Service.php
@@ -101,12 +101,12 @@ class Service
      */
     private function decryptConnectToken(string $encryptedConnectToken): string
     {
-        $tok = base64_decode(strtr($encryptedConnectToken, '-_,', '+/='), true);
-        if ($tok === false) {
+        $decodedToken = base64_decode(strtr($encryptedConnectToken, '-_', '+/'), true);
+        if ($decodedToken === false) {
             throw new ActivityDetailsException('Could not decode one time use token.');
         }
 
-        openssl_private_decrypt($tok, $token, (string) $this->pemFile);
+        openssl_private_decrypt($decodedToken, $token, (string) $this->pemFile);
 
         if (!isset($token) || strlen($token) === 0) {
             throw new ActivityDetailsException('Could not decrypt one time use token.');


### PR DESCRIPTION
### Fixed
- No longer replacing `,` with `=` - this replacement isn't required, has no effect and no other SDK does it - updated to avoid any confusion.
