### PR TITLE
SDK-1662: Install demos from packagist by default

### DIFF
--- a/examples/aml-check/composer.json
+++ b/examples/aml-check/composer.json
@@ -15,8 +15,14 @@
     }
   ],
   "scripts": {
-    "pre-install-cmd": "@copy-sdk",
-    "pre-update-cmd": "@copy-sdk",
-    "copy-sdk": "grep -q 'yoti-php-sdk' ../../composer.json && rm -fr ./sdk && cd ../../ && git archive --prefix=sdk/ --format=tar HEAD | (cd - && tar xf -) || echo 'Could not install SDK from parent directory'"
+    "copy-sdk": "grep -q 'yoti-php-sdk' ../../composer.json && rm -fr ./sdk && cd ../../ && git archive --prefix=sdk/ --format=tar HEAD | (cd - && tar xf -) || echo 'Could not install SDK from parent directory'",
+    "install-local": [
+      "@copy-sdk",
+      "composer install"
+    ],
+    "update-local": [
+      "@copy-sdk",
+      "composer update"
+    ]
   }
 }

--- a/examples/doc-scan/README.md
+++ b/examples/doc-scan/README.md
@@ -12,7 +12,7 @@ This example requires [Docker](https://docs.docker.com/)
 * Copy `.env.example` to `.env`
 * Open `.env` file and fill in the environment variables `YOTI_SDK_ID`, `YOTI_KEY_FILE_PATH`
   * Set `YOTI_KEY_FILE_PATH` to `./keys/your-application-pem-file.pem`
-* Run the `docker-compose up -d --build` command
+* Run the `docker-compose up --build` command
 * Visit [https://localhost:4003](https://localhost:4003)
 * Run the `docker-compose stop` command to stop the containers.
 

--- a/examples/doc-scan/composer.json
+++ b/examples/doc-scan/composer.json
@@ -36,10 +36,16 @@
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"
         ],
-        "pre-install-cmd": "@copy-sdk",
-        "pre-update-cmd": "@copy-sdk",
         "post-update-cmd": "@php artisan key:generate --ansi",
-        "copy-sdk": "grep -q 'yoti-php-sdk' ../../composer.json && rm -fr ./sdk && cd ../../ && git archive --prefix=sdk/ --format=tar HEAD | (cd - && tar xf -) || echo 'Could not install SDK from parent directory'"
+        "copy-sdk": "grep -q 'yoti-php-sdk' ../../composer.json && rm -fr ./sdk && cd ../../ && git archive --prefix=sdk/ --format=tar HEAD | (cd - && tar xf -) || echo 'Could not install SDK from parent directory'",
+        "install-local": [
+            "@copy-sdk",
+            "composer install"
+        ],
+        "update-local": [
+            "@copy-sdk",
+            "composer update"
+        ]
     },
     "repositories": [
         {

--- a/examples/doc-scan/docker-compose.yml
+++ b/examples/doc-scan/docker-compose.yml
@@ -22,4 +22,4 @@ services:
     volumes:
       - ../../:/usr/share/yoti-php-sdk
     working_dir: /usr/share/yoti-php-sdk/examples/doc-scan
-    command: update
+    command: update-local

--- a/examples/profile/README.md
+++ b/examples/profile/README.md
@@ -14,7 +14,7 @@ This example requires [Docker](https://docs.docker.com/)
 * Copy `.env.example` to `.env`
 * Open `.env` file and fill in the environment variables `YOTI_SCENARIO_ID`, `YOTI_SDK_ID`
   * Set `YOTI_KEY_FILE_PATH` to `./keys/your-application-pem-file.pem`
-* Run the `docker-compose up -d --build` command
+* Run the `docker-compose up --build` command
 * Visit [https://localhost:4002](https://localhost:4002)
 * Run the `docker-compose stop` command to stop the containers.
 

--- a/examples/profile/composer.json
+++ b/examples/profile/composer.json
@@ -36,10 +36,16 @@
             "Illuminate\\Foundation\\ComposerScripts::postAutoloadDump",
             "@php artisan package:discover --ansi"
         ],
-        "pre-install-cmd": "@copy-sdk",
-        "pre-update-cmd": "@copy-sdk",
         "post-update-cmd": "@php artisan key:generate --ansi",
-        "copy-sdk": "grep -q 'yoti-php-sdk' ../../composer.json && rm -fr ./sdk && cd ../../ && git archive --prefix=sdk/ --format=tar HEAD | (cd - && tar xf -) || echo 'Could not install SDK from parent directory'"
+        "copy-sdk": "grep -q 'yoti-php-sdk' ../../composer.json && rm -fr ./sdk && cd ../../ && git archive --prefix=sdk/ --format=tar HEAD | (cd - && tar xf -) || echo 'Could not install SDK from parent directory'",
+        "install-local": [
+            "@copy-sdk",
+            "composer install"
+        ],
+        "update-local": [
+            "@copy-sdk",
+            "composer update"
+        ]
     },
     "repositories": [
         {

--- a/examples/profile/docker-compose.yml
+++ b/examples/profile/docker-compose.yml
@@ -22,4 +22,4 @@ services:
     volumes:
       - ../../:/usr/share/yoti-php-sdk
     working_dir: /usr/share/yoti-php-sdk/examples/profile
-    command: update
+    command: update-local


### PR DESCRIPTION
### Changed
- Updated `composer.json` to install from packagist by default (it will not attempt to copy the SDK to `./sdk/`) - This allows users to copy the example to a different location and install/run without updating `composer.json`
- Added `update-local`/`install-local` commands to update/install using the local SDK
- Docker will continue to install the local SDK using `composer update-local`