### PR TITLE
SDK-1676: Omit null check/task config

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "yoti/yoti-php-sdk",
   "description": "Yoti SDK for quickly integrating your PHP backend with Yoti",
-  "version": "3.3.0",
+  "version": "3.3.1",
   "keywords": [
     "yoti",
     "sdk"

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -3,7 +3,7 @@ sonar.organization = getyoti
 
 sonar.projectKey = getyoti:php
 sonar.projectName = PHP SDK
-sonar.projectVersion = 3.3.0
+sonar.projectVersion = 3.3.1
 
 sonar.language = php
 sonar.sources=src

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -25,7 +25,7 @@ class Constants
     public const SDK_IDENTIFIER = 'PHP';
 
     /** Default SDK version */
-    public const SDK_VERSION = '3.3.0';
+    public const SDK_VERSION = '3.3.1';
 
     /** Base url for connect page (user will be redirected to this page eg. baseurl/app-id) */
     public const CONNECT_BASE_URL = 'https://www.yoti.com/connect';

--- a/src/DocScan/Session/Create/Check/RequestedCheck.php
+++ b/src/DocScan/Session/Create/Check/RequestedCheck.php
@@ -15,10 +15,10 @@ abstract class RequestedCheck implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
-        return [
+        return Json::withoutNullValues([
             'type' => $this->getType(),
             'config' => $this->getConfig()
-        ];
+        ]);
     }
 
     /**

--- a/src/DocScan/Session/Create/Task/RequestedTask.php
+++ b/src/DocScan/Session/Create/Task/RequestedTask.php
@@ -15,10 +15,10 @@ abstract class RequestedTask implements JsonSerializable
      */
     public function jsonSerialize(): array
     {
-        return [
+        return Json::withoutNullValues([
             'type' => $this->getType(),
             'config' => $this->getConfig()
-        ];
+        ]);
     }
 
     /**

--- a/tests/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckBuilderTest.php
+++ b/tests/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckBuilderTest.php
@@ -39,7 +39,6 @@ class RequestedDocumentAuthenticityCheckBuilderTest extends TestCase
 
         $expected = [
             'type' => 'ID_DOCUMENT_AUTHENTICITY',
-            'config' => null
         ];
 
         $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($result));
@@ -56,7 +55,6 @@ class RequestedDocumentAuthenticityCheckBuilderTest extends TestCase
 
         $expected = [
             'type' => 'ID_DOCUMENT_AUTHENTICITY',
-            'config' => null
         ];
 
         $this->assertJsonStringEqualsJsonString(json_encode($expected), $result->__toString());


### PR DESCRIPTION
### Fixed
- `null` check/task config is now omitted from session creation payload