### PR TITLE
SDK-1724: Fix Test Coverage

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     }
   },
   "require-dev": {
-    "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2",
+    "phpunit/phpunit": "^7.5 || ^8.5 || ^9.2 < 9.3",
     "squizlabs/php_codesniffer": "^3.4",
     "friendsofphp/php-cs-fixer": "^2.15",
     "brainmaestro/composer-git-hooks": "^2.8",


### PR DESCRIPTION
### Changed
- Use PHPUnit `< 9.3` until coverage reporting is resolved

We can remove this restriction once coverage reporting has been resolved in one of the related issues:
- https://github.com/sebastianbergmann/php-code-coverage/issues/799
- https://community.sonarsource.com/t/php-coverage-uncovered-new-line-at-end-of-file/29888

A ticket has been created to revisit this at a later date