### PR TITLE
SDK-1737: Document Authenticity check - manual check config

### DIFF
--- a/src/DocScan/Constants.php
+++ b/src/DocScan/Constants.php
@@ -17,4 +17,8 @@ class Constants
     public const DOCUMENT_RESTRICTIONS = 'DOCUMENT_RESTRICTIONS';
     public const INCLUSION_WHITELIST = 'WHITELIST';
     public const INCLUSION_BLACKLIST = 'BLACKLIST';
+
+    public const ALWAYS = 'ALWAYS';
+    public const FALLBACK = 'FALLBACK';
+    public const NEVER = 'NEVER';
 }

--- a/src/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheck.php
+++ b/src/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheck.php
@@ -8,6 +8,15 @@ use Yoti\DocScan\Constants;
 
 class RequestedDocumentAuthenticityCheck extends RequestedCheck
 {
+    /**
+     * @var RequestedDocumentAuthenticityCheckConfig|null
+     */
+    private $config;
+
+    public function __construct(?RequestedDocumentAuthenticityCheckConfig $config = null)
+    {
+        $this->config = $config;
+    }
 
     /**
      * @inheritDoc
@@ -22,6 +31,6 @@ class RequestedDocumentAuthenticityCheck extends RequestedCheck
      */
     protected function getConfig(): ?RequestedCheckConfigInterface
     {
-        return null;
+        return $this->config;
     }
 }

--- a/src/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckBuilder.php
+++ b/src/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckBuilder.php
@@ -4,11 +4,15 @@ declare(strict_types=1);
 
 namespace Yoti\DocScan\Session\Create\Check;
 
+use Yoti\DocScan\Session\Create\Traits\Builder\ManualCheckTrait;
+
 class RequestedDocumentAuthenticityCheckBuilder
 {
+    use ManualCheckTrait;
 
     public function build(): RequestedDocumentAuthenticityCheck
     {
-        return new RequestedDocumentAuthenticityCheck();
+        $config = new RequestedDocumentAuthenticityCheckConfig($this->manualCheck);
+        return new RequestedDocumentAuthenticityCheck($config);
     }
 }

--- a/src/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckConfig.php
+++ b/src/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckConfig.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create\Check;
+
+use Yoti\Util\Json;
+
+class RequestedDocumentAuthenticityCheckConfig implements RequestedCheckConfigInterface
+{
+    /**
+     * @var string|null
+     */
+    private $manualCheck;
+
+    public function __construct(?string $manualCheck)
+    {
+        $this->manualCheck = $manualCheck;
+    }
+
+    /**
+     * @return \stdClass
+     */
+    public function jsonSerialize(): \stdClass
+    {
+        return (object) Json::withoutNullValues([
+            'manual_check' => $this->getManualCheck(),
+        ]);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getManualCheck(): ?string
+    {
+        return $this->manualCheck;
+    }
+}

--- a/src/DocScan/Session/Create/Check/RequestedFaceMatchCheckBuilder.php
+++ b/src/DocScan/Session/Create/Check/RequestedFaceMatchCheckBuilder.php
@@ -4,40 +4,12 @@ declare(strict_types=1);
 
 namespace Yoti\DocScan\Session\Create\Check;
 
+use Yoti\DocScan\Session\Create\Traits\Builder\ManualCheckTrait;
 use Yoti\Util\Validation;
 
 class RequestedFaceMatchCheckBuilder
 {
-
-    private const ALWAYS = 'ALWAYS';
-    private const FALLBACK = 'FALLBACK';
-    private const NEVER = 'NEVER';
-
-    /**
-     * @var string
-     */
-    private $manualCheck;
-
-    public function withManualCheckAlways(): self
-    {
-        return $this->withManualCheck(self::ALWAYS);
-    }
-
-    private function withManualCheck(string $manualCheck): self
-    {
-        $this->manualCheck = $manualCheck;
-        return $this;
-    }
-
-    public function withManualCheckFallback(): self
-    {
-        return $this->withManualCheck(self::FALLBACK);
-    }
-
-    public function withManualCheckNever(): self
-    {
-        return $this->withManualCheck(self::NEVER);
-    }
+    use ManualCheckTrait;
 
     public function build(): RequestedFaceMatchCheck
     {

--- a/src/DocScan/Session/Create/Task/RequestedTextExtractionTaskBuilder.php
+++ b/src/DocScan/Session/Create/Task/RequestedTextExtractionTaskBuilder.php
@@ -4,61 +4,20 @@ declare(strict_types=1);
 
 namespace Yoti\DocScan\Session\Create\Task;
 
+use Yoti\DocScan\Session\Create\Traits\Builder\ManualCheckTrait;
 use Yoti\Util\Validation;
 
 class RequestedTextExtractionTaskBuilder
 {
+    use ManualCheckTrait;
 
-    private const ALWAYS = 'ALWAYS';
-    private const FALLBACK = 'FALLBACK';
-    private const NEVER = 'NEVER';
     private const DESIRED = 'DESIRED';
     private const IGNORE = 'IGNORE';
 
     /**
      * @var string
      */
-    private $manualCheck;
-
-    /**
-     * @var string
-     */
     private $chipData;
-
-    /**
-     * @param string $manualCheck
-     *
-     * @return $this
-     */
-    public function withManualCheck(string $manualCheck): self
-    {
-        $this->manualCheck = $manualCheck;
-        return $this;
-    }
-
-    /**
-     * @return $this
-     */
-    public function withManualCheckAlways(): self
-    {
-        return $this->withManualCheck(self::ALWAYS);
-    }
-
-    /**
-     * @return $this
-     */
-    public function withManualCheckFallback(): self
-    {
-        return $this->withManualCheck(self::FALLBACK);
-    }
-
-    /**
-     * @return $this
-     */
-    public function withManualCheckNever(): self
-    {
-        return $this->withManualCheck(self::NEVER);
-    }
 
     /**
      * @param string $chipData

--- a/src/DocScan/Session/Create/Traits/Builder/ManualCheckTrait.php
+++ b/src/DocScan/Session/Create/Traits/Builder/ManualCheckTrait.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create\Traits\Builder;
+
+use Yoti\DocScan\Constants;
+
+trait ManualCheckTrait
+{
+    /**
+     * @var string
+     */
+    private $manualCheck;
+
+    /**
+     * @param string $manualCheck
+     *
+     * @return $this
+     */
+    public function withManualCheck(string $manualCheck): self
+    {
+        $this->manualCheck = $manualCheck;
+        return $this;
+    }
+
+    /**
+     * @return $this
+     */
+    public function withManualCheckAlways(): self
+    {
+        return $this->withManualCheck(Constants::ALWAYS);
+    }
+
+    /**
+     * @return $this
+     */
+    public function withManualCheckFallback(): self
+    {
+        return $this->withManualCheck(Constants::FALLBACK);
+    }
+
+    /**
+     * @return $this
+     */
+    public function withManualCheckNever(): self
+    {
+        return $this->withManualCheck(Constants::NEVER);
+    }
+}

--- a/tests/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckBuilderTest.php
+++ b/tests/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckBuilderTest.php
@@ -28,6 +28,8 @@ class RequestedDocumentAuthenticityCheckBuilderTest extends TestCase
 
     /**
      * @test
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\Check\RequestedDocumentAuthenticityCheck::__construct
      * @covers \Yoti\DocScan\Session\Create\Check\RequestedDocumentAuthenticityCheck::jsonSerialize
      * @covers \Yoti\DocScan\Session\Create\Check\RequestedDocumentAuthenticityCheck::getType
      * @covers \Yoti\DocScan\Session\Create\Check\RequestedDocumentAuthenticityCheck::getConfig
@@ -38,6 +40,7 @@ class RequestedDocumentAuthenticityCheckBuilderTest extends TestCase
             ->build();
 
         $expected = [
+            'config' => (object) [],
             'type' => 'ID_DOCUMENT_AUTHENTICITY',
         ];
 
@@ -54,9 +57,76 @@ class RequestedDocumentAuthenticityCheckBuilderTest extends TestCase
             ->build();
 
         $expected = [
+            'config' => (object) [],
             'type' => 'ID_DOCUMENT_AUTHENTICITY',
         ];
 
         $this->assertJsonStringEqualsJsonString(json_encode($expected), $result->__toString());
+    }
+
+    /**
+     * @test
+     * @covers ::withManualCheckAlways
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\Check\RequestedDocumentAuthenticityCheck::__construct
+     */
+    public function shouldJsonEncodeCorrectlyWithManualCheckAlways()
+    {
+        $result = (new RequestedDocumentAuthenticityCheckBuilder())
+            ->withManualCheckAlways()
+            ->build();
+
+        $expected = [
+            'config' => (object) [
+                'manual_check' => 'ALWAYS',
+            ],
+            'type' => 'ID_DOCUMENT_AUTHENTICITY',
+        ];
+
+        $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($result));
+    }
+
+    /**
+     * @test
+     * @covers ::withManualCheckNever
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\Check\RequestedDocumentAuthenticityCheck::__construct
+     */
+    public function shouldJsonEncodeCorrectlyWithManualCheckNever()
+    {
+        $result = (new RequestedDocumentAuthenticityCheckBuilder())
+            ->withManualCheckNever()
+            ->build();
+
+        $expected = [
+            'config' => (object) [
+                'manual_check' => 'NEVER',
+            ],
+            'type' => 'ID_DOCUMENT_AUTHENTICITY',
+        ];
+
+        $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($result));
+    }
+
+    /**
+     * @test
+     * @covers ::withManualCheckFallback
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\Check\RequestedDocumentAuthenticityCheck::__construct
+     */
+    public function shouldJsonEncodeCorrectlyWithManualCheckFallback()
+    {
+        $result = (new RequestedDocumentAuthenticityCheckBuilder())
+            ->withManualCheckFallback()
+            ->build();
+
+        $expected = [
+            'config' => (object) [
+                'manual_check' => 'FALLBACK',
+            ],
+            'type' => 'ID_DOCUMENT_AUTHENTICITY',
+        ];
+
+        $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($result));
     }
 }

--- a/tests/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckConfigTest.php
+++ b/tests/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckConfigTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Yoti\Test\DocScan\Session\Create\Check;
+
+use Yoti\DocScan\Session\Create\Check\RequestedDocumentAuthenticityCheckConfig;
+use Yoti\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\DocScan\Session\Create\Check\RequestedDocumentAuthenticityCheckConfig
+ */
+class RequestedDocumentAuthenticityCheckConfigTest extends TestCase
+{
+    private const SOME_MANUAL_CHECK = 'someManualCheck';
+
+    /**
+     * @test
+     * @covers ::__construct
+     * @covers ::getManualCheck
+     * @covers ::jsonSerialize
+     */
+    public function shouldSerializeToJsonCorrectly()
+    {
+        $checkConfig = new RequestedDocumentAuthenticityCheckConfig(self::SOME_MANUAL_CHECK);
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'manual_check' => self::SOME_MANUAL_CHECK,
+            ]),
+            json_encode($checkConfig)
+        );
+    }
+}

--- a/tests/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckTest.php
+++ b/tests/DocScan/Session/Create/Check/RequestedDocumentAuthenticityCheckTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Yoti\Test\DocScan\Session\Create\Check;
+
+use Yoti\DocScan\Session\Create\Check\RequestedDocumentAuthenticityCheck;
+use Yoti\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\DocScan\Session\Create\Check\RequestedDocumentAuthenticityCheck
+ */
+class RequestedDocumentAuthenticityCheckTest extends TestCase
+{
+    /**
+     * @test
+     * @covers ::getConfig
+     * @covers ::getType
+     */
+    public function testConfigIsOptional()
+    {
+        $check = new RequestedDocumentAuthenticityCheck();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'type' => 'ID_DOCUMENT_AUTHENTICITY',
+            ]),
+            json_encode($check)
+        );
+    }
+}


### PR DESCRIPTION
### Added
- `RequestedDocumentAuthenticityCheckBuilder::withManualCheckAlways()`
- `RequestedDocumentAuthenticityCheckBuilder::withManualCheckNever()`
- `RequestedDocumentAuthenticityCheckBuilder::withManualCheckFallback()`

Note: Copied builder trait from #200 which should reduce some duplication