### PR TITLE
SDK-1737: Remove public withManualCheck() from builder trait

### DIFF
--- a/src/DocScan/Session/Create/Task/RequestedTextExtractionTaskBuilder.php
+++ b/src/DocScan/Session/Create/Task/RequestedTextExtractionTaskBuilder.php
@@ -47,6 +47,18 @@ class RequestedTextExtractionTaskBuilder
     }
 
     /**
+     * @deprecated custom manual check config is not supported.
+     *
+     * @param string $manualCheck
+     *
+     * @return $this
+     */
+    public function withManualCheck(string $manualCheck): self
+    {
+        return $this->setManualCheck($manualCheck);
+    }
+
+    /**
      * @return RequestedTextExtractionTask
      */
     public function build(): RequestedTextExtractionTask

--- a/src/DocScan/Session/Create/Traits/Builder/ManualCheckTrait.php
+++ b/src/DocScan/Session/Create/Traits/Builder/ManualCheckTrait.php
@@ -18,7 +18,7 @@ trait ManualCheckTrait
      *
      * @return $this
      */
-    public function withManualCheck(string $manualCheck): self
+    private function setManualCheck(string $manualCheck): self
     {
         $this->manualCheck = $manualCheck;
         return $this;
@@ -29,7 +29,7 @@ trait ManualCheckTrait
      */
     public function withManualCheckAlways(): self
     {
-        return $this->withManualCheck(Constants::ALWAYS);
+        return $this->setManualCheck(Constants::ALWAYS);
     }
 
     /**
@@ -37,7 +37,7 @@ trait ManualCheckTrait
      */
     public function withManualCheckFallback(): self
     {
-        return $this->withManualCheck(Constants::FALLBACK);
+        return $this->setManualCheck(Constants::FALLBACK);
     }
 
     /**
@@ -45,6 +45,6 @@ trait ManualCheckTrait
      */
     public function withManualCheckNever(): self
     {
-        return $this->withManualCheck(Constants::NEVER);
+        return $this->setManualCheck(Constants::NEVER);
     }
 }

--- a/tests/DocScan/Session/Create/Check/RequestedFaceMatchCheckBuilderTest.php
+++ b/tests/DocScan/Session/Create/Check/RequestedFaceMatchCheckBuilderTest.php
@@ -15,7 +15,7 @@ class RequestedFaceMatchCheckBuilderTest extends TestCase
     /**
      * @test
      * @covers ::withManualCheckAlways
-     * @covers ::withManualCheck
+     * @covers ::setManualCheck
      * @covers ::build
      */
     public function shouldCorrectlyBuildRequestedFaceMatchCheck()
@@ -31,7 +31,7 @@ class RequestedFaceMatchCheckBuilderTest extends TestCase
      * @test
      * @covers \Yoti\DocScan\Session\Create\Check\RequestedFaceMatchCheck::jsonSerialize
      * @covers ::withManualCheckAlways
-     * @covers ::withManualCheck
+     * @covers ::setManualCheck
      * @covers ::build
      * @covers \Yoti\DocScan\Session\Create\Check\RequestedFaceMatchCheck::__construct
      * @covers \Yoti\DocScan\Session\Create\Check\RequestedFaceMatchCheck::getConfig
@@ -57,7 +57,7 @@ class RequestedFaceMatchCheckBuilderTest extends TestCase
      * @test
      * @covers \Yoti\DocScan\Session\Create\Check\RequestedFaceMatchCheck::jsonSerialize
      * @covers ::withManualCheckFallback
-     * @covers ::withManualCheck
+     * @covers ::setManualCheck
      * @covers ::build
      * @covers \Yoti\DocScan\Session\Create\Check\RequestedFaceMatchCheck::__construct
      * @covers \Yoti\DocScan\Session\Create\Check\RequestedFaceMatchCheck::getConfig
@@ -83,7 +83,7 @@ class RequestedFaceMatchCheckBuilderTest extends TestCase
      * @test
      * @covers \Yoti\DocScan\Session\Create\Check\RequestedFaceMatchCheck::jsonSerialize
      * @covers ::withManualCheckNever
-     * @covers ::withManualCheck
+     * @covers ::setManualCheck
      * @covers ::build
      * @covers \Yoti\DocScan\Session\Create\Check\RequestedFaceMatchCheck::__construct
      * @covers \Yoti\DocScan\Session\Create\Check\RequestedFaceMatchCheck::getConfig

--- a/tests/DocScan/Session/Create/Task/RequestedTextExtractionTaskBuilderTest.php
+++ b/tests/DocScan/Session/Create/Task/RequestedTextExtractionTaskBuilderTest.php
@@ -17,6 +17,7 @@ class RequestedTextExtractionTaskBuilderTest extends TestCase
     /**
      * @test
      * @covers ::withManualCheck
+     * @covers ::setManualCheck
      * @covers ::build
      * @covers \Yoti\DocScan\Session\Create\Task\RequestedTextExtractionTask::__construct
      */


### PR DESCRIPTION
Fixes #205 

### Fixed
- Removed public `withManualCheck()` from builder trait (not yet released)

### Deprecated
- `RequestedTextExtractionTaskBuilder::withManualCheck()`
