### PR TITLE
SDK-1797: Replace use of deprecated Guzzle PSR7 functions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,8 @@
     "guzzlehttp/guzzle": "^6.4 || ^7.0",
     "psr/http-client": "^1.0",
     "psr/http-message": "^1.0",
-    "psr/log": "^1.1"
+    "psr/log": "^1.1",
+    "guzzlehttp/psr7": "^1.7"
   },
   "autoload": {
     "psr-4": {

--- a/src/Http/Payload.php
+++ b/src/Http/Payload.php
@@ -4,10 +4,9 @@ declare(strict_types=1);
 
 namespace Yoti\Http;
 
+use GuzzleHttp\Psr7;
 use Psr\Http\Message\StreamInterface;
 use Yoti\Util\Json;
-
-use function GuzzleHttp\Psr7\stream_for;
 
 class Payload
 {
@@ -51,7 +50,7 @@ class Payload
      */
     public static function fromString(string $string): self
     {
-        return static::fromStream(stream_for($string));
+        return static::fromStream(Psr7\Utils::streamFor($string));
     }
 
     /**

--- a/tests/Http/PayloadTest.php
+++ b/tests/Http/PayloadTest.php
@@ -4,11 +4,10 @@ declare(strict_types=1);
 
 namespace Yoti\Test\Http;
 
+use GuzzleHttp\Psr7;
 use Psr\Http\Message\StreamInterface;
 use Yoti\Http\Payload;
 use Yoti\Test\TestCase;
-
-use function GuzzleHttp\Psr7\stream_for;
 
 /**
  * @coversDefaultClass \Yoti\Http\Payload
@@ -83,7 +82,7 @@ class PayloadTest extends TestCase
      */
     public function testFromStream()
     {
-        $somePayloadStream = stream_for(self::SOME_STRING);
+        $somePayloadStream = Psr7\Utils::streamFor(self::SOME_STRING);
         $payload = Payload::fromStream($somePayloadStream);
 
         $this->assertEquals($somePayloadStream, $payload->toStream());

--- a/tests/YotiClientTest.php
+++ b/tests/YotiClientTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yoti\Test;
 
+use GuzzleHttp\Psr7;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Log\LoggerInterface;
@@ -18,8 +19,6 @@ use Yoti\ShareUrl\Policy\DynamicPolicyBuilder;
 use Yoti\ShareUrl\Result as ShareUrlResult;
 use Yoti\Util\Config;
 use Yoti\YotiClient;
-
-use function GuzzleHttp\Psr7\stream_for;
 
 /**
  * @coversDefaultClass \Yoti\YotiClient
@@ -92,8 +91,9 @@ class YotiClientTest extends TestCase
      */
     private function assertApiUrlStartsWith($expectedUrl, $clientApiUrl = null)
     {
+        $body = Psr7\Utils::streamFor(file_get_contents(TestData::AML_CHECK_RESULT_JSON));
         $response = $this->createMock(ResponseInterface::class);
-        $response->method('getBody')->willReturn(stream_for(file_get_contents(TestData::AML_CHECK_RESULT_JSON)));
+        $response->method('getBody')->willReturn($body);
         $response->method('getStatusCode')->willReturn(200);
 
         $httpClient = $this->createMock(ClientInterface::class);
@@ -150,8 +150,9 @@ class YotiClientTest extends TestCase
         $amlAddress = new AmlAddress(new AmlCountry('GBR'));
         $amlProfile = new AmlProfile('Edward Richard George', 'Heath', $amlAddress);
 
+        $body = Psr7\Utils::streamFor(file_get_contents(TestData::AML_CHECK_RESULT_JSON));
         $response = $this->createMock(ResponseInterface::class);
-        $response->method('getBody')->willReturn(stream_for(file_get_contents(TestData::AML_CHECK_RESULT_JSON)));
+        $response->method('getBody')->willReturn($body);
         $response->method('getStatusCode')->willReturn(200);
 
         $httpClient = $this->createMock(ClientInterface::class);
@@ -182,7 +183,7 @@ class YotiClientTest extends TestCase
             ->build();
 
         $response = $this->createMock(ResponseInterface::class);
-        $response->method('getBody')->willReturn(stream_for(json_encode([
+        $response->method('getBody')->willReturn(Psr7\Utils::streamFor(json_encode([
             'qrcode' => 'http://dynamic-code.yoti.com/some-qr-code',
             'ref_id' => 'some-ref-id',
         ])));


### PR DESCRIPTION
### Fixed
- Replaced uses of `stream_for()` with `Psr7\Utils::streamFor()`