### PR TITLE
SDK-1799: Support media responses with no content

### DIFF
--- a/examples/doc-scan/app/Http/Controllers/HomeController.php
+++ b/examples/doc-scan/app/Http/Controllers/HomeController.php
@@ -77,13 +77,7 @@ class HomeController extends BaseController
                     ->build()
             )
             ->withRequiredDocument(
-                (new RequiredIdDocumentBuilder())
-                    ->withFilter(
-                        (new OrthogonalRestrictionsFilterBuilder())
-                            ->withWhitelistedDocumentTypes(['DRIVING_LICENCE'])
-                            ->build()
-                    )
-                    ->build()
+                (new RequiredIdDocumentBuilder())->build()
             )
             ->withRequiredDocument(
                 (new RequiredSupplementaryDocumentBuilder())

--- a/examples/doc-scan/app/Http/Controllers/MediaController.php
+++ b/examples/doc-scan/app/Http/Controllers/MediaController.php
@@ -15,6 +15,10 @@ class MediaController extends BaseController
         $content = $media->getContent();
         $contentType = $media->getMimeType();
 
+        if ($content === '') {
+            return response('', 204);
+        }
+
         return response($content, 200)->header('Content-Type', $contentType);
     }
 }

--- a/src/DocScan/Service.php
+++ b/src/DocScan/Service.php
@@ -153,7 +153,7 @@ class Service
         self::assertResponseIsSuccess($response);
 
         $content = (string) $response->getBody();
-        $mimeType = $response->getHeader("Content-Type")[0];
+        $mimeType = $response->getHeader("Content-Type")[0] ?? '';
 
         return new Media($mimeType, $content);
     }

--- a/tests/Aml/ServiceTest.php
+++ b/tests/Aml/ServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yoti\Test\Aml;
 
+use GuzzleHttp\Psr7;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use Yoti\Aml\Address;
@@ -15,8 +16,6 @@ use Yoti\Test\TestCase;
 use Yoti\Test\TestData;
 use Yoti\Util\Config;
 use Yoti\Util\PemFile;
-
-use function GuzzleHttp\Psr7\stream_for;
 
 /**
  * @coversDefaultClass \Yoti\Aml\Service
@@ -43,7 +42,8 @@ class ServiceTest extends TestCase
         $amlProfile = new Profile('Edward Richard George', 'Heath', $amlAddress);
 
         $response = $this->createMock(ResponseInterface::class);
-        $response->method('getBody')->willReturn(stream_for(file_get_contents(TestData::AML_CHECK_RESULT_JSON)));
+        $body = file_get_contents(TestData::AML_CHECK_RESULT_JSON);
+        $response->method('getBody')->willReturn(Psr7\Utils::streamFor($body));
         $response->method('getStatusCode')->willReturn(200);
 
         $httpClient = $this->createMock(ClientInterface::class);
@@ -195,7 +195,7 @@ class ServiceTest extends TestCase
     private function createServiceWithErrorResponse($statusCode, $body = '{}', ?string $contentType = null)
     {
         $response = $this->createMock(ResponseInterface::class);
-        $response->method('getBody')->willReturn(stream_for($body));
+        $response->method('getBody')->willReturn(Psr7\Utils::streamFor($body));
         $response->method('getStatusCode')->willReturn($statusCode);
 
         if ($contentType !== null) {

--- a/tests/DocScan/Exception/DocScanExceptionTest.php
+++ b/tests/DocScan/Exception/DocScanExceptionTest.php
@@ -2,11 +2,10 @@
 
 namespace Yoti\Test\DocScan\Exception;
 
+use GuzzleHttp\Psr7;
 use Psr\Http\Message\ResponseInterface;
 use Yoti\DocScan\Exception\DocScanException;
 use Yoti\Test\TestCase;
-
-use function GuzzleHttp\Psr7\stream_for;
 
 class DocScanExceptionTest extends TestCase
 {
@@ -65,7 +64,7 @@ class DocScanExceptionTest extends TestCase
         $responseMock = $this->createMock(ResponseInterface::class);
         $responseMock->method('hasHeader')->willReturn(true);
         $responseMock->method('getHeader')->willReturn(['application/json']);
-        $responseMock->method('getBody')->willReturn(stream_for(json_encode($jsonData)));
+        $responseMock->method('getBody')->willReturn(Psr7\Utils::streamFor(json_encode($jsonData)));
 
         $docScanException = new DocScanException($message, $responseMock);
 

--- a/tests/Profile/ServiceTest.php
+++ b/tests/Profile/ServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yoti\Test\Profile;
 
+use GuzzleHttp\Psr7;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use Yoti\Profile\ActivityDetails;
@@ -12,8 +13,6 @@ use Yoti\Test\TestCase;
 use Yoti\Test\TestData;
 use Yoti\Util\Config;
 use Yoti\Util\PemFile;
-
-use function GuzzleHttp\Psr7\stream_for;
 
 /**
  * @coversDefaultClass \Yoti\Profile\Service
@@ -193,7 +192,7 @@ class ServiceTest extends TestCase
     private function createResponse($statusCode, $body = '{}')
     {
         $response = $this->createMock(ResponseInterface::class);
-        $response->method('getBody')->willReturn(stream_for($body));
+        $response->method('getBody')->willReturn(Psr7\Utils::streamFor($body));
         $response->method('getStatusCode')->willReturn($statusCode);
         return $response;
     }

--- a/tests/ShareUrl/ServiceTest.php
+++ b/tests/ShareUrl/ServiceTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yoti\Test\Service\ShareUrl;
 
+use GuzzleHttp\Psr7;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\ResponseInterface;
 use Yoti\Constants;
@@ -15,8 +16,6 @@ use Yoti\Test\TestCase;
 use Yoti\Test\TestData;
 use Yoti\Util\Config;
 use Yoti\Util\PemFile;
-
-use function GuzzleHttp\Psr7\stream_for;
 
 /**
  * @coversDefaultClass \Yoti\ShareUrl\Service
@@ -47,7 +46,7 @@ class ServiceTest extends TestCase
             ->build();
 
         $response = $this->createMock(ResponseInterface::class);
-        $response->method('getBody')->willReturn(stream_for(json_encode([
+        $response->method('getBody')->willReturn(Psr7\Utils::streamFor(json_encode([
             'qrcode' => $expectedQrCode,
             'ref_id' => $expectedRefId,
         ])));
@@ -100,7 +99,7 @@ class ServiceTest extends TestCase
     private function createServiceWithErrorResponse($statusCode)
     {
         $response = $this->createMock(ResponseInterface::class);
-        $response->method('getBody')->willReturn(stream_for('{}'));
+        $response->method('getBody')->willReturn(Psr7\Utils::streamFor('{}'));
         $response->method('getStatusCode')->willReturn($statusCode);
 
         $httpClient = $this->createMock(ClientInterface::class);


### PR DESCRIPTION
### Fixed
- `204` media responses now return `Media` with no content