### PR TITLE
SDK-1821: Privacy Policy URL

### DIFF
--- a/examples/doc-scan/app/Http/Controllers/HomeController.php
+++ b/examples/doc-scan/app/Http/Controllers/HomeController.php
@@ -65,6 +65,7 @@ class HomeController extends BaseController
                   ->withPresetIssuingCountry('GBR')
                   ->withSuccessUrl(config('app.url') . '/success')
                   ->withErrorUrl(config('app.url') . '/error')
+                  ->withPrivacyPolicyUrl(config('app.url') . '/privacy-policy')
                   ->build()
               )
             ->withRequiredDocument(

--- a/examples/doc-scan/resources/views/privacy.blade.php
+++ b/examples/doc-scan/resources/views/privacy.blade.php
@@ -1,0 +1,12 @@
+@extends('layouts.app')
+
+@section('content')
+<div class="container">
+    <div class="row pt-4">
+        <div class="col">
+            <h1>Privacy Policy</h1>
+            <p>Demo privacy policy</p>
+        </div>
+    </div>
+</div>
+@endsection

--- a/examples/doc-scan/routes/web.php
+++ b/examples/doc-scan/routes/web.php
@@ -20,3 +20,7 @@ Route::get('/success', 'SuccessController@show');
 Route::get('/media/{id}', 'MediaController@show');
 
 Route::get('/error', 'ErrorController@show');
+
+Route::get('/privacy-policy', function () {
+    return view('privacy');
+});

--- a/src/DocScan/Session/Create/NotificationConfig.php
+++ b/src/DocScan/Session/Create/NotificationConfig.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Yoti\DocScan\Session\Create;
 
-use JsonSerializable;
+use Yoti\Util\Json;
 
-class NotificationConfig implements JsonSerializable
+class NotificationConfig implements \JsonSerializable
 {
 
     /**
@@ -38,15 +38,15 @@ class NotificationConfig implements JsonSerializable
     }
 
     /**
-     * @return array<string, mixed>
+     * @return \stdClass
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): \stdClass
     {
-        return [
+        return (object) Json::withoutNullValues([
             'auth_token' => $this->getAuthToken(),
             'endpoint' => $this->getEndpoint(),
             'topics' => $this->getTopics(),
-        ];
+        ]);
     }
 
     /**

--- a/src/DocScan/Session/Create/SdkConfig.php
+++ b/src/DocScan/Session/Create/SdkConfig.php
@@ -4,9 +4,9 @@ declare(strict_types=1);
 
 namespace Yoti\DocScan\Session\Create;
 
-use JsonSerializable;
+use Yoti\Util\Json;
 
-class SdkConfig implements JsonSerializable
+class SdkConfig implements \JsonSerializable
 {
 
     /**
@@ -49,6 +49,11 @@ class SdkConfig implements JsonSerializable
      */
     private $errorUrl;
 
+    /**
+     * @var string|null
+     */
+    private $privacyPolicyUrl;
+
     public function __construct(
         ?string $allowedCaptureMethods,
         ?string $primaryColour,
@@ -57,7 +62,8 @@ class SdkConfig implements JsonSerializable
         ?string $locale,
         ?string $presetIssuingCountry,
         ?string $successUrl,
-        ?string $errorUrl
+        ?string $errorUrl,
+        ?string $privacyPolicyUrl = null
     ) {
         $this->allowedCaptureMethods = $allowedCaptureMethods;
         $this->primaryColour = $primaryColour;
@@ -67,14 +73,15 @@ class SdkConfig implements JsonSerializable
         $this->presetIssuingCountry = $presetIssuingCountry;
         $this->successUrl = $successUrl;
         $this->errorUrl = $errorUrl;
+        $this->privacyPolicyUrl = $privacyPolicyUrl;
     }
 
     /**
-     * @return array<string, mixed>
+     * @return \stdClass
      */
-    public function jsonSerialize(): array
+    public function jsonSerialize(): \stdClass
     {
-        return [
+        return (object) Json::withoutNullValues([
             'allowed_capture_methods' => $this->getAllowedCaptureMethods(),
             'primary_colour' => $this->getPrimaryColour(),
             'secondary_colour' => $this->getSecondaryColour(),
@@ -83,7 +90,8 @@ class SdkConfig implements JsonSerializable
             'preset_issuing_country' => $this->getPresetIssuingCountry(),
             'success_url' => $this->getSuccessUrl(),
             'error_url' => $this->getErrorUrl(),
-        ];
+            'privacy_policy_url' => $this->getPrivacyPolicyUrl(),
+        ]);
     }
 
     /**
@@ -148,5 +156,13 @@ class SdkConfig implements JsonSerializable
     public function getErrorUrl(): ?string
     {
         return $this->errorUrl;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPrivacyPolicyUrl(): ?string
+    {
+        return $this->privacyPolicyUrl;
     }
 }

--- a/src/DocScan/Session/Create/SdkConfigBuilder.php
+++ b/src/DocScan/Session/Create/SdkConfigBuilder.php
@@ -11,44 +11,49 @@ class SdkConfigBuilder
     private const CAMERA_AND_UPLOAD = 'CAMERA_AND_UPLOAD';
 
     /**
-     * @var string
+     * @var string|null
      */
     private $allowedCaptureMethods;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $primaryColour;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $secondaryColour;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $fontColour;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $locale;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $presetIssuingCountry;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $successUrl;
 
     /**
-     * @var string
+     * @var string|null
      */
     private $errorUrl;
+
+    /**
+     * @var string|null
+     */
+    private $privacyPolicyUrl;
 
     public function withAllowsCamera(): self
     {
@@ -108,6 +113,12 @@ class SdkConfigBuilder
         return $this;
     }
 
+    public function withPrivacyPolicyUrl(string $privacyPolicyUrl): self
+    {
+        $this->privacyPolicyUrl = $privacyPolicyUrl;
+        return $this;
+    }
+
     public function build(): SdkConfig
     {
         return new SdkConfig(
@@ -118,7 +129,8 @@ class SdkConfigBuilder
             $this->locale,
             $this->presetIssuingCountry,
             $this->successUrl,
-            $this->errorUrl
+            $this->errorUrl,
+            $this->privacyPolicyUrl
         );
     }
 }

--- a/tests/DocScan/Session/Create/NotificationConfigBuilderTest.php
+++ b/tests/DocScan/Session/Create/NotificationConfigBuilderTest.php
@@ -133,7 +133,7 @@ class NotificationConfigBuilderTest extends TestCase
      * @test
      * @covers \Yoti\DocScan\Session\Create\NotificationConfig::jsonSerialize
      */
-    public function shouldProduceCorrectOutput()
+    public function shouldSerializeWithCorrectProperties()
     {
         $result = (new NotificationConfigBuilder())
             ->withAuthToken(self::SOME_AUTH_TOKEN)
@@ -147,6 +147,21 @@ class NotificationConfigBuilderTest extends TestCase
             'topics' => [
                 self::SOME_TOPIC
             ]
+        ];
+
+        $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($result));
+    }
+
+    /**
+     * @test
+     * @covers \Yoti\DocScan\Session\Create\NotificationConfig::jsonSerialize
+     */
+    public function shouldSerializeWithoutNullValues()
+    {
+        $result = (new NotificationConfigBuilder())->build();
+
+        $expected = [
+            'topics' => []
         ];
 
         $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($result));

--- a/tests/DocScan/Session/Create/SdkConfigBuilderTest.php
+++ b/tests/DocScan/Session/Create/SdkConfigBuilderTest.php
@@ -19,6 +19,7 @@ class SdkConfigBuilderTest extends TestCase
     private const SOME_PRESET_ISSUING_COUNTRY = 'somePresetIssuingCountry';
     private const SOME_SUCCESS_URL = 'someSuccessUrl';
     private const SOME_ERROR_URL = 'someErrorUrl';
+    private const SOME_PRIVACY_POLICY_URL = 'somePrivacyPolicyUrl';
 
     /**
      * @test
@@ -31,6 +32,7 @@ class SdkConfigBuilderTest extends TestCase
      * @covers ::withPresetIssuingCountry
      * @covers ::withSuccessUrl
      * @covers ::withErrorUrl
+     * @covers ::withPrivacyPolicyUrl
      * @covers \Yoti\DocScan\Session\Create\SdkConfig::__construct
      * @covers \Yoti\DocScan\Session\Create\SdkConfig::getAllowedCaptureMethods
      * @covers \Yoti\DocScan\Session\Create\SdkConfig::getPrimaryColour
@@ -40,6 +42,7 @@ class SdkConfigBuilderTest extends TestCase
      * @covers \Yoti\DocScan\Session\Create\SdkConfig::getPresetIssuingCountry
      * @covers \Yoti\DocScan\Session\Create\SdkConfig::getSuccessUrl
      * @covers \Yoti\DocScan\Session\Create\SdkConfig::getErrorUrl
+     * @covers \Yoti\DocScan\Session\Create\SdkConfig::getPrivacyPolicyUrl
      */
     public function shouldCorrectlyBuildSdkConfig()
     {
@@ -52,6 +55,7 @@ class SdkConfigBuilderTest extends TestCase
             ->withPresetIssuingCountry(self::SOME_PRESET_ISSUING_COUNTRY)
             ->withSuccessUrl(self::SOME_SUCCESS_URL)
             ->withErrorUrl(self::SOME_ERROR_URL)
+            ->withPrivacyPolicyUrl(self::SOME_PRIVACY_POLICY_URL)
             ->build();
 
         $this->assertEquals(self::SOME_CAPTURE_METHOD, $result->getAllowedCaptureMethods());
@@ -62,6 +66,7 @@ class SdkConfigBuilderTest extends TestCase
         $this->assertEquals(self::SOME_PRESET_ISSUING_COUNTRY, $result->getPresetIssuingCountry());
         $this->assertEquals(self::SOME_SUCCESS_URL, $result->getSuccessUrl());
         $this->assertEquals(self::SOME_ERROR_URL, $result->getErrorUrl());
+        $this->assertEquals(self::SOME_PRIVACY_POLICY_URL, $result->getPrivacyPolicyUrl());
     }
 
     /**
@@ -105,6 +110,7 @@ class SdkConfigBuilderTest extends TestCase
             ->withPresetIssuingCountry(self::SOME_PRESET_ISSUING_COUNTRY)
             ->withSuccessUrl(self::SOME_SUCCESS_URL)
             ->withErrorUrl(self::SOME_ERROR_URL)
+            ->withPrivacyPolicyUrl(self::SOME_PRIVACY_POLICY_URL)
             ->build();
 
         $expected = [
@@ -116,8 +122,20 @@ class SdkConfigBuilderTest extends TestCase
             'preset_issuing_country' => self::SOME_PRESET_ISSUING_COUNTRY,
             'success_url' => self::SOME_SUCCESS_URL,
             'error_url' => self::SOME_ERROR_URL,
+            'privacy_policy_url' => self::SOME_PRIVACY_POLICY_URL,
         ];
 
         $this->assertJsonStringEqualsJsonString(json_encode($expected), json_encode($result));
+    }
+
+    /**
+     * @test
+     * @covers \Yoti\DocScan\Session\Create\SdkConfig::jsonSerialize
+     */
+    public function shouldSerializeToEmptyObjectWithNoValuesSet()
+    {
+        $result = (new SdkConfigBuilder())->build();
+
+        $this->assertJsonStringEqualsJsonString('{}', json_encode($result));
     }
 }

--- a/tests/DocScan/Session/Create/SessionSpecificationBuilderTest.php
+++ b/tests/DocScan/Session/Create/SessionSpecificationBuilderTest.php
@@ -49,10 +49,10 @@ class SessionSpecificationBuilderTest extends TestCase
     public function setup(): void
     {
         $this->sdkConfigMock = $this->createMock(SdkConfig::class);
-        $this->sdkConfigMock->method('jsonSerialize')->willReturn(['sdkConfig']);
+        $this->sdkConfigMock->method('jsonSerialize')->willReturn((object)['sdkConfig']);
 
         $this->notificationsMock = $this->createMock(NotificationConfig::class);
-        $this->notificationsMock->method('jsonSerialize')->willReturn(['notifications']);
+        $this->notificationsMock->method('jsonSerialize')->willReturn((object)['notifications']);
 
         $this->requestedCheckMock = $this->createMock(RequestedCheck::class);
         $this->requestedCheckMock->method('jsonSerialize')->willReturn(['requestedChecks']);


### PR DESCRIPTION
### Added
- Support for custom privacy policy URL

### Fixed
- `SdkConfig::jsonSerialize()` now omits `null` values and returns object instead of array
- `NotificationConfig::jsonSerialize()` now omits `null` values and returns object instead of array
