### PR TITLE
merge master -> development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,5 @@ updates:
   target-branch: development
   reviewers:
   - echarrod
-  - davidgrayston
   assignees:
-  - davidgrayston
+  - echarrod

--- a/.github/workflows/sonar.yaml
+++ b/.github/workflows/sonar.yaml
@@ -1,0 +1,30 @@
+name: Sonar Scan
+on: [push, pull_request_target]
+
+jobs:
+  sonar:
+    name: Sonar Scan
+    runs-on: ubuntu-latest
+    # always run on push events
+    # only run on pull_request_target event when pull request pulls from fork repository
+    if: >
+      github.event_name == 'push' || 
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository 
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      
+      - uses: shivammathur/setup-php@2.9.0
+        with:
+          php-version: 8.0
+
+      - run: composer install
+      - run: composer coverage-clover
+      
+      - uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,120 @@
+name: Unit Tests
+on: [ push, pull_request_target ]
+
+jobs:
+  php8compat:
+    name: Unit Tests PHP8 Compatibility (php ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    # always run on push events
+    # only run on pull_request_target event when pull request pulls from fork repository
+    if: >
+      github.event_name == 'push' || 
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository 
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ 8.0 ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@2.9.0
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      # Remove php-cs-fixer until compatible with PHP 8
+      - run: composer remove --dev --no-update --no-interaction friendsofphp/php-cs-fixer
+
+      - run: composer self-update
+
+      - run: composer install --no-interaction --prefer-source --dev
+
+      - run: composer test
+
+  php7:
+    name: Unit Tests (php ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    # always run on push events
+    # only run on pull_request_target event when pull request pulls from fork repository
+    if: >
+      github.event_name == 'push' || 
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository 
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ 7.4, 7.3, 7.2, 7.1 ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@2.9.0
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - run: composer self-update
+
+      - run: composer install --no-interaction --prefer-source --dev
+
+      - run: composer test
+
+      - run: composer lint
+
+  guzzle:
+    name: Unit Tests With Guzzle 6 (php ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    # always run on push events
+    # only run on pull_request_target event when pull request pulls from fork repository
+    if: >
+      github.event_name == 'push' || 
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository 
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ 7.4 ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@2.9.0
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - run: composer require guzzlehttp/guzzle "^6.5"
+
+      - run: composer self-update
+
+      - run: composer install --no-interaction --prefer-source --dev
+
+      - run: composer test
+
+      - run: composer lint
+
+  protobuf:
+    name: Unit Tests With Protobuf C Extension 3.13 (php ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    # always run on push events
+    # only run on pull_request_target event when pull request pulls from fork repository
+    if: >
+      github.event_name == 'push' || 
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository 
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ 7.4 ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@2.9.0
+        with:
+          php-version: ${{ matrix.php-version }}
+          extensions: protobuf
+
+      - run: composer self-update
+
+      - run: composer install --no-interaction --prefer-source --dev
+
+      - run: composer test
+
+      - run: composer lint
+

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Yoti PHP SDK
 
-[![Build Status](https://travis-ci.com/getyoti/yoti-php-sdk.svg?branch=master)](https://travis-ci.com/getyoti/yoti-php-sdk)
+[![Build Status](https://github.com/getyoti/yoti-php-sdk/workflows/Unit%20Tests/badge.svg?branch=master)](https://github.com/getyoti/yoti-php-sdk/actions)
 [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=getyoti%3Aphp&metric=coverage)](https://sonarcloud.io/dashboard?id=getyoti%3Aphp)
 [![Bugs](https://sonarcloud.io/api/project_badges/measure?project=getyoti%3Aphp&metric=bugs)](https://sonarcloud.io/dashboard?id=getyoti%3Aphp)
 [![Code Smells](https://sonarcloud.io/api/project_badges/measure?project=getyoti%3Aphp&metric=code_smells)](https://sonarcloud.io/dashboard?id=getyoti%3Aphp)

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "psr/http-client": "^1.0",
     "psr/http-message": "^1.0",
     "psr/log": "^1.1",
-    "guzzlehttp/psr7": "^1.7"
+    "guzzlehttp/psr7": "^1.7",
+    "ext-openssl": "*"
   },
   "autoload": {
     "psr-4": {

--- a/src/Profile/Util/Attribute/AttributeListConverter.php
+++ b/src/Profile/Util/Attribute/AttributeListConverter.php
@@ -28,7 +28,7 @@ class AttributeListConverter
 
         foreach ($attributeList->getAttributes() as $attr) { /** @var \Yoti\Protobuf\Attrpubapi\Attribute $attr */
             $attrName = $attr->getName();
-            if (null === $attrName || strlen($attrName) === 0) {
+            if (null == $attrName || strlen($attrName) === 0) {
                 continue;
             }
             $yotiAttribute = AttributeConverter::convertToYotiAttribute($attr, $logger);

--- a/src/Util/PemFile.php
+++ b/src/Util/PemFile.php
@@ -18,7 +18,7 @@ class PemFile
     /**
      * Private Key.
      *
-     * @var resource
+     * @var mixed
      */
     private $privateKey;
 


### PR DESCRIPTION
* SDK-1863: Migrate travis to github actions

* SDK-1863: Remove Travis status from README

* SDK-1863: Add script to generate sonar coverage

* Include "pecl install protobuf-3.13.0" command

When running Protobuf C Extension 3.13 unit tests

* Correct Github Action build status badge

* SDK-1863: Fix type check

* SDK-1863:small fix for php8.0

* SDK-1368: Change protobuf version

* SDK-1368: Trying to install pecl

* SDK-1368: Trying to install pecl

* SDK-1368: Trying to install pecl

* SDK-1368: Trying to install pecl

* SDK-1368: Trying to install pecl

Co-authored-by: Ed Harrod <echarrod@users.noreply.github.com>
Co-authored-by: Rodion Liuborets <rodion.liuborets@yoti.com>