### PR TITLE
Upgraded Guzzle PSR7 to version 2.1.0 and moved psr/log to require-dev

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
     "guzzlehttp/guzzle": "^6.4 || ^7.0",
     "psr/http-client": "^1.0",
     "psr/http-message": "^1.0",
-    "psr/log": "^1.1",
-    "guzzlehttp/psr7": "^1.7",
+    "guzzlehttp/psr7": "^2.0",
     "ext-openssl": "*"
   },
   "autoload": {
@@ -32,6 +31,7 @@
     "brainmaestro/composer-git-hooks": "^2.8",
     "phpstan/phpstan-strict-rules": "^0.12.1",
     "phpstan/extension-installer": "^1.0",
+    "psr/log": "^1.1",
     "symfony/phpunit-bridge": "^5.1"
   },
   "autoload-dev": {
@@ -58,7 +58,12 @@
   },
   "extra": {
     "hooks": {
-        "pre-commit": "composer test && composer lint"
+      "pre-commit": "composer test && composer lint"
+    }
+  },
+  "config": {
+    "allow-plugins": {
+      "phpstan/extension-installer": true
     }
   }
 }

--- a/src/Http/RequestBuilder.php
+++ b/src/Http/RequestBuilder.php
@@ -5,12 +5,11 @@ declare(strict_types=1);
 namespace Yoti\Http;
 
 use GuzzleHttp\Psr7\Request as RequestMessage;
+use GuzzleHttp\Psr7\Utils;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\StreamInterface;
 use Yoti\Util\Config;
 use Yoti\Util\PemFile;
-
-use function GuzzleHttp\Psr7\uri_for;
 
 class RequestBuilder
 {
@@ -380,7 +379,7 @@ class RequestBuilder
 
         $message = new RequestMessage(
             $this->method,
-            uri_for($url),
+            Utils::uriFor($url),
             $this->getHeaders(),
             $this->getBodyByTypeOfRequest()
         );


### PR DESCRIPTION
Title says it all. This allow the use of the latest versionsof Guzzle PSR7 and the fact to move psr/log to require-dev allow us to not have conflicts while being only used for tests. 