### PR TITLE
Fix data handling for the custom watchlist response

### DIFF
--- a/src/DocScan/Session/Retrieve/CustomAccountWatchlistCaSearchConfigResponse.php
+++ b/src/DocScan/Session/Retrieve/CustomAccountWatchlistCaSearchConfigResponse.php
@@ -35,7 +35,7 @@ class CustomAccountWatchlistCaSearchConfigResponse extends WatchlistAdvancedCaSe
         $this->apiKey = $searchConfig['api_key'];
         $this->monitoring = $searchConfig['monitoring'];
         $this->clientRef = $searchConfig['client_ref'];
-        $this->tags = json_decode($searchConfig['tags'], true);
+        $this->tags = array_key_exists('tags', $searchConfig) ? json_decode($searchConfig['tags'], true) : [];
     }
 
     /**


### PR DESCRIPTION
The returned data didn't have a tags property, this update ensures that we check the data exists before reading from it.

Fixes #328