### PR TITLE
Custom watchlist: Update handler to work with the new returned data type

### DIFF
--- a/src/DocScan/Session/Retrieve/CustomAccountWatchlistCaSearchConfigResponse.php
+++ b/src/DocScan/Session/Retrieve/CustomAccountWatchlistCaSearchConfigResponse.php
@@ -35,7 +35,7 @@ class CustomAccountWatchlistCaSearchConfigResponse extends WatchlistAdvancedCaSe
         $this->apiKey = $searchConfig['api_key'];
         $this->monitoring = $searchConfig['monitoring'];
         $this->clientRef = $searchConfig['client_ref'];
-        $this->tags = array_key_exists('tags', $searchConfig) ? json_decode($searchConfig['tags'], true) : [];
+        $this->tags = array_key_exists('tags', $searchConfig) ? $searchConfig['tags']) : [];
     }
 
     /**


### PR DESCRIPTION
The format of the returned data has changed and the tags are no longer a string but an array.