### PR TITLE
SDK-2472-added-php-idv-support-brand-id-in-session-config

### DIFF
--- a/examples/digitalidentity/resources/views/advancedidentity.blade.php
+++ b/examples/digitalidentity/resources/views/advancedidentity.blade.php
@@ -84,6 +84,6 @@
         await Yoti.ready()
         await onReadyToStart()
     }</script>
-<script src="https://www.public.stg1.dmz.yoti.com/share/client/v2" onload="onClientLoaded()"></script>
+<script src="https://www.yoti.com/share/client/v2" onload="onClientLoaded()"></script>
 </body>
 </html>

--- a/examples/digitalidentity/resources/views/advancedidentity.blade.php
+++ b/examples/digitalidentity/resources/views/advancedidentity.blade.php
@@ -84,6 +84,6 @@
         await Yoti.ready()
         await onReadyToStart()
     }</script>
-<script src="https://www.yoti.com/share/client/v2" onload="onClientLoaded()"></script>
+<script src="https://www.public.stg1.dmz.yoti.com/share/client/v2" onload="onClientLoaded()"></script>
 </body>
 </html>

--- a/examples/doc-scan/app/Http/Controllers/HomeController.php
+++ b/examples/doc-scan/app/Http/Controllers/HomeController.php
@@ -150,6 +150,7 @@ class HomeController extends BaseController
                     ->withErrorUrl(config('app.url') . '/error')
                     ->withPrivacyPolicyUrl(config('app.url') . '/privacy-policy')
                     ->withBiometricConsentFlow('EARLY')
+                    ->withBrandId('brand_id')
                     ->build()
             )
             ->withRequiredDocument(

--- a/src/DocScan/Session/Create/SdkConfig.php
+++ b/src/DocScan/Session/Create/SdkConfig.php
@@ -69,6 +69,11 @@ class SdkConfig implements \JsonSerializable
     private $biometricConsentFlow;
 
     /**
+     * @var string|null
+     */
+    private $brandId;
+
+    /**
      * @param string|null $allowedCaptureMethods
      * @param string|null $primaryColour
      * @param string|null $secondaryColour
@@ -81,6 +86,7 @@ class SdkConfig implements \JsonSerializable
      * @param bool|null $allowHandoff
      * @param array<string, int>|null $idDocumentTextDataExtractionRetriesConfig
      * @param string|null $biometricConsentFlow
+     * @param string|null $brandId
      */
     public function __construct(
         ?string $allowedCaptureMethods,
@@ -94,7 +100,8 @@ class SdkConfig implements \JsonSerializable
         ?string $privacyPolicyUrl = null,
         ?bool $allowHandoff = null,
         ?array $idDocumentTextDataExtractionRetriesConfig = null,
-        ?string $biometricConsentFlow = null
+        ?string $biometricConsentFlow = null,
+        ?string $brandId = null
     ) {
         $this->allowedCaptureMethods = $allowedCaptureMethods;
         $this->primaryColour = $primaryColour;
@@ -110,6 +117,7 @@ class SdkConfig implements \JsonSerializable
             $this->attemptsConfiguration = new AttemptsConfiguration($idDocumentTextDataExtractionRetriesConfig);
         }
         $this->biometricConsentFlow = $biometricConsentFlow;
+        $this->brandId = $brandId;
     }
 
     /**
@@ -129,7 +137,8 @@ class SdkConfig implements \JsonSerializable
             'privacy_policy_url' => $this->getPrivacyPolicyUrl(),
             'allow_handoff' => $this->getAllowHandoff(),
             'attempts_configuration' => $this->getAttemptsConfiguration(),
-            'biometric_consent_flow' => $this->getBiometricConsentFlow()
+            'biometric_consent_flow' => $this->getBiometricConsentFlow(),
+            'brand_id' => $this->getBrandId()
         ]);
     }
 
@@ -227,5 +236,13 @@ class SdkConfig implements \JsonSerializable
     public function getBiometricConsentFlow(): ?string
     {
         return $this->biometricConsentFlow;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getBrandId(): ?string
+    {
+        return $this->brandId;
     }
 }

--- a/src/DocScan/Session/Create/SdkConfigBuilder.php
+++ b/src/DocScan/Session/Create/SdkConfigBuilder.php
@@ -71,6 +71,11 @@ class SdkConfigBuilder
      */
     private $biometricConsentFlow;
 
+    /**
+     * @var string|null
+     */
+    private $brandId;
+
     public function withAllowsCamera(): self
     {
         return $this->withAllowedCaptureMethod(self::CAMERA);
@@ -199,6 +204,11 @@ class SdkConfigBuilder
         return $this;
     }
 
+    public function withBrandId(string $brandId): self
+    {
+        $this->brandId = $brandId;
+        return $this;
+    }
 
     public function build(): SdkConfig
     {
@@ -214,7 +224,8 @@ class SdkConfigBuilder
             $this->privacyPolicyUrl,
             $this->allowHandoff,
             $this->idDocumentTextDataExtractionRetriesConfig,
-            $this->biometricConsentFlow
+            $this->biometricConsentFlow,
+            $this->brandId
         );
     }
 }

--- a/tests/DocScan/Session/Create/SdkConfigBuilderTest.php
+++ b/tests/DocScan/Session/Create/SdkConfigBuilderTest.php
@@ -23,6 +23,7 @@ class SdkConfigBuilderTest extends TestCase
     private const SOME_CATEGORY = 'someCategory';
     private const SOME_NUMBER_RETRIES = 5;
     private const SOME_BIOMETRIC_CONSENT_FLOW = 'someBiometricConsentFlow';
+    private const SOME_BRAND_ID = 'someBrandId';
 
 
     /**
@@ -38,6 +39,7 @@ class SdkConfigBuilderTest extends TestCase
      * @covers ::withErrorUrl
      * @covers ::withPrivacyPolicyUrl
      * @covers ::withAllowHandoff
+     * @covers ::withBrandId
      * @covers \Yoti\DocScan\Session\Create\SdkConfig::__construct
      * @covers \Yoti\DocScan\Session\Create\SdkConfig::getAllowedCaptureMethods
      * @covers \Yoti\DocScan\Session\Create\SdkConfig::getPrimaryColour
@@ -49,6 +51,7 @@ class SdkConfigBuilderTest extends TestCase
      * @covers \Yoti\DocScan\Session\Create\SdkConfig::getErrorUrl
      * @covers \Yoti\DocScan\Session\Create\SdkConfig::getPrivacyPolicyUrl
      * @covers \Yoti\DocScan\Session\Create\SdkConfig::getAllowHandoff
+     * @covers \Yoti\DocScan\Session\Create\SdkConfig::getBrandId
      */
     public function shouldCorrectlyBuildSdkConfig()
     {
@@ -63,6 +66,7 @@ class SdkConfigBuilderTest extends TestCase
             ->withErrorUrl(self::SOME_ERROR_URL)
             ->withPrivacyPolicyUrl(self::SOME_PRIVACY_POLICY_URL)
             ->withAllowHandoff(true)
+            ->withBrandId(self::SOME_BRAND_ID)
             ->build();
 
         $this->assertEquals(self::SOME_CAPTURE_METHOD, $result->getAllowedCaptureMethods());
@@ -75,6 +79,7 @@ class SdkConfigBuilderTest extends TestCase
         $this->assertEquals(self::SOME_ERROR_URL, $result->getErrorUrl());
         $this->assertEquals(self::SOME_PRIVACY_POLICY_URL, $result->getPrivacyPolicyUrl());
         $this->assertTrue($result->getAllowHandoff());
+        $this->assertEquals(self::SOME_BRAND_ID, $result->getBrandId());
     }
 
     /**


### PR DESCRIPTION
```php

 $result = (new SdkConfigBuilder())
            ->withAllowedCaptureMethod(self::SOME_CAPTURE_METHOD)
            ->withPrimaryColour(self::SOME_PRIMARY_COLOUR)
            ->withSecondaryColour(self::SOME_SECONDARY_COLOUR)
            ->withFontColour(self::SOME_FONT_COLOUR)
            ->withLocale(self::SOME_LOCALE)
            ->withPresetIssuingCountry(self::SOME_PRESET_ISSUING_COUNTRY)
            ->withSuccessUrl(self::SOME_SUCCESS_URL)
            ->withErrorUrl(self::SOME_ERROR_URL)
            ->withPrivacyPolicyUrl(self::SOME_PRIVACY_POLICY_URL)
            ->withAllowHandoff(true)
            ->withBrandId(self::SOME_BRAND_ID)
            ->build();
            
            ```