### PR TITLE
SDK-2793-php-task-response-recommandation added

### DIFF
--- a/src/DocScan/Session/Retrieve/TaskRecommendationReasonResponse.php
+++ b/src/DocScan/Session/Retrieve/TaskRecommendationReasonResponse.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Retrieve;
+
+class TaskRecommendationReasonResponse
+{
+    /**
+     * @var string|null
+     */
+    private $value;
+
+    /**
+     * @var string|null
+     */
+    private $detail;
+
+    /**
+     * TaskRecommendationReasonResponse constructor.
+     * @param array<string, mixed> $reason
+     */
+    public function __construct(array $reason)
+    {
+        $this->value = $reason['value'] ?? null;
+        $this->detail = $reason['detail'] ?? null;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDetail(): ?string
+    {
+        return $this->detail;
+    }
+}

--- a/src/DocScan/Session/Retrieve/TaskRecommendationResponse.php
+++ b/src/DocScan/Session/Retrieve/TaskRecommendationResponse.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Retrieve;
+
+class TaskRecommendationResponse
+{
+    /**
+     * @var string|null
+     */
+    private $value;
+
+    /**
+     * @var TaskRecommendationReasonResponse|null
+     */
+    private $reason;
+
+    /**
+     * TaskRecommendationResponse constructor.
+     * @param array<string, mixed> $recommendation
+     */
+    public function __construct(array $recommendation)
+    {
+        $this->value = $recommendation['value'] ?? null;
+
+        if (isset($recommendation['reason'])) {
+            $this->reason = new TaskRecommendationReasonResponse($recommendation['reason']);
+        }
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return TaskRecommendationReasonResponse|null
+     */
+    public function getReason(): ?TaskRecommendationReasonResponse
+    {
+        return $this->reason;
+    }
+}

--- a/src/DocScan/Session/Retrieve/TaskResponse.php
+++ b/src/DocScan/Session/Retrieve/TaskResponse.php
@@ -45,6 +45,11 @@ class TaskResponse
     private $generatedMedia = [];
 
     /**
+     * @var TaskRecommendationResponse|null
+     */
+    private $recommendation;
+
+    /**
      * TaskResponse constructor.
      * @param array<string, mixed> $task
      */
@@ -66,6 +71,10 @@ class TaskResponse
 
         if (isset($task['generated_media'])) {
             $this->generatedMedia = $this->parseGeneratedMedia($task['generated_media']);
+        }
+
+        if (isset($task['recommendation'])) {
+            $this->recommendation = new TaskRecommendationResponse($task['recommendation']);
         }
     }
 
@@ -159,6 +168,14 @@ class TaskResponse
     public function getGeneratedMedia(): array
     {
         return $this->generatedMedia;
+    }
+
+    /**
+     * @return TaskRecommendationResponse|null
+     */
+    public function getRecommendation(): ?TaskRecommendationResponse
+    {
+        return $this->recommendation;
     }
 
     /**

--- a/tests/DocScan/Session/Retrieve/TaskRecommendationReasonResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/TaskRecommendationReasonResponseTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Test\DocScan\Session\Retrieve;
+
+use Yoti\DocScan\Session\Retrieve\TaskRecommendationReasonResponse;
+use Yoti\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\DocScan\Session\Retrieve\TaskRecommendationReasonResponse
+ */
+class TaskRecommendationReasonResponseTest extends TestCase
+{
+    private const SOME_VALUE = 'USER_ERROR';
+    private const SOME_DETAIL = 'NO_DOCUMENT';
+
+    /**
+     * @test
+     * @covers ::__construct
+     * @covers ::getValue
+     * @covers ::getDetail
+     */
+    public function shouldBuildCorrectly()
+    {
+        $input = [
+            'value' => self::SOME_VALUE,
+            'detail' => self::SOME_DETAIL,
+        ];
+
+        $result = new TaskRecommendationReasonResponse($input);
+
+        $this->assertEquals(self::SOME_VALUE, $result->getValue());
+        $this->assertEquals(self::SOME_DETAIL, $result->getDetail());
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function shouldNotThrowExceptionWhenMissingValues()
+    {
+        $result = new TaskRecommendationReasonResponse([]);
+
+        $this->assertNull($result->getValue());
+        $this->assertNull($result->getDetail());
+    }
+}

--- a/tests/DocScan/Session/Retrieve/TaskRecommendationResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/TaskRecommendationResponseTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Test\DocScan\Session\Retrieve;
+
+use Yoti\DocScan\Session\Retrieve\TaskRecommendationReasonResponse;
+use Yoti\DocScan\Session\Retrieve\TaskRecommendationResponse;
+use Yoti\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\DocScan\Session\Retrieve\TaskRecommendationResponse
+ */
+class TaskRecommendationResponseTest extends TestCase
+{
+    private const SOME_VALUE = 'MUST_TRY_AGAIN';
+    private const SOME_REASON_VALUE = 'USER_ERROR';
+    private const SOME_REASON_DETAIL = 'NO_DOCUMENT';
+
+    /**
+     * @test
+     * @covers ::__construct
+     * @covers ::getValue
+     * @covers ::getReason
+     */
+    public function shouldBuildCorrectly()
+    {
+        $input = [
+            'value' => self::SOME_VALUE,
+            'reason' => [
+                'value' => self::SOME_REASON_VALUE,
+                'detail' => self::SOME_REASON_DETAIL,
+            ],
+        ];
+
+        $result = new TaskRecommendationResponse($input);
+
+        $this->assertEquals(self::SOME_VALUE, $result->getValue());
+        $this->assertInstanceOf(TaskRecommendationReasonResponse::class, $result->getReason());
+        $this->assertEquals(self::SOME_REASON_VALUE, $result->getReason()->getValue());
+        $this->assertEquals(self::SOME_REASON_DETAIL, $result->getReason()->getDetail());
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function shouldNotThrowExceptionWhenMissingValues()
+    {
+        $result = new TaskRecommendationResponse([]);
+
+        $this->assertNull($result->getValue());
+        $this->assertNull($result->getReason());
+    }
+}

--- a/tests/DocScan/Session/Retrieve/TaskResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/TaskResponseTest.php
@@ -7,6 +7,8 @@ namespace Yoti\Test\DocScan\Session\Retrieve;
 use Yoti\DocScan\Session\Retrieve\GeneratedCheckResponse;
 use Yoti\DocScan\Session\Retrieve\GeneratedMedia;
 use Yoti\DocScan\Session\Retrieve\GeneratedTextDataCheckResponse;
+use Yoti\DocScan\Session\Retrieve\TaskRecommendationReasonResponse;
+use Yoti\DocScan\Session\Retrieve\TaskRecommendationResponse;
 use Yoti\DocScan\Session\Retrieve\TaskResponse;
 use Yoti\Test\TestCase;
 use Yoti\Util\DateTime;
@@ -25,6 +27,9 @@ class TaskResponseTest extends TestCase
     private const SOME_UNKNOWN_TYPE = 'someUnknownType';
     private const ID_DOCUMENT_TEXT_DATA_CHECK = 'ID_DOCUMENT_TEXT_DATA_CHECK';
     private const SUPPLEMENTARY_DOCUMENT_TEXT_DATA_CHECK = 'SUPPLEMENTARY_DOCUMENT_TEXT_DATA_CHECK';
+    private const SOME_RECOMMENDATION_VALUE = 'MUST_TRY_AGAIN';
+    private const SOME_RECOMMENDATION_REASON_VALUE = 'USER_ERROR';
+    private const SOME_RECOMMENDATION_REASON_DETAIL = 'NO_DOCUMENT';
 
     /**
      * @var TaskResponse
@@ -56,6 +61,13 @@ class TaskResponseTest extends TestCase
             'generated_media' => [
                 [],
                 [],
+            ],
+            'recommendation' => [
+                'value' => self::SOME_RECOMMENDATION_VALUE,
+                'reason' => [
+                    'value' => self::SOME_RECOMMENDATION_REASON_VALUE,
+                    'detail' => self::SOME_RECOMMENDATION_REASON_DETAIL,
+                ],
             ],
          ]);
     }
@@ -185,5 +197,22 @@ class TaskResponseTest extends TestCase
         $this->assertNull($result->getLastUpdated());
         $this->assertCount(0, $result->getGeneratedChecks());
         $this->assertCount(0, $result->getGeneratedMedia());
+        $this->assertNull($result->getRecommendation());
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     * @covers ::getRecommendation
+     */
+    public function shouldReturnRecommendation()
+    {
+        $recommendation = $this->taskResponse->getRecommendation();
+
+        $this->assertInstanceOf(TaskRecommendationResponse::class, $recommendation);
+        $this->assertEquals(self::SOME_RECOMMENDATION_VALUE, $recommendation->getValue());
+        $this->assertInstanceOf(TaskRecommendationReasonResponse::class, $recommendation->getReason());
+        $this->assertEquals(self::SOME_RECOMMENDATION_REASON_VALUE, $recommendation->getReason()->getValue());
+        $this->assertEquals(self::SOME_RECOMMENDATION_REASON_DETAIL, $recommendation->getReason()->getDetail());
     }
 }


### PR DESCRIPTION
## SDK-2793: Preserve recommendation in TaskResponse

### Problem
The `TaskResponse` class did not deserialize or preserve the `recommendation` field returned by the API. When a task response included a recommendation (e.g. `MUST_TRY_AGAIN` with a reason), this data was silently discarded


- **`TaskRecommendationResponse`** — holds `value` (string) and `reason` (TaskRecommendationReasonResponse)
- **`TaskRecommendationReasonResponse`** — holds `value` (string) and `detail` (string)

### Example payload now supported
```json
{
  "type": "ID_DOCUMENT_TEXT_DATA_EXTRACTION",
  "id": "b54287a1-...",
  "state": "DONE",
  "recommendation": {
    "value": "MUST_TRY_AGAIN",
    "reason": {
      "value": "USER_ERROR",
      "detail": "NO_DOCUMENT"
    }
  }
}