### PR TITLE
SDK-2215 allow rb to supply an applicant profile for identity profile…

### DIFF
--- a/src/DocScan/Session/Create/ApplicantProfile.php
+++ b/src/DocScan/Session/Create/ApplicantProfile.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create;
+
+use JsonSerializable;
+use stdClass;
+use Yoti\Util\Json;
+
+class ApplicantProfile implements JsonSerializable
+{
+    /**
+     * @var string|null
+     */
+    private $fullName;
+
+    /**
+     * @var string|null
+     */
+    private $dateOfBirth;
+
+    /**
+     * @var string|null
+     */
+    private $namePrefix;
+
+    /**
+     * @var StructuredPostalAddress|null
+     */
+    private $structuredPostalAddress;
+
+    /**
+     * @param string|null $fullName
+     * @param string|null $dateOfBirth
+     * @param string|null $namePrefix
+     * @param StructuredPostalAddress|null $structuredPostalAddress
+     */
+    public function __construct(
+        ?string $fullName,
+        ?string $dateOfBirth,
+        ?string $namePrefix,
+        ?StructuredPostalAddress $structuredPostalAddress
+    ) {
+        $this->fullName = $fullName;
+        $this->dateOfBirth = $dateOfBirth;
+        $this->namePrefix = $namePrefix;
+        $this->structuredPostalAddress = $structuredPostalAddress;
+    }
+
+    /**
+     * @return stdClass
+     */
+    public function jsonSerialize(): stdClass
+    {
+        return (object) Json::withoutNullValues([
+            'full_name' => $this->fullName,
+            'date_of_birth' => $this->dateOfBirth,
+            'name_prefix' => $this->namePrefix,
+            'structured_postal_address' => $this->structuredPostalAddress,
+        ]);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFullName(): ?string
+    {
+        return $this->fullName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDateOfBirth(): ?string
+    {
+        return $this->dateOfBirth;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getNamePrefix(): ?string
+    {
+        return $this->namePrefix;
+    }
+
+    /**
+     * @return StructuredPostalAddress|null
+     */
+    public function getStructuredPostalAddress(): ?StructuredPostalAddress
+    {
+        return $this->structuredPostalAddress;
+    }
+}

--- a/src/DocScan/Session/Create/ApplicantProfileBuilder.php
+++ b/src/DocScan/Session/Create/ApplicantProfileBuilder.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create;
+
+class ApplicantProfileBuilder
+{
+    /**
+     * @var string|null
+     */
+    private $fullName;
+
+    /**
+     * @var string|null
+     */
+    private $dateOfBirth;
+
+    /**
+     * @var string|null
+     */
+    private $namePrefix;
+
+    /**
+     * @var StructuredPostalAddress|null
+     */
+    private $structuredPostalAddress;
+
+    /**
+     * @param string $fullName
+     * @return $this
+     */
+    public function withFullName(string $fullName): self
+    {
+        $this->fullName = $fullName;
+        return $this;
+    }
+
+    /**
+     * @param string $dateOfBirth
+     * @return $this
+     */
+    public function withDateOfBirth(string $dateOfBirth): self
+    {
+        $this->dateOfBirth = $dateOfBirth;
+        return $this;
+    }
+
+    /**
+     * @param string $namePrefix
+     * @return $this
+     */
+    public function withNamePrefix(string $namePrefix): self
+    {
+        $this->namePrefix = $namePrefix;
+        return $this;
+    }
+
+    /**
+     * @param StructuredPostalAddress $structuredPostalAddress
+     * @return $this
+     */
+    public function withStructuredPostalAddress(StructuredPostalAddress $structuredPostalAddress): self
+    {
+        $this->structuredPostalAddress = $structuredPostalAddress;
+        return $this;
+    }
+
+    /**
+     * @return ApplicantProfile
+     */
+    public function build(): ApplicantProfile
+    {
+        return new ApplicantProfile(
+            $this->fullName,
+            $this->dateOfBirth,
+            $this->namePrefix,
+            $this->structuredPostalAddress
+        );
+    }
+}

--- a/src/DocScan/Session/Create/ResourceCreationContainer.php
+++ b/src/DocScan/Session/Create/ResourceCreationContainer.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create;
+
+use JsonSerializable;
+use stdClass;
+use Yoti\Util\Json;
+
+class ResourceCreationContainer implements JsonSerializable
+{
+    /**
+     * @var ApplicantProfile|null
+     */
+    private $applicantProfile;
+
+    /**
+     * @param ApplicantProfile|null $applicantProfile
+     */
+    public function __construct(?ApplicantProfile $applicantProfile)
+    {
+        $this->applicantProfile = $applicantProfile;
+    }
+
+    /**
+     * @return stdClass
+     */
+    public function jsonSerialize(): stdClass
+    {
+        return (object) Json::withoutNullValues([
+            'applicant_profile' => $this->applicantProfile,
+        ]);
+    }
+
+    /**
+     * @return ApplicantProfile|null
+     */
+    public function getApplicantProfile(): ?ApplicantProfile
+    {
+        return $this->applicantProfile;
+    }
+}

--- a/src/DocScan/Session/Create/ResourceCreationContainerBuilder.php
+++ b/src/DocScan/Session/Create/ResourceCreationContainerBuilder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create;
+
+class ResourceCreationContainerBuilder
+{
+    /**
+     * @var ApplicantProfile|null
+     */
+    private $applicantProfile;
+
+    /**
+     * @param ApplicantProfile $applicantProfile
+     * @return $this
+     */
+    public function withApplicantProfile(ApplicantProfile $applicantProfile): self
+    {
+        $this->applicantProfile = $applicantProfile;
+        return $this;
+    }
+
+    /**
+     * @return ResourceCreationContainer
+     */
+    public function build(): ResourceCreationContainer
+    {
+        return new ResourceCreationContainer(
+            $this->applicantProfile
+        );
+    }
+}

--- a/src/DocScan/Session/Create/SessionSpecification.php
+++ b/src/DocScan/Session/Create/SessionSpecification.php
@@ -91,6 +91,11 @@ class SessionSpecification implements JsonSerializable
     private $importToken;
 
     /**
+     * @var ResourceCreationContainer|null
+     */
+    private $resources;
+
+    /**
      * @param int|null $clientSessionTokenTtl
      * @param string|null $sessionDeadline
      * @param int|null $resourcesTtl
@@ -107,6 +112,7 @@ class SessionSpecification implements JsonSerializable
      * @param object|null $advancedIdentityProfileRequirements
      * @param bool|null $createIdentityProfilePreview
      * @param ImportToken|null $importToken
+     * @param ResourceCreationContainer|null $resources
      */
     public function __construct(
         ?int $clientSessionTokenTtl,
@@ -124,7 +130,8 @@ class SessionSpecification implements JsonSerializable
         ?object $identityProfileRequirements = null,
         ?object $advancedIdentityProfileRequirements = null,
         ?bool $createIdentityProfilePreview = null,
-        ?ImportToken $importToken = null
+        ?ImportToken $importToken = null,
+        ?ResourceCreationContainer $resources = null
     ) {
         $this->clientSessionTokenTtl = $clientSessionTokenTtl;
         $this->sessionDeadline = $sessionDeadline;
@@ -142,6 +149,7 @@ class SessionSpecification implements JsonSerializable
         $this->advancedIdentityProfileRequirements = $advancedIdentityProfileRequirements;
         $this->createIdentityProfilePreview = $createIdentityProfilePreview;
         $this->importToken = $importToken;
+        $this->resources = $resources;
     }
 
     /**
@@ -166,6 +174,7 @@ class SessionSpecification implements JsonSerializable
             'advanced_identity_profile_requirements' => $this->getAdvancedIdentityProfileRequirements(),
             'create_identity_profile_preview' => $this->getCreateIdentityProfilePreview(),
             'import_token' => $this->getImportToken(),
+            'resources' => $this->getResources(),
         ]);
     }
 
@@ -294,5 +303,13 @@ class SessionSpecification implements JsonSerializable
     public function getImportToken(): ?ImportToken
     {
         return $this->importToken;
+    }
+
+    /**
+     * @return ResourceCreationContainer|null
+     */
+    public function getResources(): ?ResourceCreationContainer
+    {
+        return $this->resources;
     }
 }

--- a/src/DocScan/Session/Create/SessionSpecificationBuilder.php
+++ b/src/DocScan/Session/Create/SessionSpecificationBuilder.php
@@ -89,6 +89,11 @@ class SessionSpecificationBuilder
     private $importToken;
 
     /**
+     * @var ResourceCreationContainer|null
+     */
+    private $resources;
+
+    /**
      * @var bool
      */
     private bool $createIdentityProfilePreview = false;
@@ -293,6 +298,19 @@ class SessionSpecificationBuilder
     }
 
     /**
+     * Sets the resources for the session
+     *
+     * @param ResourceCreationContainer $resources
+     *
+     * @return $this
+     */
+    public function withResources(ResourceCreationContainer $resources): self
+    {
+        $this->resources = $resources;
+        return $this;
+    }
+
+    /**
      * @return SessionSpecification
      */
     public function build(): SessionSpecification
@@ -314,6 +332,7 @@ class SessionSpecificationBuilder
             $this->advancedIdentityProfileRequirements,
             $this->createIdentityProfilePreview,
             $this->importToken,
+            $this->resources,
         );
     }
 }

--- a/src/DocScan/Session/Create/StructuredPostalAddress.php
+++ b/src/DocScan/Session/Create/StructuredPostalAddress.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create;
+
+use JsonSerializable;
+use stdClass;
+use Yoti\Util\Json;
+
+class StructuredPostalAddress implements JsonSerializable
+{
+    /**
+     * @var int|null
+     */
+    private $addressFormat;
+
+    /**
+     * @var string|null
+     */
+    private $buildingNumber;
+
+    /**
+     * @var string|null
+     */
+    private $addressLine1;
+
+    /**
+     * @var string|null
+     */
+    private $townCity;
+
+    /**
+     * @var string|null
+     */
+    private $postalCode;
+
+    /**
+     * @var string|null
+     */
+    private $countryIso;
+
+    /**
+     * @var string|null
+     */
+    private $country;
+
+    /**
+     * @var string|null
+     */
+    private $formattedAddress;
+
+    /**
+     * @param int|null $addressFormat
+     * @param string|null $buildingNumber
+     * @param string|null $addressLine1
+     * @param string|null $townCity
+     * @param string|null $postalCode
+     * @param string|null $countryIso
+     * @param string|null $country
+     * @param string|null $formattedAddress
+     */
+    public function __construct(
+        ?int $addressFormat,
+        ?string $buildingNumber,
+        ?string $addressLine1,
+        ?string $townCity,
+        ?string $postalCode,
+        ?string $countryIso,
+        ?string $country,
+        ?string $formattedAddress
+    ) {
+        $this->addressFormat = $addressFormat;
+        $this->buildingNumber = $buildingNumber;
+        $this->addressLine1 = $addressLine1;
+        $this->townCity = $townCity;
+        $this->postalCode = $postalCode;
+        $this->countryIso = $countryIso;
+        $this->country = $country;
+        $this->formattedAddress = $formattedAddress;
+    }
+
+    /**
+     * @return stdClass
+     */
+    public function jsonSerialize(): stdClass
+    {
+        return (object) Json::withoutNullValues([
+            'address_format' => $this->addressFormat,
+            'building_number' => $this->buildingNumber,
+            'address_line1' => $this->addressLine1,
+            'town_city' => $this->townCity,
+            'postal_code' => $this->postalCode,
+            'country_iso' => $this->countryIso,
+            'country' => $this->country,
+            'formatted_address' => $this->formattedAddress,
+        ]);
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getAddressFormat(): ?int
+    {
+        return $this->addressFormat;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getBuildingNumber(): ?string
+    {
+        return $this->buildingNumber;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAddressLine1(): ?string
+    {
+        return $this->addressLine1;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTownCity(): ?string
+    {
+        return $this->townCity;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPostalCode(): ?string
+    {
+        return $this->postalCode;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCountryIso(): ?string
+    {
+        return $this->countryIso;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCountry(): ?string
+    {
+        return $this->country;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFormattedAddress(): ?string
+    {
+        return $this->formattedAddress;
+    }
+}

--- a/src/DocScan/Session/Create/StructuredPostalAddressBuilder.php
+++ b/src/DocScan/Session/Create/StructuredPostalAddressBuilder.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create;
+
+class StructuredPostalAddressBuilder
+{
+    /**
+     * @var int|null
+     */
+    private $addressFormat;
+
+    /**
+     * @var string|null
+     */
+    private $buildingNumber;
+
+    /**
+     * @var string|null
+     */
+    private $addressLine1;
+
+    /**
+     * @var string|null
+     */
+    private $townCity;
+
+    /**
+     * @var string|null
+     */
+    private $postalCode;
+
+    /**
+     * @var string|null
+     */
+    private $countryIso;
+
+    /**
+     * @var string|null
+     */
+    private $country;
+
+    /**
+     * @var string|null
+     */
+    private $formattedAddress;
+
+    /**
+     * @param int $addressFormat
+     * @return $this
+     */
+    public function withAddressFormat(int $addressFormat): self
+    {
+        $this->addressFormat = $addressFormat;
+        return $this;
+    }
+
+    /**
+     * @param string $buildingNumber
+     * @return $this
+     */
+    public function withBuildingNumber(string $buildingNumber): self
+    {
+        $this->buildingNumber = $buildingNumber;
+        return $this;
+    }
+
+    /**
+     * @param string $addressLine1
+     * @return $this
+     */
+    public function withAddressLine1(string $addressLine1): self
+    {
+        $this->addressLine1 = $addressLine1;
+        return $this;
+    }
+
+    /**
+     * @param string $townCity
+     * @return $this
+     */
+    public function withTownCity(string $townCity): self
+    {
+        $this->townCity = $townCity;
+        return $this;
+    }
+
+    /**
+     * @param string $postalCode
+     * @return $this
+     */
+    public function withPostalCode(string $postalCode): self
+    {
+        $this->postalCode = $postalCode;
+        return $this;
+    }
+
+    /**
+     * @param string $countryIso
+     * @return $this
+     */
+    public function withCountryIso(string $countryIso): self
+    {
+        $this->countryIso = $countryIso;
+        return $this;
+    }
+
+    /**
+     * @param string $country
+     * @return $this
+     */
+    public function withCountry(string $country): self
+    {
+        $this->country = $country;
+        return $this;
+    }
+
+    /**
+     * @param string $formattedAddress
+     * @return $this
+     */
+    public function withFormattedAddress(string $formattedAddress): self
+    {
+        $this->formattedAddress = $formattedAddress;
+        return $this;
+    }
+
+    /**
+     * @return StructuredPostalAddress
+     */
+    public function build(): StructuredPostalAddress
+    {
+        return new StructuredPostalAddress(
+            $this->addressFormat,
+            $this->buildingNumber,
+            $this->addressLine1,
+            $this->townCity,
+            $this->postalCode,
+            $this->countryIso,
+            $this->country,
+            $this->formattedAddress
+        );
+    }
+}

--- a/tests/DocScan/Session/Create/ApplicantProfileBuilderTest.php
+++ b/tests/DocScan/Session/Create/ApplicantProfileBuilderTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Test\DocScan\Session\Create;
+
+use Yoti\DocScan\Session\Create\ApplicantProfileBuilder;
+use Yoti\DocScan\Session\Create\StructuredPostalAddressBuilder;
+use Yoti\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\DocScan\Session\Create\ApplicantProfileBuilder
+ */
+class ApplicantProfileBuilderTest extends TestCase
+{
+    private const SOME_FULL_NAME = 'John Doe';
+    private const SOME_DATE_OF_BIRTH = '1988-11-02';
+    private const SOME_NAME_PREFIX = 'Mr';
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers ::withFullName
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::__construct
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::getFullName
+     */
+    public function shouldBuildWithFullName()
+    {
+        $profile = (new ApplicantProfileBuilder())
+            ->withFullName(self::SOME_FULL_NAME)
+            ->build();
+
+        $this->assertEquals(self::SOME_FULL_NAME, $profile->getFullName());
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers ::withDateOfBirth
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::__construct
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::getDateOfBirth
+     */
+    public function shouldBuildWithDateOfBirth()
+    {
+        $profile = (new ApplicantProfileBuilder())
+            ->withDateOfBirth(self::SOME_DATE_OF_BIRTH)
+            ->build();
+
+        $this->assertEquals(self::SOME_DATE_OF_BIRTH, $profile->getDateOfBirth());
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers ::withNamePrefix
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::__construct
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::getNamePrefix
+     */
+    public function shouldBuildWithNamePrefix()
+    {
+        $profile = (new ApplicantProfileBuilder())
+            ->withNamePrefix(self::SOME_NAME_PREFIX)
+            ->build();
+
+        $this->assertEquals(self::SOME_NAME_PREFIX, $profile->getNamePrefix());
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers ::withStructuredPostalAddress
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::__construct
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::getStructuredPostalAddress
+     */
+    public function shouldBuildWithStructuredPostalAddress()
+    {
+        $address = (new StructuredPostalAddressBuilder())
+            ->withBuildingNumber('74')
+            ->withPostalCode('E143RN')
+            ->build();
+
+        $profile = (new ApplicantProfileBuilder())
+            ->withStructuredPostalAddress($address)
+            ->build();
+
+        $this->assertEquals('74', $profile->getStructuredPostalAddress()->getBuildingNumber());
+        $this->assertEquals('E143RN', $profile->getStructuredPostalAddress()->getPostalCode());
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::jsonSerialize
+     */
+    public function shouldCorrectlySerializeWithAllProperties()
+    {
+        $address = (new StructuredPostalAddressBuilder())
+            ->withAddressFormat(1)
+            ->withBuildingNumber('74')
+            ->withAddressLine1('AddressLine1')
+            ->withTownCity('CityName')
+            ->withPostalCode('E143RN')
+            ->withCountryIso('GBR')
+            ->withCountry('United Kingdom')
+            ->build();
+
+        $profile = (new ApplicantProfileBuilder())
+            ->withFullName(self::SOME_FULL_NAME)
+            ->withDateOfBirth(self::SOME_DATE_OF_BIRTH)
+            ->withNamePrefix(self::SOME_NAME_PREFIX)
+            ->withStructuredPostalAddress($address)
+            ->build();
+
+        $json = json_encode($profile);
+
+        $this->assertStringContainsString('"full_name":"John Doe"', $json);
+        $this->assertStringContainsString('"date_of_birth":"1988-11-02"', $json);
+        $this->assertStringContainsString('"name_prefix":"Mr"', $json);
+        $this->assertStringContainsString('"structured_postal_address"', $json);
+        $this->assertStringContainsString('"building_number":"74"', $json);
+        $this->assertStringContainsString('"country_iso":"GBR"', $json);
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::jsonSerialize
+     */
+    public function shouldSerializeWithoutNullValues()
+    {
+        $profile = (new ApplicantProfileBuilder())
+            ->withFullName(self::SOME_FULL_NAME)
+            ->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'full_name' => self::SOME_FULL_NAME,
+            ]),
+            json_encode($profile)
+        );
+    }
+}

--- a/tests/DocScan/Session/Create/ResourceCreationContainerBuilderTest.php
+++ b/tests/DocScan/Session/Create/ResourceCreationContainerBuilderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Test\DocScan\Session\Create;
+
+use Yoti\DocScan\Session\Create\ApplicantProfileBuilder;
+use Yoti\DocScan\Session\Create\ResourceCreationContainerBuilder;
+use Yoti\DocScan\Session\Create\StructuredPostalAddressBuilder;
+use Yoti\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\DocScan\Session\Create\ResourceCreationContainerBuilder
+ */
+class ResourceCreationContainerBuilderTest extends TestCase
+{
+    /**
+     * @test
+     * @covers ::build
+     * @covers ::withApplicantProfile
+     * @covers \Yoti\DocScan\Session\Create\ResourceCreationContainer::__construct
+     * @covers \Yoti\DocScan\Session\Create\ResourceCreationContainer::getApplicantProfile
+     */
+    public function shouldBuildWithApplicantProfile()
+    {
+        $applicantProfile = (new ApplicantProfileBuilder())
+            ->withFullName('John Doe')
+            ->withDateOfBirth('1988-11-02')
+            ->build();
+
+        $container = (new ResourceCreationContainerBuilder())
+            ->withApplicantProfile($applicantProfile)
+            ->build();
+
+        $this->assertEquals($applicantProfile, $container->getApplicantProfile());
+        $this->assertEquals('John Doe', $container->getApplicantProfile()->getFullName());
+        $this->assertEquals('1988-11-02', $container->getApplicantProfile()->getDateOfBirth());
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\ResourceCreationContainer::jsonSerialize
+     */
+    public function shouldCorrectlySerializeApplicantProfile()
+    {
+        $address = (new StructuredPostalAddressBuilder())
+            ->withAddressFormat(1)
+            ->withBuildingNumber('74')
+            ->withAddressLine1('AddressLine1')
+            ->withTownCity('CityName')
+            ->withPostalCode('E143RN')
+            ->withCountryIso('GBR')
+            ->withCountry('United Kingdom')
+            ->build();
+
+        $applicantProfile = (new ApplicantProfileBuilder())
+            ->withFullName('John Doe')
+            ->withDateOfBirth('1988-11-02')
+            ->withNamePrefix('Mr')
+            ->withStructuredPostalAddress($address)
+            ->build();
+
+        $container = (new ResourceCreationContainerBuilder())
+            ->withApplicantProfile($applicantProfile)
+            ->build();
+
+        $json = json_encode($container);
+
+        $this->assertStringContainsString('"applicant_profile"', $json);
+        $this->assertStringContainsString('"full_name":"John Doe"', $json);
+        $this->assertStringContainsString('"date_of_birth":"1988-11-02"', $json);
+        $this->assertStringContainsString('"name_prefix":"Mr"', $json);
+        $this->assertStringContainsString('"building_number":"74"', $json);
+        $this->assertStringContainsString('"country_iso":"GBR"', $json);
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\ResourceCreationContainer::jsonSerialize
+     */
+    public function shouldSerializeWithoutNullValues()
+    {
+        $container = (new ResourceCreationContainerBuilder())
+            ->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode(new \stdClass()),
+            json_encode($container)
+        );
+    }
+}

--- a/tests/DocScan/Session/Create/SessionSpecificationBuilderTest.php
+++ b/tests/DocScan/Session/Create/SessionSpecificationBuilderTest.php
@@ -9,6 +9,7 @@ use Yoti\DocScan\Session\Create\Filters\RequiredDocument;
 use Yoti\DocScan\Session\Create\IbvOptions;
 use Yoti\DocScan\Session\Create\ImportToken;
 use Yoti\DocScan\Session\Create\NotificationConfig;
+use Yoti\DocScan\Session\Create\ResourceCreationContainer;
 use Yoti\DocScan\Session\Create\SdkConfig;
 use Yoti\DocScan\Session\Create\SessionSpecificationBuilder;
 use Yoti\DocScan\Session\Create\Task\RequestedTask;
@@ -73,6 +74,11 @@ class SessionSpecificationBuilderTest extends TestCase
      */
     private $importTokenMock;
 
+    /**
+     * @var ResourceCreationContainer
+     */
+    private $resourcesMock;
+
     public function setup(): void
     {
         $this->sdkConfigMock = $this->createMock(SdkConfig::class);
@@ -93,6 +99,11 @@ class SessionSpecificationBuilderTest extends TestCase
         $this->ibvOptionsMock = $this->createMock(IbvOptions::class);
 
         $this->importTokenMock = $this->createMock(ImportToken::class);
+
+        $this->resourcesMock = $this->createMock(ResourceCreationContainer::class);
+        $this->resourcesMock
+            ->method('jsonSerialize')
+            ->willReturn((object)['applicant_profile' => (object)['full_name' => 'John Doe']]);
 
         $this->subject = (object)[1 => 'some'];
 
@@ -601,6 +612,60 @@ class SessionSpecificationBuilderTest extends TestCase
                 'required_documents' => [],
                 'create_identity_profile_preview' => false,
                 'advanced_identity_profile_requirements' => $this->advancedIdentityProfileRequirements,
+            ]),
+            json_encode($sessionSpecification)
+        );
+    }
+
+    /**
+     * @test
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecification::getResources
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecification::__construct
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecificationBuilder::withResources
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecificationBuilder::build
+     */
+    public function shouldBuildWithResources()
+    {
+        $sessionSpecificationResult = (new SessionSpecificationBuilder())
+            ->withResources($this->resourcesMock)
+            ->build();
+
+        $this->assertEquals($this->resourcesMock, $sessionSpecificationResult->getResources());
+    }
+
+    /**
+     * @test
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecification::getResources
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecification::__construct
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecificationBuilder::build
+     */
+    public function shouldNotImplicitlySetAValueForResources()
+    {
+        $sessionSpecificationResult = (new SessionSpecificationBuilder())
+            ->build();
+
+        $this->assertNull($sessionSpecificationResult->getResources());
+    }
+
+    /**
+     * @test
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecification::jsonSerialize
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecificationBuilder::withResources
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecificationBuilder::build
+     */
+    public function shouldReturnCorrectJsonStringWithResources()
+    {
+        $sessionSpecification = (new SessionSpecificationBuilder())
+            ->withResources($this->resourcesMock)
+            ->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'requested_checks' => [],
+                'requested_tasks' => [],
+                'required_documents' => [],
+                'create_identity_profile_preview' => false,
+                'resources' => $this->resourcesMock,
             ]),
             json_encode($sessionSpecification)
         );

--- a/tests/DocScan/Session/Create/StructuredPostalAddressBuilderTest.php
+++ b/tests/DocScan/Session/Create/StructuredPostalAddressBuilderTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Test\DocScan\Session\Create;
+
+use Yoti\DocScan\Session\Create\StructuredPostalAddressBuilder;
+use Yoti\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\DocScan\Session\Create\StructuredPostalAddressBuilder
+ */
+class StructuredPostalAddressBuilderTest extends TestCase
+{
+    private const SOME_ADDRESS_FORMAT = 1;
+    private const SOME_BUILDING_NUMBER = '74';
+    private const SOME_ADDRESS_LINE_1 = 'AddressLine1';
+    private const SOME_TOWN_CITY = 'CityName';
+    private const SOME_POSTAL_CODE = 'E143RN';
+    private const SOME_COUNTRY_ISO = 'GBR';
+    private const SOME_COUNTRY = 'United Kingdom';
+    private const SOME_FORMATTED_ADDRESS = "74\nAddressLine1\nCityName\nE143RN\nGBR";
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers ::withAddressFormat
+     * @covers ::withBuildingNumber
+     * @covers ::withAddressLine1
+     * @covers ::withTownCity
+     * @covers ::withPostalCode
+     * @covers ::withCountryIso
+     * @covers ::withCountry
+     * @covers ::withFormattedAddress
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::__construct
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getAddressFormat
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getBuildingNumber
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getAddressLine1
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getTownCity
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getPostalCode
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getCountryIso
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getCountry
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getFormattedAddress
+     */
+    public function shouldBuildWithAllProperties()
+    {
+        $address = (new StructuredPostalAddressBuilder())
+            ->withAddressFormat(self::SOME_ADDRESS_FORMAT)
+            ->withBuildingNumber(self::SOME_BUILDING_NUMBER)
+            ->withAddressLine1(self::SOME_ADDRESS_LINE_1)
+            ->withTownCity(self::SOME_TOWN_CITY)
+            ->withPostalCode(self::SOME_POSTAL_CODE)
+            ->withCountryIso(self::SOME_COUNTRY_ISO)
+            ->withCountry(self::SOME_COUNTRY)
+            ->withFormattedAddress(self::SOME_FORMATTED_ADDRESS)
+            ->build();
+
+        $this->assertEquals(self::SOME_ADDRESS_FORMAT, $address->getAddressFormat());
+        $this->assertEquals(self::SOME_BUILDING_NUMBER, $address->getBuildingNumber());
+        $this->assertEquals(self::SOME_ADDRESS_LINE_1, $address->getAddressLine1());
+        $this->assertEquals(self::SOME_TOWN_CITY, $address->getTownCity());
+        $this->assertEquals(self::SOME_POSTAL_CODE, $address->getPostalCode());
+        $this->assertEquals(self::SOME_COUNTRY_ISO, $address->getCountryIso());
+        $this->assertEquals(self::SOME_COUNTRY, $address->getCountry());
+        $this->assertEquals(self::SOME_FORMATTED_ADDRESS, $address->getFormattedAddress());
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::jsonSerialize
+     */
+    public function shouldCorrectlySerialize()
+    {
+        $address = (new StructuredPostalAddressBuilder())
+            ->withAddressFormat(self::SOME_ADDRESS_FORMAT)
+            ->withBuildingNumber(self::SOME_BUILDING_NUMBER)
+            ->withAddressLine1(self::SOME_ADDRESS_LINE_1)
+            ->withTownCity(self::SOME_TOWN_CITY)
+            ->withPostalCode(self::SOME_POSTAL_CODE)
+            ->withCountryIso(self::SOME_COUNTRY_ISO)
+            ->withCountry(self::SOME_COUNTRY)
+            ->withFormattedAddress(self::SOME_FORMATTED_ADDRESS)
+            ->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'address_format' => self::SOME_ADDRESS_FORMAT,
+                'building_number' => self::SOME_BUILDING_NUMBER,
+                'address_line1' => self::SOME_ADDRESS_LINE_1,
+                'town_city' => self::SOME_TOWN_CITY,
+                'postal_code' => self::SOME_POSTAL_CODE,
+                'country_iso' => self::SOME_COUNTRY_ISO,
+                'country' => self::SOME_COUNTRY,
+                'formatted_address' => self::SOME_FORMATTED_ADDRESS,
+            ]),
+            json_encode($address)
+        );
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::jsonSerialize
+     */
+    public function shouldSerializeWithoutNullValues()
+    {
+        $address = (new StructuredPostalAddressBuilder())
+            ->withBuildingNumber(self::SOME_BUILDING_NUMBER)
+            ->withPostalCode(self::SOME_POSTAL_CODE)
+            ->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'building_number' => self::SOME_BUILDING_NUMBER,
+                'postal_code' => self::SOME_POSTAL_CODE,
+            ]),
+            json_encode($address)
+        );
+    }
+}


### PR DESCRIPTION
## SDK-2215: Allow RB to supply an applicant profile for Identity Profile sessions

### Problem
Businesses had no way to provide an applicant profile when creating Identity Profile sessions via the SDK. The API already supports an `applicant_profile` object nested under `resources` in the session creation payload, but the PHP SDK did not expose this capability.

### Solution
Added full support for building and serializing `applicant_profile` within the `resources` section of the session creation payload. This follows the same builder pattern used throughout the SDK and mirrors the existing .NET SDK implementation.


```php
<?php
$address = (new StructuredPostalAddressBuilder())
    ->withAddressFormat(1)
    ->withBuildingNumber('74')
    ->withAddressLine1('AddressLine1')
    ->withTownCity('CityName')
    ->withPostalCode('E143RN')
    ->withCountryIso('GBR')
    ->withCountry('United Kingdom')
    ->build();

$applicantProfile = (new ApplicantProfileBuilder())
    ->withFullName('John Doe')
    ->withDateOfBirth('1988-11-02')
    ->withNamePrefix('Mr')
    ->withStructuredPostalAddress($address)
    ->build();

$resources = (new ResourceCreationContainerBuilder())
    ->withApplicantProfile($applicantProfile)
    ->build();

$sessionSpec = (new SessionSpecificationBuilder())
    ->withResources($resources)
    // ... other session settings
    ->build();
   ```