### PR TITLE
Sdk 2795 php upgrade to protobuf 4 33 6 and phpseclib 3 0 50

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,8 +8,8 @@ jobs:
     # always run on push events
     # only run on pull_request_target event when pull request pulls from fork repository
     if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository 
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:
@@ -31,11 +31,61 @@ jobs:
 
       - run: composer test
 
+  php8-2:
+    name: Unit Tests php8.2 (php ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ 8.2 ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@2.9.0
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - run: composer remove --dev --no-update --no-interaction friendsofphp/php-cs-fixer
+
+      - run: composer self-update
+
+      - run: composer install --no-interaction --prefer-source --dev
+
+      - run: composer test
+
+  php8-3:
+    name: Unit Tests php8.3 (php ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ 8.3 ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@2.9.0
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - run: composer remove --dev --no-update --no-interaction friendsofphp/php-cs-fixer
+
+      - run: composer self-update
+
+      - run: composer install --no-interaction --prefer-source --dev
+
+      - run: composer test
+
   php8-4:
     name: Unit Tests php8.4 (php ${{ matrix.php-version }})
     runs-on: ubuntu-latest
-    # always run on push events
-    # only run on pull_request_target event when pull request pulls from fork repository
     if: >
       github.event_name == 'push' ||
       github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
@@ -51,8 +101,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
 
-      # Remove php-cs-fixer until compatible with PHP 8
-      # This step might be removable if php-cs-fixer is compatible with 8.4 by the time this runs
       - run: composer remove --dev --no-update --no-interaction friendsofphp/php-cs-fixer
 
       - run: composer self-update
@@ -61,66 +109,14 @@ jobs:
 
       - run: composer test
 
-  php7-4:
-    name: Unit Tests php7.4 (php ${{ matrix.php-version }})
-    runs-on: ubuntu-latest
-    # always run on push events
-    # only run on pull_request_target event when pull request pulls from fork repository
-    if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version: [ 7.4 ]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: shivammathur/setup-php@2.9.0
-        with:
-          php-version: ${{ matrix.php-version }}
-
-      - run: composer self-update
-
-      - run: composer install --no-interaction --prefer-source --dev
-
-      - run: composer test
-
-  php8-0:
-    name: Unit Tests php8.0 (php ${{ matrix.php-version }})
-    runs-on: ubuntu-latest
-    # always run on push events
-    # only run on pull_request_target event when pull request pulls from fork repository
-    if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version: [ 8.0 ]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: shivammathur/setup-php@2.9.0
-        with:
-          php-version: ${{ matrix.php-version }}
-
-      - run: composer self-update
-
-      - run: composer install --no-interaction --prefer-source --dev
-
-      - run: composer test
-
   protobuf:
-    name: Unit Tests With Protobuf C Extension 3.13 (php ${{ matrix.php-version }})
+    name: Unit Tests With Protobuf C Extension (php ${{ matrix.php-version }})
     runs-on: ubuntu-latest
     # always run on push events
     # only run on pull_request_target event when pull request pulls from fork repository
     if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository 
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please feel free to reach out
 
 ## Requirements
 
-* PHP ^7.4 || ^8.0 || ^8.1
+* PHP ^8.1
 * CURL PHP extension (must support TLSv1.2)
 
 ### Recommended (optional)
@@ -42,13 +42,13 @@ Add the Yoti SDK dependency:
 
 ```json
 "require": {
-    "yoti/yoti-php-sdk" : "^4.4.2"
+    "yoti/yoti-php-sdk" : "^4.5.0"
 }
 ```
 
 Or run this Composer command
 ```console
-$ composer require yoti/yoti-php-sdk "^4.4.2"
+$ composer require yoti/yoti-php-sdk "^4.5.0"
 ```
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ Add the Yoti SDK dependency:
 
 ```json
 "require": {
-    "yoti/yoti-php-sdk" : "^4.4.1"
+    "yoti/yoti-php-sdk" : "^4.4.2"
 }
 ```
 
 Or run this Composer command
 ```console
-$ composer require yoti/yoti-php-sdk "^4.4.1"
+$ composer require yoti/yoti-php-sdk "^4.4.2"
 ```
 
 ## Setup

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "yoti/yoti-php-sdk",
   "description": "Yoti SDK for quickly integrating your PHP backend with Yoti",
-  "version": "4.4.2",
+  "version": "4.5.0",
   "keywords": [
     "yoti",
     "sdk"
@@ -9,10 +9,10 @@
   "homepage": "https://yoti.com",
   "license": "MIT",
   "require": {
-    "php": "^7.4 || ^8.0 || ^8.1 || ^8.4",
+    "php": "^8.1",
     "ext-json": "*",
-    "google/protobuf": "^3.10",
-    "phpseclib/phpseclib": "^3.0",
+    "google/protobuf": "^4.33.6",
+    "phpseclib/phpseclib": "^3.0.50",
     "guzzlehttp/guzzle": "^7.0",
     "psr/http-client": "^1.0",
     "psr/http-message": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "yoti/yoti-php-sdk",
   "description": "Yoti SDK for quickly integrating your PHP backend with Yoti",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "keywords": [
     "yoti",
     "sdk"

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -37,7 +37,7 @@ class Constants
     public const SDK_IDENTIFIER = 'PHP';
 
     /** Default SDK version */
-    public const SDK_VERSION = '4.4.2';
+    public const SDK_VERSION = '4.5.0';
 
     /** Base url for connect page (user will be redirected to this page eg. baseurl/app-id) */
     public const CONNECT_BASE_URL = 'https://www.yoti.com/connect';

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -37,7 +37,7 @@ class Constants
     public const SDK_IDENTIFIER = 'PHP';
 
     /** Default SDK version */
-    public const SDK_VERSION = '4.4.1';
+    public const SDK_VERSION = '4.4.2';
 
     /** Base url for connect page (user will be redirected to this page eg. baseurl/app-id) */
     public const CONNECT_BASE_URL = 'https://www.yoti.com/connect';


### PR DESCRIPTION
## Summary

Security update addressing two dependency vulnerabilities. Minimum PHP version raised to 8.1.

## Security Fixes

### google/protobuf — [GHSA-p2gh-cfq4-4wjc](https://github.com/advisories/GHSA-p2gh-cfq4-4wjc) (HIGH)

Denial of Service issue through malicious messages containing negative varints or deep recursion.

- **Affected:** < 4.33.6
- **Patched:** 4.33.6
- **Constraint updated:** `^3.10` → `^4.33.6`

### phpseclib/phpseclib — CVE-2026-32935 (MEDIUM)

AES-CBC padding oracle timing attack.

- **Affected:** <= 3.0.49
- **Patched:** 3.0.50
- **Constraint updated:** `^3.0` → `^3.0.50`

## Breaking Changes

| | Before | After |
|---|---|---|
| **PHP** | `^7.4 \|\| ^8.0 \|\| ^8.1 \|\| ^8.4` | `^8.1` |
| **google/protobuf** | `^3.10` | `^4.33.6` |
| **phpseclib/phpseclib** | `^3.0` | `^3.0.50` |

> ⚠️ PHP 7.4 and 8.0 are no longer supported.

## Changes

- Updated `google/protobuf` constraint to `^4.33.6`
- Updated `phpseclib/phpseclib` constraint to `^3.0.50`
- Updated minimum PHP version to `^8.1`
- Updated CI matrix: PHP 8.1, 8.2, 8.3, 8.4 (removed 7.4, 8.0)
- Bumped SDK version to `4.5.0`