### PR TITLE
Sdk 2791 php add support for retrieving the extraction image ids field from the idv pages

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,8 +8,8 @@ jobs:
     # always run on push events
     # only run on pull_request_target event when pull request pulls from fork repository
     if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository 
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:
@@ -31,11 +31,61 @@ jobs:
 
       - run: composer test
 
+  php8-2:
+    name: Unit Tests php8.2 (php ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ 8.2 ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@2.9.0
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - run: composer remove --dev --no-update --no-interaction friendsofphp/php-cs-fixer
+
+      - run: composer self-update
+
+      - run: composer install --no-interaction --prefer-source --dev
+
+      - run: composer test
+
+  php8-3:
+    name: Unit Tests php8.3 (php ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ 8.3 ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@2.9.0
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - run: composer remove --dev --no-update --no-interaction friendsofphp/php-cs-fixer
+
+      - run: composer self-update
+
+      - run: composer install --no-interaction --prefer-source --dev
+
+      - run: composer test
+
   php8-4:
     name: Unit Tests php8.4 (php ${{ matrix.php-version }})
     runs-on: ubuntu-latest
-    # always run on push events
-    # only run on pull_request_target event when pull request pulls from fork repository
     if: >
       github.event_name == 'push' ||
       github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
@@ -51,8 +101,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
 
-      # Remove php-cs-fixer until compatible with PHP 8
-      # This step might be removable if php-cs-fixer is compatible with 8.4 by the time this runs
       - run: composer remove --dev --no-update --no-interaction friendsofphp/php-cs-fixer
 
       - run: composer self-update
@@ -61,66 +109,14 @@ jobs:
 
       - run: composer test
 
-  php7-4:
-    name: Unit Tests php7.4 (php ${{ matrix.php-version }})
-    runs-on: ubuntu-latest
-    # always run on push events
-    # only run on pull_request_target event when pull request pulls from fork repository
-    if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version: [ 7.4 ]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: shivammathur/setup-php@2.9.0
-        with:
-          php-version: ${{ matrix.php-version }}
-
-      - run: composer self-update
-
-      - run: composer install --no-interaction --prefer-source --dev
-
-      - run: composer test
-
-  php8-0:
-    name: Unit Tests php8.0 (php ${{ matrix.php-version }})
-    runs-on: ubuntu-latest
-    # always run on push events
-    # only run on pull_request_target event when pull request pulls from fork repository
-    if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version: [ 8.0 ]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: shivammathur/setup-php@2.9.0
-        with:
-          php-version: ${{ matrix.php-version }}
-
-      - run: composer self-update
-
-      - run: composer install --no-interaction --prefer-source --dev
-
-      - run: composer test
-
   protobuf:
-    name: Unit Tests With Protobuf C Extension 3.13 (php ${{ matrix.php-version }})
+    name: Unit Tests With Protobuf C Extension (php ${{ matrix.php-version }})
     runs-on: ubuntu-latest
     # always run on push events
     # only run on pull_request_target event when pull request pulls from fork repository
     if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository 
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please feel free to reach out
 
 ## Requirements
 
-* PHP ^7.4 || ^8.0 || ^8.1
+* PHP ^8.1
 * CURL PHP extension (must support TLSv1.2)
 
 ### Recommended (optional)
@@ -42,13 +42,13 @@ Add the Yoti SDK dependency:
 
 ```json
 "require": {
-    "yoti/yoti-php-sdk" : "^4.4.2"
+    "yoti/yoti-php-sdk" : "^4.5.0"
 }
 ```
 
 Or run this Composer command
 ```console
-$ composer require yoti/yoti-php-sdk "^4.4.2"
+$ composer require yoti/yoti-php-sdk "^4.5.0"
 ```
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Please feel free to reach out
 * PHP ^8.1
 * CURL PHP extension (must support TLSv1.2)
 
+> **Breaking change:** this SDK release supports PHP 8.1 and above only.
+> Support for PHP 7.4 and PHP 8.0 has been removed.
+> If you are still running on PHP 7.4/8.0, please remain on an earlier SDK version until you can upgrade your runtime.
 ### Recommended (optional)
 - [Protobuf C extension](https://github.com/protocolbuffers/protobuf/tree/master/php) (PHP package will be used by default)
 

--- a/README.md
+++ b/README.md
@@ -42,13 +42,13 @@ Add the Yoti SDK dependency:
 
 ```json
 "require": {
-    "yoti/yoti-php-sdk" : "^4.4.1"
+    "yoti/yoti-php-sdk" : "^4.4.2"
 }
 ```
 
 Or run this Composer command
 ```console
-$ composer require yoti/yoti-php-sdk "^4.4.1"
+$ composer require yoti/yoti-php-sdk "^4.4.2"
 ```
 
 ## Setup

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "yoti/yoti-php-sdk",
   "description": "Yoti SDK for quickly integrating your PHP backend with Yoti",
-  "version": "4.4.2",
+  "version": "4.5.0",
   "keywords": [
     "yoti",
     "sdk"
@@ -9,10 +9,10 @@
   "homepage": "https://yoti.com",
   "license": "MIT",
   "require": {
-    "php": "^7.4 || ^8.0 || ^8.1 || ^8.4",
+    "php": "^8.1",
     "ext-json": "*",
-    "google/protobuf": "^3.10",
-    "phpseclib/phpseclib": "^3.0",
+    "google/protobuf": "^4.33.6",
+    "phpseclib/phpseclib": "^3.0.50",
     "guzzlehttp/guzzle": "^7.0",
     "psr/http-client": "^1.0",
     "psr/http-message": "^2.0",

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "yoti/yoti-php-sdk",
   "description": "Yoti SDK for quickly integrating your PHP backend with Yoti",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "keywords": [
     "yoti",
     "sdk"

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -37,7 +37,7 @@ class Constants
     public const SDK_IDENTIFIER = 'PHP';
 
     /** Default SDK version */
-    public const SDK_VERSION = '4.4.2';
+    public const SDK_VERSION = '4.5.0';
 
     /** Base url for connect page (user will be redirected to this page eg. baseurl/app-id) */
     public const CONNECT_BASE_URL = 'https://www.yoti.com/connect';

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -37,7 +37,7 @@ class Constants
     public const SDK_IDENTIFIER = 'PHP';
 
     /** Default SDK version */
-    public const SDK_VERSION = '4.4.1';
+    public const SDK_VERSION = '4.4.2';
 
     /** Base url for connect page (user will be redirected to this page eg. baseurl/app-id) */
     public const CONNECT_BASE_URL = 'https://www.yoti.com/connect';

--- a/src/DocScan/Session/Retrieve/PageResponse.php
+++ b/src/DocScan/Session/Retrieve/PageResponse.php
@@ -22,6 +22,11 @@ class PageResponse
     private $frames = [];
 
     /**
+     * @var string[]
+     */
+    private $extractionImageIds = [];
+
+    /**
      * PageInfo constructor.
      * @param array<string, mixed> $page
      */
@@ -38,6 +43,8 @@ class PageResponse
                 $this->frames[] = new FrameResponse($frame);
             }
         }
+
+        $this->extractionImageIds = $page['extraction_image_ids'] ?? [];
     }
 
     /**
@@ -62,5 +69,13 @@ class PageResponse
     public function getFrames(): array
     {
         return $this->frames;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExtractionImageIds(): array
+    {
+        return $this->extractionImageIds;
     }
 }

--- a/tests/DocScan/Session/Retrieve/PageResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/PageResponseTest.php
@@ -57,6 +57,25 @@ class PageResponseTest extends TestCase
     }
 
     /**
+     * @covers ::__construct
+     * @covers ::getExtractionImageIds
+     */
+    public function testGetExtractionImageIds()
+    {
+        $extractionImageIds = [
+            '066a9372-0a52-4fe4-a026-866f8aee6fcb',
+            '9b0c9c0a-ff30-41ed-815b-d95d63271d45',
+        ];
+
+        $pageResponse = new PageResponse([
+            'extraction_image_ids' => $extractionImageIds,
+        ]);
+
+        $this->assertCount(2, $pageResponse->getExtractionImageIds());
+        $this->assertEquals($extractionImageIds, $pageResponse->getExtractionImageIds());
+    }
+
+    /**
      * @test
      * @covers ::__construct
      */
@@ -67,5 +86,6 @@ class PageResponseTest extends TestCase
         $this->assertNull($result->getCaptureMethod());
         $this->assertNull($result->getMedia());
         $this->assertEquals([], $result->getFrames());
+        $this->assertEquals([], $result->getExtractionImageIds());
     }
 }


### PR DESCRIPTION
## Summary
  - Add `extraction_image_ids` field to `PageResponse` to expose which media was used for
  automated extraction
  - Field is parsed as an array of UUID strings, defaults to empty array when absent