### PR TITLE
Release/4.5.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,8 +8,8 @@ jobs:
     # always run on push events
     # only run on pull_request_target event when pull request pulls from fork repository
     if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository 
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:
@@ -31,11 +31,61 @@ jobs:
 
       - run: composer test
 
+  php8-2:
+    name: Unit Tests php8.2 (php ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ 8.2 ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@2.9.0
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - run: composer remove --dev --no-update --no-interaction friendsofphp/php-cs-fixer
+
+      - run: composer self-update
+
+      - run: composer install --no-interaction --prefer-source --dev
+
+      - run: composer test
+
+  php8-3:
+    name: Unit Tests php8.3 (php ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ 8.3 ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@2.9.0
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - run: composer remove --dev --no-update --no-interaction friendsofphp/php-cs-fixer
+
+      - run: composer self-update
+
+      - run: composer install --no-interaction --prefer-source --dev
+
+      - run: composer test
+
   php8-4:
     name: Unit Tests php8.4 (php ${{ matrix.php-version }})
     runs-on: ubuntu-latest
-    # always run on push events
-    # only run on pull_request_target event when pull request pulls from fork repository
     if: >
       github.event_name == 'push' ||
       github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
@@ -51,8 +101,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
 
-      # Remove php-cs-fixer until compatible with PHP 8
-      # This step might be removable if php-cs-fixer is compatible with 8.4 by the time this runs
       - run: composer remove --dev --no-update --no-interaction friendsofphp/php-cs-fixer
 
       - run: composer self-update
@@ -61,66 +109,14 @@ jobs:
 
       - run: composer test
 
-  php7-4:
-    name: Unit Tests php7.4 (php ${{ matrix.php-version }})
-    runs-on: ubuntu-latest
-    # always run on push events
-    # only run on pull_request_target event when pull request pulls from fork repository
-    if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version: [ 7.4 ]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: shivammathur/setup-php@2.9.0
-        with:
-          php-version: ${{ matrix.php-version }}
-
-      - run: composer self-update
-
-      - run: composer install --no-interaction --prefer-source --dev
-
-      - run: composer test
-
-  php8-0:
-    name: Unit Tests php8.0 (php ${{ matrix.php-version }})
-    runs-on: ubuntu-latest
-    # always run on push events
-    # only run on pull_request_target event when pull request pulls from fork repository
-    if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version: [ 8.0 ]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: shivammathur/setup-php@2.9.0
-        with:
-          php-version: ${{ matrix.php-version }}
-
-      - run: composer self-update
-
-      - run: composer install --no-interaction --prefer-source --dev
-
-      - run: composer test
-
   protobuf:
-    name: Unit Tests With Protobuf C Extension 3.13 (php ${{ matrix.php-version }})
+    name: Unit Tests With Protobuf C Extension (php ${{ matrix.php-version }})
     runs-on: ubuntu-latest
     # always run on push events
     # only run on pull_request_target event when pull request pulls from fork repository
     if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository 
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please feel free to reach out
 
 ## Requirements
 
-* PHP ^7.4 || ^8.0 || ^8.1
+* PHP ^8.1
 * CURL PHP extension (must support TLSv1.2)
 
 ### Recommended (optional)
@@ -42,13 +42,13 @@ Add the Yoti SDK dependency:
 
 ```json
 "require": {
-    "yoti/yoti-php-sdk" : "^4.4.1"
+    "yoti/yoti-php-sdk" : "^4.5.0"
 }
 ```
 
 Or run this Composer command
 ```console
-$ composer require yoti/yoti-php-sdk "^4.4.1"
+$ composer require yoti/yoti-php-sdk "^4.5.0"
 ```
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -30,6 +30,9 @@ Please feel free to reach out
 * PHP ^8.1
 * CURL PHP extension (must support TLSv1.2)
 
+> **Breaking change:** this SDK release supports PHP 8.1 and above only.
+> Support for PHP 7.4 and PHP 8.0 has been removed.
+> If you are still running on PHP 7.4/8.0, please remain on an earlier SDK version until you can upgrade your runtime.
 ### Recommended (optional)
 - [Protobuf C extension](https://github.com/protocolbuffers/protobuf/tree/master/php) (PHP package will be used by default)
 

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "yoti/yoti-php-sdk",
   "description": "Yoti SDK for quickly integrating your PHP backend with Yoti",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "keywords": [
     "yoti",
     "sdk"
@@ -9,10 +9,10 @@
   "homepage": "https://yoti.com",
   "license": "MIT",
   "require": {
-    "php": "^7.4 || ^8.0 || ^8.1 || ^8.4",
+    "php": "^8.1",
     "ext-json": "*",
-    "google/protobuf": "^3.10",
-    "phpseclib/phpseclib": "^3.0",
+    "google/protobuf": "^4.33.6",
+    "phpseclib/phpseclib": "^3.0.50",
     "guzzlehttp/guzzle": "^7.0",
     "psr/http-client": "^1.0",
     "psr/http-message": "^2.0",

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -37,7 +37,7 @@ class Constants
     public const SDK_IDENTIFIER = 'PHP';
 
     /** Default SDK version */
-    public const SDK_VERSION = '4.4.1';
+    public const SDK_VERSION = '4.5.0';
 
     /** Base url for connect page (user will be redirected to this page eg. baseurl/app-id) */
     public const CONNECT_BASE_URL = 'https://www.yoti.com/connect';

--- a/src/DocScan/Session/Create/ApplicantProfile.php
+++ b/src/DocScan/Session/Create/ApplicantProfile.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create;
+
+use JsonSerializable;
+use stdClass;
+use Yoti\Util\Json;
+
+class ApplicantProfile implements JsonSerializable
+{
+    /**
+     * @var string|null
+     */
+    private $fullName;
+
+    /**
+     * @var string|null
+     */
+    private $dateOfBirth;
+
+    /**
+     * @var string|null
+     */
+    private $namePrefix;
+
+    /**
+     * @var StructuredPostalAddress|null
+     */
+    private $structuredPostalAddress;
+
+    /**
+     * @param string|null $fullName
+     * @param string|null $dateOfBirth
+     * @param string|null $namePrefix
+     * @param StructuredPostalAddress|null $structuredPostalAddress
+     */
+    public function __construct(
+        ?string $fullName,
+        ?string $dateOfBirth,
+        ?string $namePrefix,
+        ?StructuredPostalAddress $structuredPostalAddress
+    ) {
+        $this->fullName = $fullName;
+        $this->dateOfBirth = $dateOfBirth;
+        $this->namePrefix = $namePrefix;
+        $this->structuredPostalAddress = $structuredPostalAddress;
+    }
+
+    /**
+     * @return stdClass
+     */
+    public function jsonSerialize(): stdClass
+    {
+        return (object) Json::withoutNullValues([
+            'full_name' => $this->fullName,
+            'date_of_birth' => $this->dateOfBirth,
+            'name_prefix' => $this->namePrefix,
+            'structured_postal_address' => $this->structuredPostalAddress,
+        ]);
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFullName(): ?string
+    {
+        return $this->fullName;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDateOfBirth(): ?string
+    {
+        return $this->dateOfBirth;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getNamePrefix(): ?string
+    {
+        return $this->namePrefix;
+    }
+
+    /**
+     * @return StructuredPostalAddress|null
+     */
+    public function getStructuredPostalAddress(): ?StructuredPostalAddress
+    {
+        return $this->structuredPostalAddress;
+    }
+}

--- a/src/DocScan/Session/Create/ApplicantProfileBuilder.php
+++ b/src/DocScan/Session/Create/ApplicantProfileBuilder.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create;
+
+class ApplicantProfileBuilder
+{
+    /**
+     * @var string|null
+     */
+    private $fullName;
+
+    /**
+     * @var string|null
+     */
+    private $dateOfBirth;
+
+    /**
+     * @var string|null
+     */
+    private $namePrefix;
+
+    /**
+     * @var StructuredPostalAddress|null
+     */
+    private $structuredPostalAddress;
+
+    /**
+     * @param string $fullName
+     * @return $this
+     */
+    public function withFullName(string $fullName): self
+    {
+        $this->fullName = $fullName;
+        return $this;
+    }
+
+    /**
+     * @param string $dateOfBirth
+     * @return $this
+     */
+    public function withDateOfBirth(string $dateOfBirth): self
+    {
+        $this->dateOfBirth = $dateOfBirth;
+        return $this;
+    }
+
+    /**
+     * @param string $namePrefix
+     * @return $this
+     */
+    public function withNamePrefix(string $namePrefix): self
+    {
+        $this->namePrefix = $namePrefix;
+        return $this;
+    }
+
+    /**
+     * @param StructuredPostalAddress $structuredPostalAddress
+     * @return $this
+     */
+    public function withStructuredPostalAddress(StructuredPostalAddress $structuredPostalAddress): self
+    {
+        $this->structuredPostalAddress = $structuredPostalAddress;
+        return $this;
+    }
+
+    /**
+     * @return ApplicantProfile
+     */
+    public function build(): ApplicantProfile
+    {
+        return new ApplicantProfile(
+            $this->fullName,
+            $this->dateOfBirth,
+            $this->namePrefix,
+            $this->structuredPostalAddress
+        );
+    }
+}

--- a/src/DocScan/Session/Create/ResourceCreationContainer.php
+++ b/src/DocScan/Session/Create/ResourceCreationContainer.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create;
+
+use JsonSerializable;
+use stdClass;
+use Yoti\Util\Json;
+
+class ResourceCreationContainer implements JsonSerializable
+{
+    /**
+     * @var ApplicantProfile|null
+     */
+    private $applicantProfile;
+
+    /**
+     * @param ApplicantProfile|null $applicantProfile
+     */
+    public function __construct(?ApplicantProfile $applicantProfile)
+    {
+        $this->applicantProfile = $applicantProfile;
+    }
+
+    /**
+     * @return stdClass
+     */
+    public function jsonSerialize(): stdClass
+    {
+        return (object) Json::withoutNullValues([
+            'applicant_profile' => $this->applicantProfile,
+        ]);
+    }
+
+    /**
+     * @return ApplicantProfile|null
+     */
+    public function getApplicantProfile(): ?ApplicantProfile
+    {
+        return $this->applicantProfile;
+    }
+}

--- a/src/DocScan/Session/Create/ResourceCreationContainerBuilder.php
+++ b/src/DocScan/Session/Create/ResourceCreationContainerBuilder.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create;
+
+class ResourceCreationContainerBuilder
+{
+    /**
+     * @var ApplicantProfile|null
+     */
+    private $applicantProfile;
+
+    /**
+     * @param ApplicantProfile $applicantProfile
+     * @return $this
+     */
+    public function withApplicantProfile(ApplicantProfile $applicantProfile): self
+    {
+        $this->applicantProfile = $applicantProfile;
+        return $this;
+    }
+
+    /**
+     * @return ResourceCreationContainer
+     */
+    public function build(): ResourceCreationContainer
+    {
+        return new ResourceCreationContainer(
+            $this->applicantProfile
+        );
+    }
+}

--- a/src/DocScan/Session/Create/SessionSpecification.php
+++ b/src/DocScan/Session/Create/SessionSpecification.php
@@ -91,6 +91,11 @@ class SessionSpecification implements JsonSerializable
     private $importToken;
 
     /**
+     * @var ResourceCreationContainer|null
+     */
+    private $resources;
+
+    /**
      * @param int|null $clientSessionTokenTtl
      * @param string|null $sessionDeadline
      * @param int|null $resourcesTtl
@@ -107,6 +112,7 @@ class SessionSpecification implements JsonSerializable
      * @param object|null $advancedIdentityProfileRequirements
      * @param bool|null $createIdentityProfilePreview
      * @param ImportToken|null $importToken
+     * @param ResourceCreationContainer|null $resources
      */
     public function __construct(
         ?int $clientSessionTokenTtl,
@@ -124,7 +130,8 @@ class SessionSpecification implements JsonSerializable
         ?object $identityProfileRequirements = null,
         ?object $advancedIdentityProfileRequirements = null,
         ?bool $createIdentityProfilePreview = null,
-        ?ImportToken $importToken = null
+        ?ImportToken $importToken = null,
+        ?ResourceCreationContainer $resources = null
     ) {
         $this->clientSessionTokenTtl = $clientSessionTokenTtl;
         $this->sessionDeadline = $sessionDeadline;
@@ -142,6 +149,7 @@ class SessionSpecification implements JsonSerializable
         $this->advancedIdentityProfileRequirements = $advancedIdentityProfileRequirements;
         $this->createIdentityProfilePreview = $createIdentityProfilePreview;
         $this->importToken = $importToken;
+        $this->resources = $resources;
     }
 
     /**
@@ -166,6 +174,7 @@ class SessionSpecification implements JsonSerializable
             'advanced_identity_profile_requirements' => $this->getAdvancedIdentityProfileRequirements(),
             'create_identity_profile_preview' => $this->getCreateIdentityProfilePreview(),
             'import_token' => $this->getImportToken(),
+            'resources' => $this->getResources(),
         ]);
     }
 
@@ -294,5 +303,13 @@ class SessionSpecification implements JsonSerializable
     public function getImportToken(): ?ImportToken
     {
         return $this->importToken;
+    }
+
+    /**
+     * @return ResourceCreationContainer|null
+     */
+    public function getResources(): ?ResourceCreationContainer
+    {
+        return $this->resources;
     }
 }

--- a/src/DocScan/Session/Create/SessionSpecificationBuilder.php
+++ b/src/DocScan/Session/Create/SessionSpecificationBuilder.php
@@ -89,6 +89,11 @@ class SessionSpecificationBuilder
     private $importToken;
 
     /**
+     * @var ResourceCreationContainer|null
+     */
+    private $resources;
+
+    /**
      * @var bool
      */
     private bool $createIdentityProfilePreview = false;
@@ -293,6 +298,19 @@ class SessionSpecificationBuilder
     }
 
     /**
+     * Sets the resources for the session
+     *
+     * @param ResourceCreationContainer $resources
+     *
+     * @return $this
+     */
+    public function withResources(ResourceCreationContainer $resources): self
+    {
+        $this->resources = $resources;
+        return $this;
+    }
+
+    /**
      * @return SessionSpecification
      */
     public function build(): SessionSpecification
@@ -314,6 +332,7 @@ class SessionSpecificationBuilder
             $this->advancedIdentityProfileRequirements,
             $this->createIdentityProfilePreview,
             $this->importToken,
+            $this->resources,
         );
     }
 }

--- a/src/DocScan/Session/Create/StructuredPostalAddress.php
+++ b/src/DocScan/Session/Create/StructuredPostalAddress.php
@@ -1,0 +1,163 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create;
+
+use JsonSerializable;
+use stdClass;
+use Yoti\Util\Json;
+
+class StructuredPostalAddress implements JsonSerializable
+{
+    /**
+     * @var int|null
+     */
+    private $addressFormat;
+
+    /**
+     * @var string|null
+     */
+    private $buildingNumber;
+
+    /**
+     * @var string|null
+     */
+    private $addressLine1;
+
+    /**
+     * @var string|null
+     */
+    private $townCity;
+
+    /**
+     * @var string|null
+     */
+    private $postalCode;
+
+    /**
+     * @var string|null
+     */
+    private $countryIso;
+
+    /**
+     * @var string|null
+     */
+    private $country;
+
+    /**
+     * @var string|null
+     */
+    private $formattedAddress;
+
+    /**
+     * @param int|null $addressFormat
+     * @param string|null $buildingNumber
+     * @param string|null $addressLine1
+     * @param string|null $townCity
+     * @param string|null $postalCode
+     * @param string|null $countryIso
+     * @param string|null $country
+     * @param string|null $formattedAddress
+     */
+    public function __construct(
+        ?int $addressFormat,
+        ?string $buildingNumber,
+        ?string $addressLine1,
+        ?string $townCity,
+        ?string $postalCode,
+        ?string $countryIso,
+        ?string $country,
+        ?string $formattedAddress
+    ) {
+        $this->addressFormat = $addressFormat;
+        $this->buildingNumber = $buildingNumber;
+        $this->addressLine1 = $addressLine1;
+        $this->townCity = $townCity;
+        $this->postalCode = $postalCode;
+        $this->countryIso = $countryIso;
+        $this->country = $country;
+        $this->formattedAddress = $formattedAddress;
+    }
+
+    /**
+     * @return stdClass
+     */
+    public function jsonSerialize(): stdClass
+    {
+        return (object) Json::withoutNullValues([
+            'address_format' => $this->addressFormat,
+            'building_number' => $this->buildingNumber,
+            'address_line1' => $this->addressLine1,
+            'town_city' => $this->townCity,
+            'postal_code' => $this->postalCode,
+            'country_iso' => $this->countryIso,
+            'country' => $this->country,
+            'formatted_address' => $this->formattedAddress,
+        ]);
+    }
+
+    /**
+     * @return int|null
+     */
+    public function getAddressFormat(): ?int
+    {
+        return $this->addressFormat;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getBuildingNumber(): ?string
+    {
+        return $this->buildingNumber;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getAddressLine1(): ?string
+    {
+        return $this->addressLine1;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getTownCity(): ?string
+    {
+        return $this->townCity;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getPostalCode(): ?string
+    {
+        return $this->postalCode;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCountryIso(): ?string
+    {
+        return $this->countryIso;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getCountry(): ?string
+    {
+        return $this->country;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getFormattedAddress(): ?string
+    {
+        return $this->formattedAddress;
+    }
+}

--- a/src/DocScan/Session/Create/StructuredPostalAddressBuilder.php
+++ b/src/DocScan/Session/Create/StructuredPostalAddressBuilder.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create;
+
+class StructuredPostalAddressBuilder
+{
+    /**
+     * @var int|null
+     */
+    private $addressFormat;
+
+    /**
+     * @var string|null
+     */
+    private $buildingNumber;
+
+    /**
+     * @var string|null
+     */
+    private $addressLine1;
+
+    /**
+     * @var string|null
+     */
+    private $townCity;
+
+    /**
+     * @var string|null
+     */
+    private $postalCode;
+
+    /**
+     * @var string|null
+     */
+    private $countryIso;
+
+    /**
+     * @var string|null
+     */
+    private $country;
+
+    /**
+     * @var string|null
+     */
+    private $formattedAddress;
+
+    /**
+     * @param int $addressFormat
+     * @return $this
+     */
+    public function withAddressFormat(int $addressFormat): self
+    {
+        $this->addressFormat = $addressFormat;
+        return $this;
+    }
+
+    /**
+     * @param string $buildingNumber
+     * @return $this
+     */
+    public function withBuildingNumber(string $buildingNumber): self
+    {
+        $this->buildingNumber = $buildingNumber;
+        return $this;
+    }
+
+    /**
+     * @param string $addressLine1
+     * @return $this
+     */
+    public function withAddressLine1(string $addressLine1): self
+    {
+        $this->addressLine1 = $addressLine1;
+        return $this;
+    }
+
+    /**
+     * @param string $townCity
+     * @return $this
+     */
+    public function withTownCity(string $townCity): self
+    {
+        $this->townCity = $townCity;
+        return $this;
+    }
+
+    /**
+     * @param string $postalCode
+     * @return $this
+     */
+    public function withPostalCode(string $postalCode): self
+    {
+        $this->postalCode = $postalCode;
+        return $this;
+    }
+
+    /**
+     * @param string $countryIso
+     * @return $this
+     */
+    public function withCountryIso(string $countryIso): self
+    {
+        $this->countryIso = $countryIso;
+        return $this;
+    }
+
+    /**
+     * @param string $country
+     * @return $this
+     */
+    public function withCountry(string $country): self
+    {
+        $this->country = $country;
+        return $this;
+    }
+
+    /**
+     * @param string $formattedAddress
+     * @return $this
+     */
+    public function withFormattedAddress(string $formattedAddress): self
+    {
+        $this->formattedAddress = $formattedAddress;
+        return $this;
+    }
+
+    /**
+     * @return StructuredPostalAddress
+     */
+    public function build(): StructuredPostalAddress
+    {
+        return new StructuredPostalAddress(
+            $this->addressFormat,
+            $this->buildingNumber,
+            $this->addressLine1,
+            $this->townCity,
+            $this->postalCode,
+            $this->countryIso,
+            $this->country,
+            $this->formattedAddress
+        );
+    }
+}

--- a/src/DocScan/Session/Retrieve/ApplicantProfileResourceResponse.php
+++ b/src/DocScan/Session/Retrieve/ApplicantProfileResourceResponse.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Retrieve;
+
+use Yoti\Exception\DateTimeException;
+use Yoti\Util\DateTime;
+
+class ApplicantProfileResourceResponse extends ResourceResponse
+{
+    /**
+     * @var MediaResponse|null
+     */
+    private $media;
+
+    /**
+     * @var \DateTime|null
+     */
+    private $createdAt;
+
+    /**
+     * @var \DateTime|null
+     */
+    private $lastUpdated;
+
+    /**
+     * ApplicantProfileResourceResponse constructor.
+     * @param array<string, mixed> $applicantProfile
+     * @throws DateTimeException
+     */
+    public function __construct(array $applicantProfile)
+    {
+        parent::__construct($applicantProfile);
+
+        if (isset($applicantProfile['media'])) {
+            $this->media = new MediaResponse($applicantProfile['media']);
+        }
+
+        $this->createdAt = isset($applicantProfile['created_at'])
+            ? DateTime::stringToDateTime($applicantProfile['created_at']) : null;
+
+        $this->lastUpdated = isset($applicantProfile['last_updated'])
+            ? DateTime::stringToDateTime($applicantProfile['last_updated']) : null;
+    }
+
+    /**
+     * @return MediaResponse|null
+     */
+    public function getMedia(): ?MediaResponse
+    {
+        return $this->media;
+    }
+
+    /**
+     * @return \DateTime|null
+     */
+    public function getCreatedAt(): ?\DateTime
+    {
+        return $this->createdAt;
+    }
+
+    /**
+     * @return \DateTime|null
+     */
+    public function getLastUpdated(): ?\DateTime
+    {
+        return $this->lastUpdated;
+    }
+}

--- a/src/DocScan/Session/Retrieve/BreakdownResponse.php
+++ b/src/DocScan/Session/Retrieve/BreakdownResponse.php
@@ -17,6 +17,11 @@ class BreakdownResponse
     private $result;
 
     /**
+     * @var string|null
+     */
+    private $process;
+
+    /**
      * @var DetailsResponse[]
      */
     private $details = [];
@@ -29,6 +34,7 @@ class BreakdownResponse
     {
         $this->subCheck = $breakdown['sub_check'] ?? null;
         $this->result = $breakdown['result'] ?? null;
+        $this->process = $breakdown['process'] ?? null;
 
         if (isset($breakdown['details'])) {
             foreach ($breakdown['details'] as $detail) {
@@ -51,6 +57,14 @@ class BreakdownResponse
     public function getResult(): ?string
     {
         return $this->result;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getProcess(): ?string
+    {
+        return $this->process;
     }
 
     /**

--- a/src/DocScan/Session/Retrieve/PageResponse.php
+++ b/src/DocScan/Session/Retrieve/PageResponse.php
@@ -22,6 +22,11 @@ class PageResponse
     private $frames = [];
 
     /**
+     * @var string[]
+     */
+    private $extractionImageIds = [];
+
+    /**
      * PageInfo constructor.
      * @param array<string, mixed> $page
      */
@@ -38,6 +43,8 @@ class PageResponse
                 $this->frames[] = new FrameResponse($frame);
             }
         }
+
+        $this->extractionImageIds = $page['extraction_image_ids'] ?? [];
     }
 
     /**
@@ -62,5 +69,13 @@ class PageResponse
     public function getFrames(): array
     {
         return $this->frames;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getExtractionImageIds(): array
+    {
+        return $this->extractionImageIds;
     }
 }

--- a/src/DocScan/Session/Retrieve/ResourceContainer.php
+++ b/src/DocScan/Session/Retrieve/ResourceContainer.php
@@ -32,6 +32,11 @@ class ResourceContainer
     private $shareCodes = [];
 
     /**
+     * @var ApplicantProfileResourceResponse[]
+     */
+    private $applicantProfiles = [];
+
+    /**
      * ResourceContainer constructor.
      * @param array<string, mixed> $resources
      */
@@ -55,6 +60,10 @@ class ResourceContainer
 
         if (isset($resources['share_codes'])) {
             $this->shareCodes = $this->parseShareCodes($resources['share_codes']);
+        }
+
+        if (isset($resources['applicant_profiles'])) {
+            $this->applicantProfiles = $this->parseApplicantProfiles($resources['applicant_profiles']);
         }
     }
 
@@ -179,6 +188,14 @@ class ResourceContainer
     }
 
     /**
+     * @return ApplicantProfileResourceResponse[]
+     */
+    public function getApplicantProfiles(): array
+    {
+        return $this->applicantProfiles;
+    }
+
+    /**
      * @param array<array<string, mixed>> $shareCodes
      * @return ShareCodeResourceResponse[]
      */
@@ -189,6 +206,19 @@ class ResourceContainer
             $parsedShareCodes[] = new ShareCodeResourceResponse($shareCode);
         }
         return $parsedShareCodes;
+    }
+
+    /**
+     * @param array<array<string, mixed>> $applicantProfiles
+     * @return ApplicantProfileResourceResponse[]
+     */
+    private function parseApplicantProfiles(array $applicantProfiles): array
+    {
+        $parsedApplicantProfiles = [];
+        foreach ($applicantProfiles as $applicantProfile) {
+            $parsedApplicantProfiles[] = new ApplicantProfileResourceResponse($applicantProfile);
+        }
+        return $parsedApplicantProfiles;
     }
 
     /**

--- a/src/DocScan/Session/Retrieve/TaskRecommendationReasonResponse.php
+++ b/src/DocScan/Session/Retrieve/TaskRecommendationReasonResponse.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Retrieve;
+
+class TaskRecommendationReasonResponse
+{
+    /**
+     * @var string|null
+     */
+    private $value;
+
+    /**
+     * @var string|null
+     */
+    private $detail;
+
+    /**
+     * TaskRecommendationReasonResponse constructor.
+     * @param array<string, mixed> $reason
+     */
+    public function __construct(array $reason)
+    {
+        $this->value = $reason['value'] ?? null;
+        $this->detail = $reason['detail'] ?? null;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getDetail(): ?string
+    {
+        return $this->detail;
+    }
+}

--- a/src/DocScan/Session/Retrieve/TaskRecommendationResponse.php
+++ b/src/DocScan/Session/Retrieve/TaskRecommendationResponse.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Retrieve;
+
+class TaskRecommendationResponse
+{
+    /**
+     * @var string|null
+     */
+    private $value;
+
+    /**
+     * @var TaskRecommendationReasonResponse|null
+     */
+    private $reason;
+
+    /**
+     * TaskRecommendationResponse constructor.
+     * @param array<string, mixed> $recommendation
+     */
+    public function __construct(array $recommendation)
+    {
+        $this->value = $recommendation['value'] ?? null;
+
+        if (isset($recommendation['reason'])) {
+            $this->reason = new TaskRecommendationReasonResponse($recommendation['reason']);
+        }
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getValue(): ?string
+    {
+        return $this->value;
+    }
+
+    /**
+     * @return TaskRecommendationReasonResponse|null
+     */
+    public function getReason(): ?TaskRecommendationReasonResponse
+    {
+        return $this->reason;
+    }
+}

--- a/src/DocScan/Session/Retrieve/TaskResponse.php
+++ b/src/DocScan/Session/Retrieve/TaskResponse.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Yoti\DocScan\Session\Retrieve;
 
 use Yoti\DocScan\Constants;
+use Yoti\Exception\DateTimeException;
 use Yoti\Util\DateTime;
 
 class TaskResponse
@@ -52,6 +53,7 @@ class TaskResponse
     /**
      * TaskResponse constructor.
      * @param array<string, mixed> $task
+     * @throws DateTimeException
      */
     public function __construct(array $task)
     {

--- a/src/DocScan/Session/Retrieve/TaskResponse.php
+++ b/src/DocScan/Session/Retrieve/TaskResponse.php
@@ -45,6 +45,11 @@ class TaskResponse
     private $generatedMedia = [];
 
     /**
+     * @var TaskRecommendationResponse|null
+     */
+    private $recommendation;
+
+    /**
      * TaskResponse constructor.
      * @param array<string, mixed> $task
      */
@@ -66,6 +71,10 @@ class TaskResponse
 
         if (isset($task['generated_media'])) {
             $this->generatedMedia = $this->parseGeneratedMedia($task['generated_media']);
+        }
+
+        if (isset($task['recommendation'])) {
+            $this->recommendation = new TaskRecommendationResponse($task['recommendation']);
         }
     }
 
@@ -159,6 +168,14 @@ class TaskResponse
     public function getGeneratedMedia(): array
     {
         return $this->generatedMedia;
+    }
+
+    /**
+     * @return TaskRecommendationResponse|null
+     */
+    public function getRecommendation(): ?TaskRecommendationResponse
+    {
+        return $this->recommendation;
     }
 
     /**

--- a/tests/DocScan/Session/Create/ApplicantProfileBuilderTest.php
+++ b/tests/DocScan/Session/Create/ApplicantProfileBuilderTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Test\DocScan\Session\Create;
+
+use Yoti\DocScan\Session\Create\ApplicantProfileBuilder;
+use Yoti\DocScan\Session\Create\StructuredPostalAddressBuilder;
+use Yoti\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\DocScan\Session\Create\ApplicantProfileBuilder
+ */
+class ApplicantProfileBuilderTest extends TestCase
+{
+    private const SOME_FULL_NAME = 'John Doe';
+    private const SOME_DATE_OF_BIRTH = '1988-11-02';
+    private const SOME_NAME_PREFIX = 'Mr';
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers ::withFullName
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::__construct
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::getFullName
+     */
+    public function shouldBuildWithFullName()
+    {
+        $profile = (new ApplicantProfileBuilder())
+            ->withFullName(self::SOME_FULL_NAME)
+            ->build();
+
+        $this->assertEquals(self::SOME_FULL_NAME, $profile->getFullName());
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers ::withDateOfBirth
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::__construct
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::getDateOfBirth
+     */
+    public function shouldBuildWithDateOfBirth()
+    {
+        $profile = (new ApplicantProfileBuilder())
+            ->withDateOfBirth(self::SOME_DATE_OF_BIRTH)
+            ->build();
+
+        $this->assertEquals(self::SOME_DATE_OF_BIRTH, $profile->getDateOfBirth());
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers ::withNamePrefix
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::__construct
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::getNamePrefix
+     */
+    public function shouldBuildWithNamePrefix()
+    {
+        $profile = (new ApplicantProfileBuilder())
+            ->withNamePrefix(self::SOME_NAME_PREFIX)
+            ->build();
+
+        $this->assertEquals(self::SOME_NAME_PREFIX, $profile->getNamePrefix());
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers ::withStructuredPostalAddress
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::__construct
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::getStructuredPostalAddress
+     */
+    public function shouldBuildWithStructuredPostalAddress()
+    {
+        $address = (new StructuredPostalAddressBuilder())
+            ->withBuildingNumber('74')
+            ->withPostalCode('E143RN')
+            ->build();
+
+        $profile = (new ApplicantProfileBuilder())
+            ->withStructuredPostalAddress($address)
+            ->build();
+
+        $this->assertEquals('74', $profile->getStructuredPostalAddress()->getBuildingNumber());
+        $this->assertEquals('E143RN', $profile->getStructuredPostalAddress()->getPostalCode());
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::jsonSerialize
+     */
+    public function shouldCorrectlySerializeWithAllProperties()
+    {
+        $address = (new StructuredPostalAddressBuilder())
+            ->withAddressFormat(1)
+            ->withBuildingNumber('74')
+            ->withAddressLine1('AddressLine1')
+            ->withTownCity('CityName')
+            ->withPostalCode('E143RN')
+            ->withCountryIso('GBR')
+            ->withCountry('United Kingdom')
+            ->build();
+
+        $profile = (new ApplicantProfileBuilder())
+            ->withFullName(self::SOME_FULL_NAME)
+            ->withDateOfBirth(self::SOME_DATE_OF_BIRTH)
+            ->withNamePrefix(self::SOME_NAME_PREFIX)
+            ->withStructuredPostalAddress($address)
+            ->build();
+
+        $json = json_encode($profile);
+
+        $this->assertStringContainsString('"full_name":"John Doe"', $json);
+        $this->assertStringContainsString('"date_of_birth":"1988-11-02"', $json);
+        $this->assertStringContainsString('"name_prefix":"Mr"', $json);
+        $this->assertStringContainsString('"structured_postal_address"', $json);
+        $this->assertStringContainsString('"building_number":"74"', $json);
+        $this->assertStringContainsString('"country_iso":"GBR"', $json);
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\ApplicantProfile::jsonSerialize
+     */
+    public function shouldSerializeWithoutNullValues()
+    {
+        $profile = (new ApplicantProfileBuilder())
+            ->withFullName(self::SOME_FULL_NAME)
+            ->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'full_name' => self::SOME_FULL_NAME,
+            ]),
+            json_encode($profile)
+        );
+    }
+}

--- a/tests/DocScan/Session/Create/ResourceCreationContainerBuilderTest.php
+++ b/tests/DocScan/Session/Create/ResourceCreationContainerBuilderTest.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Test\DocScan\Session\Create;
+
+use Yoti\DocScan\Session\Create\ApplicantProfileBuilder;
+use Yoti\DocScan\Session\Create\ResourceCreationContainerBuilder;
+use Yoti\DocScan\Session\Create\StructuredPostalAddressBuilder;
+use Yoti\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\DocScan\Session\Create\ResourceCreationContainerBuilder
+ */
+class ResourceCreationContainerBuilderTest extends TestCase
+{
+    /**
+     * @test
+     * @covers ::build
+     * @covers ::withApplicantProfile
+     * @covers \Yoti\DocScan\Session\Create\ResourceCreationContainer::__construct
+     * @covers \Yoti\DocScan\Session\Create\ResourceCreationContainer::getApplicantProfile
+     */
+    public function shouldBuildWithApplicantProfile()
+    {
+        $applicantProfile = (new ApplicantProfileBuilder())
+            ->withFullName('John Doe')
+            ->withDateOfBirth('1988-11-02')
+            ->build();
+
+        $container = (new ResourceCreationContainerBuilder())
+            ->withApplicantProfile($applicantProfile)
+            ->build();
+
+        $this->assertEquals($applicantProfile, $container->getApplicantProfile());
+        $this->assertEquals('John Doe', $container->getApplicantProfile()->getFullName());
+        $this->assertEquals('1988-11-02', $container->getApplicantProfile()->getDateOfBirth());
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\ResourceCreationContainer::jsonSerialize
+     */
+    public function shouldCorrectlySerializeApplicantProfile()
+    {
+        $address = (new StructuredPostalAddressBuilder())
+            ->withAddressFormat(1)
+            ->withBuildingNumber('74')
+            ->withAddressLine1('AddressLine1')
+            ->withTownCity('CityName')
+            ->withPostalCode('E143RN')
+            ->withCountryIso('GBR')
+            ->withCountry('United Kingdom')
+            ->build();
+
+        $applicantProfile = (new ApplicantProfileBuilder())
+            ->withFullName('John Doe')
+            ->withDateOfBirth('1988-11-02')
+            ->withNamePrefix('Mr')
+            ->withStructuredPostalAddress($address)
+            ->build();
+
+        $container = (new ResourceCreationContainerBuilder())
+            ->withApplicantProfile($applicantProfile)
+            ->build();
+
+        $json = json_encode($container);
+
+        $this->assertStringContainsString('"applicant_profile"', $json);
+        $this->assertStringContainsString('"full_name":"John Doe"', $json);
+        $this->assertStringContainsString('"date_of_birth":"1988-11-02"', $json);
+        $this->assertStringContainsString('"name_prefix":"Mr"', $json);
+        $this->assertStringContainsString('"building_number":"74"', $json);
+        $this->assertStringContainsString('"country_iso":"GBR"', $json);
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\ResourceCreationContainer::jsonSerialize
+     */
+    public function shouldSerializeWithoutNullValues()
+    {
+        $container = (new ResourceCreationContainerBuilder())
+            ->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode(new \stdClass()),
+            json_encode($container)
+        );
+    }
+}

--- a/tests/DocScan/Session/Create/SessionSpecificationBuilderTest.php
+++ b/tests/DocScan/Session/Create/SessionSpecificationBuilderTest.php
@@ -9,6 +9,7 @@ use Yoti\DocScan\Session\Create\Filters\RequiredDocument;
 use Yoti\DocScan\Session\Create\IbvOptions;
 use Yoti\DocScan\Session\Create\ImportToken;
 use Yoti\DocScan\Session\Create\NotificationConfig;
+use Yoti\DocScan\Session\Create\ResourceCreationContainer;
 use Yoti\DocScan\Session\Create\SdkConfig;
 use Yoti\DocScan\Session\Create\SessionSpecificationBuilder;
 use Yoti\DocScan\Session\Create\Task\RequestedTask;
@@ -73,6 +74,11 @@ class SessionSpecificationBuilderTest extends TestCase
      */
     private $importTokenMock;
 
+    /**
+     * @var ResourceCreationContainer
+     */
+    private $resourcesMock;
+
     public function setup(): void
     {
         $this->sdkConfigMock = $this->createMock(SdkConfig::class);
@@ -93,6 +99,11 @@ class SessionSpecificationBuilderTest extends TestCase
         $this->ibvOptionsMock = $this->createMock(IbvOptions::class);
 
         $this->importTokenMock = $this->createMock(ImportToken::class);
+
+        $this->resourcesMock = $this->createMock(ResourceCreationContainer::class);
+        $this->resourcesMock
+            ->method('jsonSerialize')
+            ->willReturn((object)['applicant_profile' => (object)['full_name' => 'John Doe']]);
 
         $this->subject = (object)[1 => 'some'];
 
@@ -601,6 +612,60 @@ class SessionSpecificationBuilderTest extends TestCase
                 'required_documents' => [],
                 'create_identity_profile_preview' => false,
                 'advanced_identity_profile_requirements' => $this->advancedIdentityProfileRequirements,
+            ]),
+            json_encode($sessionSpecification)
+        );
+    }
+
+    /**
+     * @test
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecification::getResources
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecification::__construct
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecificationBuilder::withResources
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecificationBuilder::build
+     */
+    public function shouldBuildWithResources()
+    {
+        $sessionSpecificationResult = (new SessionSpecificationBuilder())
+            ->withResources($this->resourcesMock)
+            ->build();
+
+        $this->assertEquals($this->resourcesMock, $sessionSpecificationResult->getResources());
+    }
+
+    /**
+     * @test
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecification::getResources
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecification::__construct
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecificationBuilder::build
+     */
+    public function shouldNotImplicitlySetAValueForResources()
+    {
+        $sessionSpecificationResult = (new SessionSpecificationBuilder())
+            ->build();
+
+        $this->assertNull($sessionSpecificationResult->getResources());
+    }
+
+    /**
+     * @test
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecification::jsonSerialize
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecificationBuilder::withResources
+     * @covers \Yoti\DocScan\Session\Create\SessionSpecificationBuilder::build
+     */
+    public function shouldReturnCorrectJsonStringWithResources()
+    {
+        $sessionSpecification = (new SessionSpecificationBuilder())
+            ->withResources($this->resourcesMock)
+            ->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'requested_checks' => [],
+                'requested_tasks' => [],
+                'required_documents' => [],
+                'create_identity_profile_preview' => false,
+                'resources' => $this->resourcesMock,
             ]),
             json_encode($sessionSpecification)
         );

--- a/tests/DocScan/Session/Create/StructuredPostalAddressBuilderTest.php
+++ b/tests/DocScan/Session/Create/StructuredPostalAddressBuilderTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Test\DocScan\Session\Create;
+
+use Yoti\DocScan\Session\Create\StructuredPostalAddressBuilder;
+use Yoti\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\DocScan\Session\Create\StructuredPostalAddressBuilder
+ */
+class StructuredPostalAddressBuilderTest extends TestCase
+{
+    private const SOME_ADDRESS_FORMAT = 1;
+    private const SOME_BUILDING_NUMBER = '74';
+    private const SOME_ADDRESS_LINE_1 = 'AddressLine1';
+    private const SOME_TOWN_CITY = 'CityName';
+    private const SOME_POSTAL_CODE = 'E143RN';
+    private const SOME_COUNTRY_ISO = 'GBR';
+    private const SOME_COUNTRY = 'United Kingdom';
+    private const SOME_FORMATTED_ADDRESS = "74\nAddressLine1\nCityName\nE143RN\nGBR";
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers ::withAddressFormat
+     * @covers ::withBuildingNumber
+     * @covers ::withAddressLine1
+     * @covers ::withTownCity
+     * @covers ::withPostalCode
+     * @covers ::withCountryIso
+     * @covers ::withCountry
+     * @covers ::withFormattedAddress
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::__construct
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getAddressFormat
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getBuildingNumber
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getAddressLine1
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getTownCity
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getPostalCode
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getCountryIso
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getCountry
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::getFormattedAddress
+     */
+    public function shouldBuildWithAllProperties()
+    {
+        $address = (new StructuredPostalAddressBuilder())
+            ->withAddressFormat(self::SOME_ADDRESS_FORMAT)
+            ->withBuildingNumber(self::SOME_BUILDING_NUMBER)
+            ->withAddressLine1(self::SOME_ADDRESS_LINE_1)
+            ->withTownCity(self::SOME_TOWN_CITY)
+            ->withPostalCode(self::SOME_POSTAL_CODE)
+            ->withCountryIso(self::SOME_COUNTRY_ISO)
+            ->withCountry(self::SOME_COUNTRY)
+            ->withFormattedAddress(self::SOME_FORMATTED_ADDRESS)
+            ->build();
+
+        $this->assertEquals(self::SOME_ADDRESS_FORMAT, $address->getAddressFormat());
+        $this->assertEquals(self::SOME_BUILDING_NUMBER, $address->getBuildingNumber());
+        $this->assertEquals(self::SOME_ADDRESS_LINE_1, $address->getAddressLine1());
+        $this->assertEquals(self::SOME_TOWN_CITY, $address->getTownCity());
+        $this->assertEquals(self::SOME_POSTAL_CODE, $address->getPostalCode());
+        $this->assertEquals(self::SOME_COUNTRY_ISO, $address->getCountryIso());
+        $this->assertEquals(self::SOME_COUNTRY, $address->getCountry());
+        $this->assertEquals(self::SOME_FORMATTED_ADDRESS, $address->getFormattedAddress());
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::jsonSerialize
+     */
+    public function shouldCorrectlySerialize()
+    {
+        $address = (new StructuredPostalAddressBuilder())
+            ->withAddressFormat(self::SOME_ADDRESS_FORMAT)
+            ->withBuildingNumber(self::SOME_BUILDING_NUMBER)
+            ->withAddressLine1(self::SOME_ADDRESS_LINE_1)
+            ->withTownCity(self::SOME_TOWN_CITY)
+            ->withPostalCode(self::SOME_POSTAL_CODE)
+            ->withCountryIso(self::SOME_COUNTRY_ISO)
+            ->withCountry(self::SOME_COUNTRY)
+            ->withFormattedAddress(self::SOME_FORMATTED_ADDRESS)
+            ->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'address_format' => self::SOME_ADDRESS_FORMAT,
+                'building_number' => self::SOME_BUILDING_NUMBER,
+                'address_line1' => self::SOME_ADDRESS_LINE_1,
+                'town_city' => self::SOME_TOWN_CITY,
+                'postal_code' => self::SOME_POSTAL_CODE,
+                'country_iso' => self::SOME_COUNTRY_ISO,
+                'country' => self::SOME_COUNTRY,
+                'formatted_address' => self::SOME_FORMATTED_ADDRESS,
+            ]),
+            json_encode($address)
+        );
+    }
+
+    /**
+     * @test
+     * @covers ::build
+     * @covers \Yoti\DocScan\Session\Create\StructuredPostalAddress::jsonSerialize
+     */
+    public function shouldSerializeWithoutNullValues()
+    {
+        $address = (new StructuredPostalAddressBuilder())
+            ->withBuildingNumber(self::SOME_BUILDING_NUMBER)
+            ->withPostalCode(self::SOME_POSTAL_CODE)
+            ->build();
+
+        $this->assertJsonStringEqualsJsonString(
+            json_encode([
+                'building_number' => self::SOME_BUILDING_NUMBER,
+                'postal_code' => self::SOME_POSTAL_CODE,
+            ]),
+            json_encode($address)
+        );
+    }
+}

--- a/tests/DocScan/Session/Retrieve/ApplicantProfileResourceResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/ApplicantProfileResourceResponseTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Test\DocScan\Session\Retrieve;
+
+use Yoti\DocScan\Session\Retrieve\ApplicantProfileResourceResponse;
+use Yoti\DocScan\Session\Retrieve\MediaResponse;
+use Yoti\Test\TestCase;
+use Yoti\Util\DateTime;
+
+/**
+ * @coversDefaultClass \Yoti\DocScan\Session\Retrieve\ApplicantProfileResourceResponse
+ */
+class ApplicantProfileResourceResponseTest extends TestCase
+{
+    private const SOME_ID = '3fa85f64-5717-4562-b3fc-2c963f66afa6';
+    private const SOME_MEDIA_ID = 'some-media-id';
+    private const SOME_MEDIA_TYPE = 'IMAGE';
+    private const SOME_CREATED_AT = '2021-06-11T11:39:24Z';
+    private const SOME_LAST_UPDATED = '2021-06-11T12:00:00Z';
+    private const SOME_SOURCE_TYPE = 'END_USER';
+
+    /**
+     * @test
+     * @covers ::__construct
+     * @covers ::getMedia
+     * @covers ::getCreatedAt
+     * @covers ::getLastUpdated
+     */
+    public function shouldBuildCorrectly()
+    {
+        $input = [
+            'id' => self::SOME_ID,
+            'source' => [
+                'type' => self::SOME_SOURCE_TYPE,
+            ],
+            'media' => [
+                'id' => self::SOME_MEDIA_ID,
+                'type' => self::SOME_MEDIA_TYPE,
+                'created' => self::SOME_CREATED_AT,
+                'last_updated' => self::SOME_LAST_UPDATED,
+            ],
+            'created_at' => self::SOME_CREATED_AT,
+            'last_updated' => self::SOME_LAST_UPDATED,
+            'tasks' => [],
+        ];
+
+        $result = new ApplicantProfileResourceResponse($input);
+
+        $this->assertEquals(self::SOME_ID, $result->getId());
+        $this->assertNotNull($result->getSource());
+        $this->assertInstanceOf(MediaResponse::class, $result->getMedia());
+        $this->assertEquals(self::SOME_MEDIA_ID, $result->getMedia()->getId());
+        $this->assertEquals(self::SOME_MEDIA_TYPE, $result->getMedia()->getType());
+        $this->assertEquals(
+            DateTime::stringToDateTime(self::SOME_CREATED_AT),
+            $result->getCreatedAt()
+        );
+        $this->assertEquals(
+            DateTime::stringToDateTime(self::SOME_LAST_UPDATED),
+            $result->getLastUpdated()
+        );
+        $this->assertCount(0, $result->getTasks());
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function shouldNotThrowExceptionWhenMissingValues()
+    {
+        $result = new ApplicantProfileResourceResponse([]);
+
+        $this->assertNull($result->getId());
+        $this->assertNull($result->getMedia());
+        $this->assertNull($result->getCreatedAt());
+        $this->assertNull($result->getLastUpdated());
+        $this->assertCount(0, $result->getTasks());
+    }
+}

--- a/tests/DocScan/Session/Retrieve/BreakdownResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/BreakdownResponseTest.php
@@ -25,11 +25,14 @@ class BreakdownResponseTest extends TestCase
         ],
     ];
 
+    private const SOME_PROCESS = 'AUTOMATED';
+
     /**
      * @test
      * @covers ::__construct
      * @covers ::getSubCheck
      * @covers ::getResult
+     * @covers ::getProcess
      * @covers ::getDetails
      * @covers \Yoti\DocScan\Session\Retrieve\DetailsResponse::__construct
      * @covers \Yoti\DocScan\Session\Retrieve\DetailsResponse::getName
@@ -40,6 +43,7 @@ class BreakdownResponseTest extends TestCase
         $input = [
             'sub_check' => self::SOME_SUB_CHECK,
             'result' => self::SOME_RESULT,
+            'process' => self::SOME_PROCESS,
             'details' => self::SOME_DETAILS,
         ];
 
@@ -47,6 +51,7 @@ class BreakdownResponseTest extends TestCase
 
         $this->assertEquals(self::SOME_SUB_CHECK, $result->getSubCheck());
         $this->assertEquals(self::SOME_RESULT, $result->getResult());
+        $this->assertEquals(self::SOME_PROCESS, $result->getProcess());
 
         $details = $result->getDetails();
         for ($i = 0; $i < count(self::SOME_DETAILS); $i++) {
@@ -61,6 +66,7 @@ class BreakdownResponseTest extends TestCase
      * @covers ::__construct
      * @covers ::getSubCheck
      * @covers ::getResult
+     * @covers ::getProcess
      * @covers ::getDetails
      */
     public function shouldNotThrowExceptionWhenValuesAreMissing()
@@ -71,6 +77,7 @@ class BreakdownResponseTest extends TestCase
 
         $this->assertNull($result->getSubCheck());
         $this->assertNull($result->getResult());
+        $this->assertNull($result->getProcess());
         $this->assertCount(0, $result->getDetails());
     }
 }

--- a/tests/DocScan/Session/Retrieve/PageResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/PageResponseTest.php
@@ -57,6 +57,25 @@ class PageResponseTest extends TestCase
     }
 
     /**
+     * @covers ::__construct
+     * @covers ::getExtractionImageIds
+     */
+    public function testGetExtractionImageIds()
+    {
+        $extractionImageIds = [
+            '066a9372-0a52-4fe4-a026-866f8aee6fcb',
+            '9b0c9c0a-ff30-41ed-815b-d95d63271d45',
+        ];
+
+        $pageResponse = new PageResponse([
+            'extraction_image_ids' => $extractionImageIds,
+        ]);
+
+        $this->assertCount(2, $pageResponse->getExtractionImageIds());
+        $this->assertEquals($extractionImageIds, $pageResponse->getExtractionImageIds());
+    }
+
+    /**
      * @test
      * @covers ::__construct
      */
@@ -67,5 +86,6 @@ class PageResponseTest extends TestCase
         $this->assertNull($result->getCaptureMethod());
         $this->assertNull($result->getMedia());
         $this->assertEquals([], $result->getFrames());
+        $this->assertEquals([], $result->getExtractionImageIds());
     }
 }

--- a/tests/DocScan/Session/Retrieve/ResourceContainerTest.php
+++ b/tests/DocScan/Session/Retrieve/ResourceContainerTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Yoti\Test\DocScan\Session\Retrieve;
 
+use Yoti\DocScan\Session\Retrieve\ApplicantProfileResourceResponse;
 use Yoti\DocScan\Session\Retrieve\ResourceContainer;
 use Yoti\DocScan\Session\Retrieve\ShareCodeResourceResponse;
 use Yoti\DocScan\Session\Retrieve\StaticLivenessResourceResponse;
@@ -53,7 +54,10 @@ class ResourceContainerTest extends TestCase
             'share_codes' => [
                 ['id' => 'share-code-1'],
                 ['id' => 'share-code-2'],
-            ]
+            ],
+            'applicant_profiles' => [
+                ['id' => 'applicant-profile-1'],
+            ],
         ];
 
         $result = new ResourceContainer($input);
@@ -65,6 +69,7 @@ class ResourceContainerTest extends TestCase
         $this->assertCount(2, $result->getSupplementaryDocuments());
         $this->assertCount(1, $result->getFaceCapture());
         $this->assertCount(2, $result->getShareCodes());
+        $this->assertCount(1, $result->getApplicantProfiles());
     }
 
     /**
@@ -78,6 +83,7 @@ class ResourceContainerTest extends TestCase
         $this->assertCount(0, $result->getIdDocuments());
         $this->assertCount(0, $result->getLivenessCapture());
         $this->assertCount(0, $result->getShareCodes());
+        $this->assertCount(0, $result->getApplicantProfiles());
     }
 
     /**
@@ -174,5 +180,43 @@ class ResourceContainerTest extends TestCase
         );
         $this->assertEquals('share-code-1', $result->getShareCodes()[0]->getId());
         $this->assertEquals('share-code-2', $result->getShareCodes()[1]->getId());
+    }
+
+    /**
+     * @test
+     * @covers ::parseApplicantProfiles
+     * @covers ::getApplicantProfiles
+     */
+    public function shouldParseApplicantProfiles(): void
+    {
+        $input = [
+            'applicant_profiles' => [
+                [
+                    'id' => '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+                    'source' => ['type' => 'END_USER'],
+                    'media' => [
+                        'id' => 'media-id-123',
+                        'type' => 'IMAGE',
+                        'created' => '2021-06-11T11:39:24Z',
+                        'last_updated' => '2021-06-11T11:39:24Z',
+                    ],
+                    'created_at' => '2021-06-11T11:39:24Z',
+                    'last_updated' => '2021-06-11T11:39:24Z',
+                    'tasks' => [],
+                ],
+            ],
+        ];
+
+        $result = new ResourceContainer($input);
+
+        $this->assertCount(1, $result->getApplicantProfiles());
+        $this->assertContainsOnlyInstancesOf(
+            ApplicantProfileResourceResponse::class,
+            $result->getApplicantProfiles()
+        );
+        $this->assertEquals(
+            '3fa85f64-5717-4562-b3fc-2c963f66afa6',
+            $result->getApplicantProfiles()[0]->getId()
+        );
     }
 }

--- a/tests/DocScan/Session/Retrieve/TaskRecommendationReasonResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/TaskRecommendationReasonResponseTest.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Test\DocScan\Session\Retrieve;
+
+use Yoti\DocScan\Session\Retrieve\TaskRecommendationReasonResponse;
+use Yoti\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\DocScan\Session\Retrieve\TaskRecommendationReasonResponse
+ */
+class TaskRecommendationReasonResponseTest extends TestCase
+{
+    private const SOME_VALUE = 'USER_ERROR';
+    private const SOME_DETAIL = 'NO_DOCUMENT';
+
+    /**
+     * @test
+     * @covers ::__construct
+     * @covers ::getValue
+     * @covers ::getDetail
+     */
+    public function shouldBuildCorrectly()
+    {
+        $input = [
+            'value' => self::SOME_VALUE,
+            'detail' => self::SOME_DETAIL,
+        ];
+
+        $result = new TaskRecommendationReasonResponse($input);
+
+        $this->assertEquals(self::SOME_VALUE, $result->getValue());
+        $this->assertEquals(self::SOME_DETAIL, $result->getDetail());
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function shouldNotThrowExceptionWhenMissingValues()
+    {
+        $result = new TaskRecommendationReasonResponse([]);
+
+        $this->assertNull($result->getValue());
+        $this->assertNull($result->getDetail());
+    }
+}

--- a/tests/DocScan/Session/Retrieve/TaskRecommendationResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/TaskRecommendationResponseTest.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\Test\DocScan\Session\Retrieve;
+
+use Yoti\DocScan\Session\Retrieve\TaskRecommendationReasonResponse;
+use Yoti\DocScan\Session\Retrieve\TaskRecommendationResponse;
+use Yoti\Test\TestCase;
+
+/**
+ * @coversDefaultClass \Yoti\DocScan\Session\Retrieve\TaskRecommendationResponse
+ */
+class TaskRecommendationResponseTest extends TestCase
+{
+    private const SOME_VALUE = 'MUST_TRY_AGAIN';
+    private const SOME_REASON_VALUE = 'USER_ERROR';
+    private const SOME_REASON_DETAIL = 'NO_DOCUMENT';
+
+    /**
+     * @test
+     * @covers ::__construct
+     * @covers ::getValue
+     * @covers ::getReason
+     */
+    public function shouldBuildCorrectly()
+    {
+        $input = [
+            'value' => self::SOME_VALUE,
+            'reason' => [
+                'value' => self::SOME_REASON_VALUE,
+                'detail' => self::SOME_REASON_DETAIL,
+            ],
+        ];
+
+        $result = new TaskRecommendationResponse($input);
+
+        $this->assertEquals(self::SOME_VALUE, $result->getValue());
+        $this->assertInstanceOf(TaskRecommendationReasonResponse::class, $result->getReason());
+        $this->assertEquals(self::SOME_REASON_VALUE, $result->getReason()->getValue());
+        $this->assertEquals(self::SOME_REASON_DETAIL, $result->getReason()->getDetail());
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     */
+    public function shouldNotThrowExceptionWhenMissingValues()
+    {
+        $result = new TaskRecommendationResponse([]);
+
+        $this->assertNull($result->getValue());
+        $this->assertNull($result->getReason());
+    }
+}

--- a/tests/DocScan/Session/Retrieve/TaskResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/TaskResponseTest.php
@@ -7,6 +7,8 @@ namespace Yoti\Test\DocScan\Session\Retrieve;
 use Yoti\DocScan\Session\Retrieve\GeneratedCheckResponse;
 use Yoti\DocScan\Session\Retrieve\GeneratedMedia;
 use Yoti\DocScan\Session\Retrieve\GeneratedTextDataCheckResponse;
+use Yoti\DocScan\Session\Retrieve\TaskRecommendationReasonResponse;
+use Yoti\DocScan\Session\Retrieve\TaskRecommendationResponse;
 use Yoti\DocScan\Session\Retrieve\TaskResponse;
 use Yoti\Test\TestCase;
 use Yoti\Util\DateTime;
@@ -25,6 +27,9 @@ class TaskResponseTest extends TestCase
     private const SOME_UNKNOWN_TYPE = 'someUnknownType';
     private const ID_DOCUMENT_TEXT_DATA_CHECK = 'ID_DOCUMENT_TEXT_DATA_CHECK';
     private const SUPPLEMENTARY_DOCUMENT_TEXT_DATA_CHECK = 'SUPPLEMENTARY_DOCUMENT_TEXT_DATA_CHECK';
+    private const SOME_RECOMMENDATION_VALUE = 'MUST_TRY_AGAIN';
+    private const SOME_RECOMMENDATION_REASON_VALUE = 'USER_ERROR';
+    private const SOME_RECOMMENDATION_REASON_DETAIL = 'NO_DOCUMENT';
 
     /**
      * @var TaskResponse
@@ -56,6 +61,13 @@ class TaskResponseTest extends TestCase
             'generated_media' => [
                 [],
                 [],
+            ],
+            'recommendation' => [
+                'value' => self::SOME_RECOMMENDATION_VALUE,
+                'reason' => [
+                    'value' => self::SOME_RECOMMENDATION_REASON_VALUE,
+                    'detail' => self::SOME_RECOMMENDATION_REASON_DETAIL,
+                ],
             ],
          ]);
     }
@@ -185,5 +197,22 @@ class TaskResponseTest extends TestCase
         $this->assertNull($result->getLastUpdated());
         $this->assertCount(0, $result->getGeneratedChecks());
         $this->assertCount(0, $result->getGeneratedMedia());
+        $this->assertNull($result->getRecommendation());
+    }
+
+    /**
+     * @test
+     * @covers ::__construct
+     * @covers ::getRecommendation
+     */
+    public function shouldReturnRecommendation()
+    {
+        $recommendation = $this->taskResponse->getRecommendation();
+
+        $this->assertInstanceOf(TaskRecommendationResponse::class, $recommendation);
+        $this->assertEquals(self::SOME_RECOMMENDATION_VALUE, $recommendation->getValue());
+        $this->assertInstanceOf(TaskRecommendationReasonResponse::class, $recommendation->getReason());
+        $this->assertEquals(self::SOME_RECOMMENDATION_REASON_VALUE, $recommendation->getReason()->getValue());
+        $this->assertEquals(self::SOME_RECOMMENDATION_REASON_DETAIL, $recommendation->getReason()->getDetail());
     }
 }


### PR DESCRIPTION
## Release 4.5.0                                                                             
                                                                                               
  ### Breaking Changes                                                                         
  - **PHP 8.1+ required** — Dropped support for PHP 7.4 and 8.0. CI now tests PHP 8.1–8.4 only 
  (#408)                                                                                       
   
  ### Security Fixes                                                                           
  - **google/protobuf** upgraded from ^3.10 to ^4.33.6 — fixes DoS via malicious messages with 
  negative varints or deep recursion (GHSA-p2gh-cfq4-4wjc, HIGH) (#408)                        
  - **phpseclib** upgraded from ^3.0 to ^3.0.50 — fixes AES-CBC padding oracle timing attack
  (CVE-2026-32935, MEDIUM) (#408)                                                              
                                                                                             
  ### New Features                                                                             
  - **Extraction Image IDs** — `PageResponse::getExtractionImageIds()` exposes which media was
  used for automated data extraction on IDV document pages (#409)                              
  - **Breakdown Process** — `BreakdownResponse::getProcess()` exposes the breakdown process
  type (`AUTOMATED` / `EXPERT_REVIEW`) (#410)                                                  
  - **Task Recommendation** — `TaskResponse::getRecommendation()` deserializes task-level    
  recommendation data including value, reason, and detail (#404)                               
  - **Applicant Profile (Create)** — Support for supplying applicant profile data (name,     
  address) when creating Identity Profile sessions via `SessionSpecificationBuilder` (#405)    
  - **Applicant Profile (Retrieve)** — `GetSessionResult` now deserializes `applicant_profiles`
   from session resources, exposing media, timestamps, and tasks (#406)                        
                                                                                             
  ### PRs Included                                                                             
  - #404 — SDK-2793: Task response recommendation support                                    
  - #405 — SDK-2215: Applicant profile in session creation                                     
  - #406 — SDK-2296: Applicant profile retrieval from sessions
  - #408 — SDK-2795: Protobuf/phpseclib upgrade + PHP 8.1 minimum                              
  - #409 — SDK-2791: Extraction image IDs on page response                                     
  - #410 — SDK-2742: Breakdown process property   