### PR TITLE
Release 4.5.0

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -8,8 +8,8 @@ jobs:
     # always run on push events
     # only run on pull_request_target event when pull request pulls from fork repository
     if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository 
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:
@@ -31,11 +31,61 @@ jobs:
 
       - run: composer test
 
+  php8-2:
+    name: Unit Tests php8.2 (php ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ 8.2 ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@2.9.0
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - run: composer remove --dev --no-update --no-interaction friendsofphp/php-cs-fixer
+
+      - run: composer self-update
+
+      - run: composer install --no-interaction --prefer-source --dev
+
+      - run: composer test
+
+  php8-3:
+    name: Unit Tests php8.3 (php ${{ matrix.php-version }})
+    runs-on: ubuntu-latest
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
+    strategy:
+      fail-fast: false
+      matrix:
+        php-version: [ 8.3 ]
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: shivammathur/setup-php@2.9.0
+        with:
+          php-version: ${{ matrix.php-version }}
+
+      - run: composer remove --dev --no-update --no-interaction friendsofphp/php-cs-fixer
+
+      - run: composer self-update
+
+      - run: composer install --no-interaction --prefer-source --dev
+
+      - run: composer test
+
   php8-4:
     name: Unit Tests php8.4 (php ${{ matrix.php-version }})
     runs-on: ubuntu-latest
-    # always run on push events
-    # only run on pull_request_target event when pull request pulls from fork repository
     if: >
       github.event_name == 'push' ||
       github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
@@ -51,8 +101,6 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
 
-      # Remove php-cs-fixer until compatible with PHP 8
-      # This step might be removable if php-cs-fixer is compatible with 8.4 by the time this runs
       - run: composer remove --dev --no-update --no-interaction friendsofphp/php-cs-fixer
 
       - run: composer self-update
@@ -61,66 +109,14 @@ jobs:
 
       - run: composer test
 
-  php7-4:
-    name: Unit Tests php7.4 (php ${{ matrix.php-version }})
-    runs-on: ubuntu-latest
-    # always run on push events
-    # only run on pull_request_target event when pull request pulls from fork repository
-    if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version: [ 7.4 ]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: shivammathur/setup-php@2.9.0
-        with:
-          php-version: ${{ matrix.php-version }}
-
-      - run: composer self-update
-
-      - run: composer install --no-interaction --prefer-source --dev
-
-      - run: composer test
-
-  php8-0:
-    name: Unit Tests php8.0 (php ${{ matrix.php-version }})
-    runs-on: ubuntu-latest
-    # always run on push events
-    # only run on pull_request_target event when pull request pulls from fork repository
-    if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
-    strategy:
-      fail-fast: false
-      matrix:
-        php-version: [ 8.0 ]
-
-    steps:
-      - uses: actions/checkout@v2
-
-      - uses: shivammathur/setup-php@2.9.0
-        with:
-          php-version: ${{ matrix.php-version }}
-
-      - run: composer self-update
-
-      - run: composer install --no-interaction --prefer-source --dev
-
-      - run: composer test
-
   protobuf:
-    name: Unit Tests With Protobuf C Extension 3.13 (php ${{ matrix.php-version }})
+    name: Unit Tests With Protobuf C Extension (php ${{ matrix.php-version }})
     runs-on: ubuntu-latest
     # always run on push events
     # only run on pull_request_target event when pull request pulls from fork repository
     if: >
-      github.event_name == 'push' || 
-      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository 
+      github.event_name == 'push' ||
+      github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != github.repository
     strategy:
       fail-fast: false
       matrix:

--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ coverage
 
 .DS_Store
 .php-cs-fixer.cache
+.claude/

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Please feel free to reach out
 
 ## Requirements
 
-* PHP ^7.4 || ^8.0 || ^8.1
+* PHP ^8.1
 * CURL PHP extension (must support TLSv1.2)
 
 ### Recommended (optional)
@@ -42,13 +42,13 @@ Add the Yoti SDK dependency:
 
 ```json
 "require": {
-    "yoti/yoti-php-sdk" : "^4.4.2"
+    "yoti/yoti-php-sdk" : "^4.5.0"
 }
 ```
 
 Or run this Composer command
 ```console
-$ composer require yoti/yoti-php-sdk "^4.4.2"
+$ composer require yoti/yoti-php-sdk "^4.5.0"
 ```
 
 ## Setup

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
   "name": "yoti/yoti-php-sdk",
   "description": "Yoti SDK for quickly integrating your PHP backend with Yoti",
-  "version": "4.4.2",
+  "version": "4.5.0",
   "keywords": [
     "yoti",
     "sdk"
@@ -9,10 +9,10 @@
   "homepage": "https://yoti.com",
   "license": "MIT",
   "require": {
-    "php": "^7.4 || ^8.0 || ^8.1 || ^8.4",
+    "php": "^8.1",
     "ext-json": "*",
-    "google/protobuf": "^3.10",
-    "phpseclib/phpseclib": "^3.0",
+    "google/protobuf": "^4.33.6",
+    "phpseclib/phpseclib": "^3.0.50",
     "guzzlehttp/guzzle": "^7.0",
     "psr/http-client": "^1.0",
     "psr/http-message": "^2.0",

--- a/examples/doc-scan/app/Http/Controllers/HomeController.php
+++ b/examples/doc-scan/app/Http/Controllers/HomeController.php
@@ -152,11 +152,19 @@ class HomeController extends BaseController
                     ->withPrivacyPolicyUrl(config('app.url') . '/privacy-policy')
                     ->withBiometricConsentFlow('EARLY')
                     ->withBrandId('brand_id')
-                    // Suppress specific screens to shorten the flow
-                    ->withSuppressedScreens(['intro_screen', 'document_capture_instruction'])
+                    // Suppress specific screens to shorten the flow.
+                    // Available screen identifiers:
+                    //   'IDENTITY_DOCUMENT_EDUCATION'
+                    //   'IDENTITY_DOCUMENT_REQUIREMENTS'
+                    //   'SUPPLEMENTARY_DOCUMENT_REQUIREMENTS'
+                    //   'ZOOM_LIVENESS_EDUCATION'
+                    //   'STATIC_LIVENESS_EDUCATION'
+                    //   'FACE_CAPTURE_EDUCATION'
+                    //   'FLOW_COMPLETION'
+                    // ->withSuppressedScreens(['IDENTITY_DOCUMENT_EDUCATION', 'IDENTITY_DOCUMENT_REQUIREMENTS'])
                     // Or add screens individually:
-                    // ->withSuppressedScreen('intro_screen')
-                    // ->withSuppressedScreen('document_capture_instruction')
+                    // ->withSuppressedScreen('IDENTITY_DOCUMENT_EDUCATION')
+                    // ->withSuppressedScreen('IDENTITY_DOCUMENT_REQUIREMENTS')
                     ->build()
             )
             ->withRequiredDocument(

--- a/examples/doc-scan/app/Http/Controllers/HomeController.php
+++ b/examples/doc-scan/app/Http/Controllers/HomeController.php
@@ -151,20 +151,7 @@ class HomeController extends BaseController
                     ->withErrorUrl(config('app.url') . '/error')
                     ->withPrivacyPolicyUrl(config('app.url') . '/privacy-policy')
                     ->withBiometricConsentFlow('EARLY')
-                    ->withBrandId('brand_id')
-                    // Suppress specific screens to shorten the flow.
-                    // Available screen identifiers:
-                    //   'IDENTITY_DOCUMENT_EDUCATION'
-                    //   'IDENTITY_DOCUMENT_REQUIREMENTS'
-                    //   'SUPPLEMENTARY_DOCUMENT_REQUIREMENTS'
-                    //   'ZOOM_LIVENESS_EDUCATION'
-                    //   'STATIC_LIVENESS_EDUCATION'
-                    //   'FACE_CAPTURE_EDUCATION'
-                    //   'FLOW_COMPLETION'
-                    // ->withSuppressedScreens(['IDENTITY_DOCUMENT_EDUCATION', 'IDENTITY_DOCUMENT_REQUIREMENTS'])
-                    // Or add screens individually:
-                    // ->withSuppressedScreen('IDENTITY_DOCUMENT_EDUCATION')
-                    // ->withSuppressedScreen('IDENTITY_DOCUMENT_REQUIREMENTS')
+                    //->withBrandId('brand_id')
                     ->build()
             )
             ->withRequiredDocument(

--- a/src/Constants.php
+++ b/src/Constants.php
@@ -37,7 +37,7 @@ class Constants
     public const SDK_IDENTIFIER = 'PHP';
 
     /** Default SDK version */
-    public const SDK_VERSION = '4.4.2';
+    public const SDK_VERSION = '4.5.0';
 
     /** Base url for connect page (user will be redirected to this page eg. baseurl/app-id) */
     public const CONNECT_BASE_URL = 'https://www.yoti.com/connect';

--- a/tests/DocScan/Session/Create/SdkConfigBuilderTest.php
+++ b/tests/DocScan/Session/Create/SdkConfigBuilderTest.php
@@ -26,8 +26,8 @@ class SdkConfigBuilderTest extends TestCase
     private const SOME_DARK_MODE = 'someDarkMode';
     private const SOME_PRIMARY_COLOUR_DARK_MODE = 'somePrimaryColourDarkMode';
     private const SOME_BRAND_ID = 'someBrandId';
-    private const SOME_SCREEN_IDENTIFIER = 'someScreenIdentifier';
-    private const ANOTHER_SCREEN_IDENTIFIER = 'anotherScreenIdentifier';
+    private const SOME_SCREEN_IDENTIFIER = 'IDENTITY_DOCUMENT_EDUCATION';
+    private const ANOTHER_SCREEN_IDENTIFIER = 'IDENTITY_DOCUMENT_REQUIREMENTS';
 
     /**
      * @test

--- a/tests/DocScan/Session/Retrieve/Configuration/SessionConfigurationResponseTest.php
+++ b/tests/DocScan/Session/Retrieve/Configuration/SessionConfigurationResponseTest.php
@@ -14,8 +14,8 @@ class SessionConfigurationResponseTest extends TestCase
     private const SOME_CLIENT_SESSION_TTL = 12345678;
     private const SOME_SESSION_ID = 'SOME_SESSION_ID';
     private const SOME_REQUESTED_CHECKS = ['SOME_CHECK', 'SOME_ANOTHER_CHECK'];
-    private const SOME_SCREEN_IDENTIFIER = 'someScreenIdentifier';
-    private const ANOTHER_SCREEN_IDENTIFIER = 'anotherScreenIdentifier';
+    private const SOME_SCREEN_IDENTIFIER = 'IDENTITY_DOCUMENT_EDUCATION';
+    private const ANOTHER_SCREEN_IDENTIFIER = 'IDENTITY_DOCUMENT_REQUIREMENTS';
     private const SOME_CAPTURE = [
         'biometric_consent' => 'SOME_STRING',
         'required_resources' => [


### PR DESCRIPTION
## Release 4.5.0                                                                       
                                                                                               
  ### Breaking Changes                                                                         
  - **PHP 8.1+ required** — Dropped support for PHP 7.4 and 8.0. CI now tests PHP 8.1–8.4 only 
  (#408)                                                                                       
   
  ### Security Fixes                                                                           
  - **google/protobuf** upgraded from ^3.10 to ^4.33.6 — fixes DoS via malicious messages with 
  negative varints or deep recursion (GHSA-p2gh-cfq4-4wjc, HIGH) (#408)                        
  - **phpseclib** upgraded from ^3.0 to ^3.0.50 — fixes AES-CBC padding oracle timing attack
  (CVE-2026-32935, MEDIUM) (#408)                                                              
                         
                                                                                             
  ### PRs Included                                                                             
  - #408 — SDK-2795: Protobuf/phpseclib upgrade + PHP 8.1 minimum  