### PR TITLE
SDK-2615: PHP - Support configuration for IDV shortened flow - php

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(git rev-list *)",
+      "Bash(./vendor/bin/phpunit --filter 'SdkConfigBuilderTest|SessionConfigurationResponseTest')",
+      "Bash(git config *)"
+    ]
+  }
+}

--- a/src/DocScan/Session/Create/SdkConfig.php
+++ b/src/DocScan/Session/Create/SdkConfig.php
@@ -296,4 +296,19 @@ class SdkConfig implements \JsonSerializable
     {
         return $this->suppressedScreens;
     }
+
+    /**
+     * Returns true when the given screen identifier has been configured to be suppressed.
+     *
+     * @param string $screenIdentifier
+     * @return bool
+     */
+    public function isScreenSuppressed(string $screenIdentifier): bool
+    {
+        if ($this->suppressedScreens === null) {
+            return false;
+        }
+
+        return in_array($screenIdentifier, $this->suppressedScreens, true);
+    }
 }

--- a/src/DocScan/Session/Create/SuppressedScreen.php
+++ b/src/DocScan/Session/Create/SuppressedScreen.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Yoti\DocScan\Session\Create;
+
+class SuppressedScreen
+{
+    public const ID_DOCUMENT_EDUCATION = 'ID_DOCUMENT_EDUCATION';
+    public const ID_DOCUMENT_REQUIREMENTS = 'ID_DOCUMENT_REQUIREMENTS';
+    public const SUPPLEMENTARY_DOCUMENT_EDUCATION = 'SUPPLEMENTARY_DOCUMENT_EDUCATION';
+    public const ZOOM_LIVENESS_EDUCATION = 'ZOOM_LIVENESS_EDUCATION';
+    public const STATIC_LIVENESS_EDUCATION = 'STATIC_LIVENESS_EDUCATION';
+    public const FACE_CAPTURE_EDUCATION = 'FACE_CAPTURE_EDUCATION';
+    public const FLOW_COMPLETION = 'FLOW_COMPLETION';
+}

--- a/tests/DocScan/Session/Create/SdkConfigBuilderTest.php
+++ b/tests/DocScan/Session/Create/SdkConfigBuilderTest.php
@@ -4,6 +4,7 @@ namespace Yoti\Test\DocScan\Session\Create;
 
 use Yoti\DocScan\Constants;
 use Yoti\DocScan\Session\Create\SdkConfigBuilder;
+use Yoti\DocScan\Session\Create\SuppressedScreen;
 use Yoti\Test\TestCase;
 
 /**
@@ -439,5 +440,115 @@ class SdkConfigBuilderTest extends TestCase
 
         $jsonData = $result->jsonSerialize();
         $this->assertFalse(property_exists($jsonData, 'suppressed_screens'));
+    }
+
+    /**
+     * @test
+     * @covers ::withSuppressedScreens
+     * @covers \Yoti\DocScan\Session\Create\SdkConfig::getSuppressedScreens
+     */
+    public function shouldAllowEmptySuppressedScreensArray()
+    {
+        $result = (new SdkConfigBuilder())
+            ->withSuppressedScreens([])
+            ->build();
+
+        $this->assertSame([], $result->getSuppressedScreens());
+    }
+
+    /**
+     * @test
+     * @covers ::withSuppressedScreens
+     * @covers \Yoti\DocScan\Session\Create\SdkConfig::getSuppressedScreens
+     */
+    public function shouldBuildUsingSuppressedScreenConstants()
+    {
+        $suppressedScreens = [
+            SuppressedScreen::ID_DOCUMENT_EDUCATION,
+            SuppressedScreen::ID_DOCUMENT_REQUIREMENTS,
+            SuppressedScreen::SUPPLEMENTARY_DOCUMENT_EDUCATION,
+            SuppressedScreen::ZOOM_LIVENESS_EDUCATION,
+            SuppressedScreen::STATIC_LIVENESS_EDUCATION,
+            SuppressedScreen::FACE_CAPTURE_EDUCATION,
+            SuppressedScreen::FLOW_COMPLETION,
+        ];
+
+        $result = (new SdkConfigBuilder())
+            ->withSuppressedScreens($suppressedScreens)
+            ->build();
+
+        $this->assertEquals($suppressedScreens, $result->getSuppressedScreens());
+    }
+
+    /**
+     * @test
+     * @covers \Yoti\DocScan\Session\Create\SuppressedScreen
+     */
+    public function suppressedScreenConstantsShouldHaveExpectedValues()
+    {
+        $this->assertSame('ID_DOCUMENT_EDUCATION', SuppressedScreen::ID_DOCUMENT_EDUCATION);
+        $this->assertSame('ID_DOCUMENT_REQUIREMENTS', SuppressedScreen::ID_DOCUMENT_REQUIREMENTS);
+        $this->assertSame(
+            'SUPPLEMENTARY_DOCUMENT_EDUCATION',
+            SuppressedScreen::SUPPLEMENTARY_DOCUMENT_EDUCATION
+        );
+        $this->assertSame('ZOOM_LIVENESS_EDUCATION', SuppressedScreen::ZOOM_LIVENESS_EDUCATION);
+        $this->assertSame('STATIC_LIVENESS_EDUCATION', SuppressedScreen::STATIC_LIVENESS_EDUCATION);
+        $this->assertSame('FACE_CAPTURE_EDUCATION', SuppressedScreen::FACE_CAPTURE_EDUCATION);
+        $this->assertSame('FLOW_COMPLETION', SuppressedScreen::FLOW_COMPLETION);
+    }
+
+    /**
+     * @test
+     * @covers \Yoti\DocScan\Session\Create\SdkConfig::isScreenSuppressed
+     */
+    public function isScreenSuppressedShouldReturnTrueForListedScreen()
+    {
+        $result = (new SdkConfigBuilder())
+            ->withSuppressedScreens([
+                SuppressedScreen::ID_DOCUMENT_EDUCATION,
+                SuppressedScreen::FLOW_COMPLETION,
+            ])
+            ->build();
+
+        $this->assertTrue($result->isScreenSuppressed(SuppressedScreen::ID_DOCUMENT_EDUCATION));
+        $this->assertTrue($result->isScreenSuppressed(SuppressedScreen::FLOW_COMPLETION));
+    }
+
+    /**
+     * @test
+     * @covers \Yoti\DocScan\Session\Create\SdkConfig::isScreenSuppressed
+     */
+    public function isScreenSuppressedShouldReturnFalseForUnlistedScreen()
+    {
+        $result = (new SdkConfigBuilder())
+            ->withSuppressedScreen(SuppressedScreen::ID_DOCUMENT_EDUCATION)
+            ->build();
+
+        $this->assertFalse($result->isScreenSuppressed(SuppressedScreen::FLOW_COMPLETION));
+    }
+
+    /**
+     * @test
+     * @covers \Yoti\DocScan\Session\Create\SdkConfig::isScreenSuppressed
+     */
+    public function isScreenSuppressedShouldReturnFalseWhenSuppressedScreensIsNull()
+    {
+        $result = (new SdkConfigBuilder())->build();
+
+        $this->assertFalse($result->isScreenSuppressed(SuppressedScreen::ID_DOCUMENT_EDUCATION));
+    }
+
+    /**
+     * @test
+     * @covers \Yoti\DocScan\Session\Create\SdkConfig::isScreenSuppressed
+     */
+    public function isScreenSuppressedShouldBeCaseSensitive()
+    {
+        $result = (new SdkConfigBuilder())
+            ->withSuppressedScreen(SuppressedScreen::ID_DOCUMENT_EDUCATION)
+            ->build();
+
+        $this->assertFalse($result->isScreenSuppressed('id_document_education'));
     }
 }


### PR DESCRIPTION
## Summary
Adds first-class support for configuring the IDV shortened flow by introducing a `SuppressedScreen` constants class and a convenience `isScreenSuppressed()` lookup on `SdkConfig`. This lets integrators suppress specific IDV screens (e.g. education, requirements, flow completion) using named constants rather than raw strings, and inspect whether a given screen has been suppressed.

## Changes
- `src/DocScan/Session/Create/SuppressedScreen.php` (new): Defines string constants for the supported suppressible screens: `ID_DOCUMENT_EDUCATION`, `ID_DOCUMENT_REQUIREMENTS`, `SUPPLEMENTARY_DOCUMENT_EDUCATION`, `ZOOM_LIVENESS_EDUCATION`, `STATIC_LIVENESS_EDUCATION`, `FACE_CAPTURE_EDUCATION`, `FLOW_COMPLETION`.
- `src/DocScan/Session/Create/SdkConfig.php`: Adds `isScreenSuppressed(string $screenIdentifier): bool`, which returns `false` when no suppressed screens are configured and otherwise performs a strict `in_array` check against the configured list.
- `tests/DocScan/Session/Create/SdkConfigBuilderTest.php`: Adds coverage for empty-array suppressed screens, building with the new constants, constant value assertions, and `isScreenSuppressed` across matched, unmatched, null, and case-sensitivity scenarios.
- `.claude/settings.local.json`: Local tooling settings update (not production code).

## QA Test Steps
1. Check out the branch and run `composer install` to install dependencies.
2. Run the full test suite: `vendor/bin/phpunit` — confirm all tests pass, including the new ones in `SdkConfigBuilderTest`.
3. Run just the targeted class to focus review:
   `vendor/bin/phpunit --filter SdkConfigBuilderTest tests/DocScan/Session/Create/SdkConfigBuilderTest.php`.
4. Happy path — constants usage: In a scratch script, build an `SdkConfig` via `SdkConfigBuilder::withSuppressedScreens([SuppressedScreen::ID_DOCUMENT_EDUCATION, SuppressedScreen::FLOW_COMPLETION])` and assert `getSuppressedScreens()` returns exactly those values, and that `isScreenSuppressed(SuppressedScreen::ID_DOCUMENT_EDUCATION)` returns `true`.
5. Happy path — single screen: Use `withSuppressedScreen(SuppressedScreen::ID_DOCUMENT_EDUCATION)` and verify `isScreenSuppressed(SuppressedScreen::ID_DOCUMENT_EDUCATION)` is `true` while `isScreenSuppressed(SuppressedScreen::FLOW_COMPLETION)` is `false`.
6. Edge — empty list: `withSuppressedScreens([])` builds successfully and `getSuppressedScreens()` returns `[]`.
7. Edge — not configured: An `SdkConfigBuilder` with no suppressed-screen call produces an `SdkConfig` where `isScreenSuppressed(...)` returns `false` for every constant (null-safe behavior).
8. Edge — case sensitivity: After suppressing `SuppressedScreen::ID_DOCUMENT_EDUCATION`, call `isScreenSuppressed('id_document_education')` and verify it returns `false` (strict comparison).
9. Constants sanity: Verify each `SuppressedScreen::*` constant string value matches its identifier name exactly (e.g. `SuppressedScreen::FLOW_COMPLETION === 'FLOW_COMPLETION'`).
10. Regression — serialization: Build an `SdkConfig` without calling any suppressed-screens setter and confirm `jsonSerialize()` output does not contain a `suppressed_screens` property (pre-existing behavior retained).
11. Regression — existing suppressed-screen flows: Create a full DocScan session against the sandbox using a config with `withSuppressedScreens([...])` and verify the `sdk_config.suppressed_screens` array in the outbound request payload is unchanged from prior releases.
12. Run static analysis / linters used by the repo (e.g. `composer test` or any CI command defined in `composer.json`) and confirm no new warnings.

## Notes
- The `SuppressedScreen` class is a plain constants holder (no enum) to stay consistent with the PHP version floor of the SDK and with existing constants-style classes in the codebase.
- `isScreenSuppressed()` is case-sensitive by design, matching the exact string values the backend expects.
- No changes to the `SdkConfigBuilder` public API or the JSON wire format — this is purely additive (new class + new read helper), so existing integrations continue to work unchanged.
- `.claude/settings.local.json` is an ancillary tooling file; reviewers may want to confirm whether it should be committed or gitignored per project convention.

---

*Related Jira:* SDK-2615
*Auto-generated by n8n + Claude CLI*