### PR TITLE
SDK-2791: Render extraction_image_ids on doc-scan success page

### DIFF
--- a/examples/doc-scan/resources/views/success.blade.php
+++ b/examples/doc-scan/resources/views/success.blade.php
@@ -562,6 +562,23 @@
                                                 </div>
                                             @endif
 
+                                            @if (count($page->getExtractionImageIds()) > 0)
+                                                <div class="card-group">
+                                                    <div class="card" style="width: 18rem;">
+                                                        <div class="card-body">
+                                                            <h6 class="card-title">Extraction Image IDs</h6>
+                                                            <ul class="list-unstyled mb-0">
+                                                                @foreach ($page->getExtractionImageIds() as $extractionImageId)
+                                                                    <li>
+                                                                        <a href="/media/{{ $extractionImageId }}" target="_blank">{{ $extractionImageId }}</a>
+                                                                    </li>
+                                                                @endforeach
+                                                            </ul>
+                                                        </div>
+                                                    </div>
+                                                </div>
+                                            @endif
+
                                         </div>
                                     </div>
                                 @endforeach
@@ -740,6 +757,23 @@
                                                             </div>
                                                         @endif
                                                     @endforeach
+                                                </div>
+                                            @endif
+
+                                            @if (count($page->getExtractionImageIds()) > 0)
+                                                <div class="card-group">
+                                                    <div class="card" style="width: 18rem;">
+                                                        <div class="card-body">
+                                                            <h6 class="card-title">Extraction Image IDs</h6>
+                                                            <ul class="list-unstyled mb-0">
+                                                                @foreach ($page->getExtractionImageIds() as $extractionImageId)
+                                                                    <li>
+                                                                        <a href="/media/{{ $extractionImageId }}" target="_blank">{{ $extractionImageId }}</a>
+                                                                    </li>
+                                                                @endforeach
+                                                            </ul>
+                                                        </div>
+                                                    </div>
                                                 </div>
                                             @endif
 


### PR DESCRIPTION
Add UI block to display extraction image IDs for each page of ID documents and supplementary documents on the success view. Each ID is rendered as a link to the existing /media/{id} route so the image can be opened directly for QA verification. Block is hidden when the array is empty.