### PR TITLE
Release/4.5.2

### DIFF
--- a/src/Http/AuthStrategy/SignedRequestStrategy.php
+++ b/src/Http/AuthStrategy/SignedRequestStrategy.php
@@ -61,7 +61,7 @@ class SignedRequestStrategy implements AuthStrategyInterface
     {
         $params = [
             'nonce' => self::generateNonce(),
-            'timestamp' => (string)(round(microtime(true) * 1000)),
+            'timestamp' => sprintf('%.0F', microtime(true) * 1000),
         ];
 
         if ($this->sdkId !== null) {

--- a/tests/Http/AuthStrategy/SignedRequestStrategyTest.php
+++ b/tests/Http/AuthStrategy/SignedRequestStrategyTest.php
@@ -77,17 +77,19 @@ class SignedRequestStrategyTest extends TestCase
      * can cause (string)(round(microtime(true) * 1000)) to emit scientific notation
      * (e.g. "1.78231576830E+12"), which breaks Yoti signature verification with 401.
      */
-    public function shouldReturnTimestampAsPlainIntegerStringUnderLowPrecision(string $precision): void
+    public function shouldReturnTimestampAsPlainIntegerStringUnderLowPrecision(string $precision)
     {
         $strategy = new SignedRequestStrategy(PemFile::fromFilePath(TestData::PEM_FILE));
 
         $originalPrecision = ini_get('precision');
-        ini_set('precision', $precision);
+        if ($originalPrecision === false || ini_set('precision', $precision) === false) {
+            $this->markTestSkipped('Unable to set ini precision for this runtime');
+        }
 
         try {
             $params = $strategy->createQueryParams();
         } finally {
-            ini_set('precision', $originalPrecision);
+            ini_set('precision', (string) $originalPrecision);
         }
 
         $this->assertMatchesRegularExpression(
@@ -109,19 +111,21 @@ class SignedRequestStrategyTest extends TestCase
      * @test
      * @covers ::createQueryParams
      */
-    public function shouldReturnTimestampAsUnixMilliseconds(): void
+    public function shouldReturnTimestampAsUnixMilliseconds()
     {
         $strategy = new SignedRequestStrategy(PemFile::fromFilePath(TestData::PEM_FILE));
 
         $originalPrecision = ini_get('precision');
-        ini_set('precision', '8');
+        if ($originalPrecision === false || ini_set('precision', '8') === false) {
+            $this->markTestSkipped('Unable to set ini precision for this runtime');
+        }
 
         try {
             $beforeMs = (int) floor(microtime(true) * 1000);
             $params = $strategy->createQueryParams();
             $afterMs = (int) ceil(microtime(true) * 1000);
         } finally {
-            ini_set('precision', $originalPrecision);
+            ini_set('precision', (string) $originalPrecision);
         }
 
         // Assert plain integer format first — (int) cast alone would mask scientific notation

--- a/tests/Http/AuthStrategy/SignedRequestStrategyTest.php
+++ b/tests/Http/AuthStrategy/SignedRequestStrategyTest.php
@@ -71,6 +71,68 @@ class SignedRequestStrategyTest extends TestCase
     /**
      * @test
      * @covers ::createQueryParams
+     * @dataProvider lowPrecisionProvider
+     *
+     * On PHP 8.4 FPM environments (e.g. WP Engine) the `precision` ini setting
+     * can cause (string)(round(microtime(true) * 1000)) to emit scientific notation
+     * (e.g. "1.78231576830E+12"), which breaks Yoti signature verification with 401.
+     */
+    public function shouldReturnTimestampAsPlainIntegerStringUnderLowPrecision(string $precision): void
+    {
+        $strategy = new SignedRequestStrategy(PemFile::fromFilePath(TestData::PEM_FILE));
+
+        $originalPrecision = ini_get('precision');
+        ini_set('precision', $precision);
+
+        try {
+            $params = $strategy->createQueryParams();
+        } finally {
+            ini_set('precision', $originalPrecision);
+        }
+
+        $this->assertMatchesRegularExpression(
+            '/^\d+$/',
+            $params['timestamp'],
+            "Timestamp must be a plain integer string (no scientific notation) at precision={$precision}"
+        );
+    }
+
+    public function lowPrecisionProvider(): array
+    {
+        return [
+            'precision=12' => ['12'],
+            'precision=8'  => ['8'],
+        ];
+    }
+
+    /**
+     * @test
+     * @covers ::createQueryParams
+     */
+    public function shouldReturnTimestampAsUnixMilliseconds(): void
+    {
+        $strategy = new SignedRequestStrategy(PemFile::fromFilePath(TestData::PEM_FILE));
+
+        $originalPrecision = ini_get('precision');
+        ini_set('precision', '8');
+
+        try {
+            $beforeMs = (int) floor(microtime(true) * 1000);
+            $params = $strategy->createQueryParams();
+            $afterMs = (int) ceil(microtime(true) * 1000);
+        } finally {
+            ini_set('precision', $originalPrecision);
+        }
+
+        // Assert plain integer format first — (int) cast alone would mask scientific notation
+        $this->assertMatchesRegularExpression('/^\d+$/', $params['timestamp']);
+        $this->assertGreaterThanOrEqual($beforeMs, (int) $params['timestamp']);
+        $this->assertLessThanOrEqual($afterMs, (int) $params['timestamp']);
+    }
+
+    /**
+     * @test
+     * @covers ::createQueryParams
      */
     public function shouldIncludeNonceAsUuidFormat()
     {

--- a/tests/Http/ClientTest.php
+++ b/tests/Http/ClientTest.php
@@ -37,7 +37,7 @@ class ClientTest extends TestCase
 
         $this->assertSame(
             $someResponse,
-            $client->sendRequest(new Request('GET', '/'))
+            $client->sendRequest(new Request('GET', 'https://api.yoti.com/'))
         );
 
         $this->assertEquals(30, $someHandler->getLastOptions()['timeout']);
@@ -138,6 +138,6 @@ class ClientTest extends TestCase
 
         $client = new Client(['handler' => $someHandlerStack]);
 
-        $client->sendRequest(new Request('GET', '/'));
+        $client->sendRequest(new Request('GET', 'https://api.yoti.com/'));
     }
 }


### PR DESCRIPTION
fix: prevent scientific notation in timestamp on low-precision PHP environments (#418)

On PHP FPM environments with non-default precision ini settings (≤12), casting a large float to string could produce scientific notation (e.g. 1.78E+12) instead of a plain integer, causing Yoti signature verification to fail with 401 MESSAGE_SIGNING.

Replace (string)(round(microtime(true) * 1000)) with sprintf('%.0F', microtime(true) * 1000) which forces a plain decimal string regardless of the precision ini setting, and drops the redundant round() since %.0F already rounds to zero decimal places.

Tests added to verify plain integer output under precision=12 and precision=8 (via @dataProvider), and to assert the timestamp falls within the correct Unix-millisecond range under low precision without masking scientific notation via an early (int) cast.

Fixes #417